### PR TITLE
Split meeting platform into dedicated pages

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,173 @@
+<?php
+session_start();
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/data.php';
+
+$departments = meeting_departments();
+$locations = meeting_locations();
+
+function redirect_with_flash(string $type, string $title, string $message, string $target = 'login.php'): void
+{
+    $_SESSION['flash'] = [
+        'type' => $type,
+        'title' => $title,
+        'message' => $message,
+    ];
+    header('Location: ' . $target);
+    exit;
+}
+
+$action = $_POST['action'] ?? '';
+if (!in_array($action, ['login', 'register', 'update'], true)) {
+    redirect_with_flash('error', 'Unknown request', 'Please use the designated forms within the platform.');
+}
+
+try {
+    $pdo = get_pdo();
+} catch (PDOException $exception) {
+    $target = $action === 'register' ? 'register.php' : ($action === 'update' ? 'dashboard.php#update' : 'login.php');
+    redirect_with_flash('error', 'Database connection failed', 'Verify the connection settings in config.php and try again.', $target);
+}
+
+function generate_unique_code(PDO $pdo): string
+{
+    do {
+        $candidate = 'RM' . strtoupper(bin2hex(random_bytes(4)));
+        $stmt = $pdo->prepare('SELECT id FROM meeting_users WHERE unique_code = ? LIMIT 1');
+        $stmt->execute([$candidate]);
+        $exists = $stmt->fetch();
+    } while ($exists);
+
+    return $candidate;
+}
+
+if ($action === 'register') {
+    $name = trim($_POST['name'] ?? '');
+    $department = trim($_POST['department'] ?? '');
+    $email = strtolower(trim($_POST['email'] ?? ''));
+    $password = $_POST['password'] ?? '';
+    $confirm = $_POST['confirm'] ?? '';
+
+    if ($name === '' || $department === '' || $email === '' || $password === '') {
+        redirect_with_flash('error', 'Missing fields', 'Please complete all required fields to create your account.', 'register.php');
+    }
+
+    if (!in_array($department, $departments, true)) {
+        redirect_with_flash('error', 'Unknown department', 'Select a department from the approved list.', 'register.php');
+    }
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        redirect_with_flash('error', 'Invalid email', 'Enter a valid corporate email address.', 'register.php');
+    }
+
+    if ($password !== $confirm) {
+        redirect_with_flash('error', 'Passwords do not match', 'Ensure the password matches its confirmation.', 'register.php');
+    }
+
+    if (strlen($password) < 8) {
+        redirect_with_flash('error', 'Password too short', 'Use at least 8 characters to strengthen security.', 'register.php');
+    }
+
+    $stmt = $pdo->prepare('SELECT id FROM meeting_users WHERE email = ? LIMIT 1');
+    $stmt->execute([$email]);
+    if ($stmt->fetch()) {
+        redirect_with_flash('error', 'Email already used', 'This email is already registered. Sign in or use another address.', 'register.php');
+    }
+
+    $hash = password_hash($password, PASSWORD_BCRYPT);
+    $uniqueCode = generate_unique_code($pdo);
+
+    $insert = $pdo->prepare('INSERT INTO meeting_users (name, department, email, password_hash, unique_code) VALUES (?, ?, ?, ?, ?)');
+    $insert->execute([$name, $department, $email, $hash, $uniqueCode]);
+
+    $message = sprintf('Account created successfully. Your approved accreditation code: %s — keep it safe to confirm your attendance.', $uniqueCode);
+    redirect_with_flash('success', 'New account ready', $message, 'login.php');
+}
+
+if ($action === 'login') {
+    $email = strtolower(trim($_POST['email'] ?? ''));
+    $password = $_POST['password'] ?? '';
+
+    if ($email === '' || $password === '') {
+        redirect_with_flash('error', 'Credentials required', 'Enter both your email address and password.', 'login.php');
+    }
+
+    $stmt = $pdo->prepare('SELECT id, name, password_hash, unique_code, department, attendance_status, location_preference, department_scope, department_focus, meeting_summary FROM meeting_users WHERE email = ? LIMIT 1');
+    $stmt->execute([$email]);
+    $user = $stmt->fetch();
+
+    if (!$user || !password_verify($password, $user['password_hash'])) {
+        redirect_with_flash('error', 'Invalid credentials', 'We could not verify the provided details. Please try again.', 'login.php');
+    }
+
+    $_SESSION['user'] = [
+        'id' => $user['id'],
+        'name' => $user['name'],
+        'email' => $email,
+        'unique_code' => $user['unique_code'],
+        'department' => $user['department'],
+        'attendance_status' => $user['attendance_status'],
+        'location_preference' => $user['location_preference'],
+        'department_scope' => $user['department_scope'],
+        'department_focus' => $user['department_focus'],
+        'meeting_summary' => $user['meeting_summary'],
+    ];
+
+    $message = sprintf('Signed in successfully. Your accreditation code: %s.', $user['unique_code']);
+    redirect_with_flash('success', 'Welcome back', $message, 'dashboard.php');
+}
+
+if ($action === 'update') {
+    $uniqueCode = strtoupper(trim($_POST['unique_code'] ?? ''));
+    $attendance = $_POST['attendance_status'] ?? 'pending';
+    $location = trim($_POST['location_preference'] ?? '');
+    $scope = $_POST['department_scope'] ?? 'all';
+    $focus = trim($_POST['department_focus'] ?? '');
+    $summary = trim($_POST['meeting_summary'] ?? '');
+
+    if ($uniqueCode === '') {
+        redirect_with_flash('error', 'Accreditation code required', 'Provide your approved accreditation code to manage attendance.', 'dashboard.php#update');
+    }
+
+    if (!in_array($attendance, ['pending', 'attend', 'decline'], true)) {
+        redirect_with_flash('error', 'Invalid status', 'Choose a valid attendance status from the list.', 'dashboard.php#update');
+    }
+
+    if ($location !== '' && !in_array($location, $locations, true)) {
+        redirect_with_flash('error', 'Unknown location', 'Select a meeting venue from the approved list.', 'dashboard.php#update');
+    }
+
+    if (!in_array($scope, ['all', 'specific'], true)) {
+        redirect_with_flash('error', 'Invalid scope', 'Specify whether participation includes all departments or a specific one.', 'dashboard.php#update');
+    }
+
+    if ($scope === 'specific') {
+        if (!in_array($focus, $departments, true)) {
+            redirect_with_flash('error', 'Department not found', 'Choose the target department from the list.', 'dashboard.php#update');
+        }
+    } else {
+        $focus = '';
+    }
+
+    $stmt = $pdo->prepare('UPDATE meeting_users SET attendance_status = ?, location_preference = ?, department_scope = ?, department_focus = ?, meeting_summary = ?, responded_at = NOW() WHERE unique_code = ?');
+    $stmt->execute([$attendance, $location, $scope, $focus, $summary === '' ? null : $summary, $uniqueCode]);
+
+    if ($stmt->rowCount() === 0) {
+        redirect_with_flash('error', 'Account not found', 'No record matched the accreditation code provided.', 'dashboard.php#update');
+    }
+
+    if (!isset($_SESSION['user']) || !is_array($_SESSION['user'])) {
+        $_SESSION['user'] = [
+            'unique_code' => $uniqueCode,
+        ];
+    }
+
+    $_SESSION['user']['unique_code'] = $uniqueCode;
+    $_SESSION['user']['attendance_status'] = $attendance;
+    $_SESSION['user']['location_preference'] = $location;
+    $_SESSION['user']['department_scope'] = $scope;
+    $_SESSION['user']['department_focus'] = $focus;
+    $_SESSION['user']['meeting_summary'] = $summary;
+
+    redirect_with_flash('success', 'Attendance updated', 'Your preferences and meeting summary were saved successfully.', 'dashboard.php');
+}

--- a/config.php
+++ b/config.php
@@ -1,0 +1,23 @@
+<?php
+const DB_HOST = 'localhost';
+const DB_NAME = 'meeting_portal';
+const DB_USER = 'root';
+const DB_PASS = '';
+
+function get_pdo(): PDO
+{
+    static $pdo = null;
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+
+    $dsn = sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4', DB_HOST, DB_NAME);
+    $options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ];
+
+    $pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
+    return $pdo;
+}

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,359 @@
+<?php
+session_start();
+
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/data.php';
+
+$flash = $_SESSION['flash'] ?? [];
+unset($_SESSION['flash']);
+
+$departments = meeting_departments();
+$locations = meeting_locations();
+$attendanceLabels = meeting_attendance_labels();
+$todayMeetings = meeting_today_agenda();
+$attendanceBoard = meeting_attendance_board();
+$summaryHighlights = meeting_summary_highlights();
+$locationsGrid = meeting_locations_grid();
+
+$userSession = $_SESSION['user'] ?? [];
+
+$userRecord = [
+    'id' => $userSession['id'] ?? null,
+    'name' => $userSession['name'] ?? null,
+    'email' => $userSession['email'] ?? null,
+    'department' => $userSession['department'] ?? null,
+    'unique_code' => $userSession['unique_code'] ?? null,
+    'attendance_status' => $userSession['attendance_status'] ?? 'pending',
+    'location_preference' => $userSession['location_preference'] ?? '',
+    'department_scope' => $userSession['department_scope'] ?? 'all',
+    'department_focus' => $userSession['department_focus'] ?? '',
+    'meeting_summary' => $userSession['meeting_summary'] ?? '',
+];
+
+try {
+    $pdo = get_pdo();
+    if ($userRecord['id']) {
+        $stmt = $pdo->prepare('SELECT name, email, department, unique_code, attendance_status, location_preference, department_scope, department_focus, meeting_summary FROM meeting_users WHERE id = ? LIMIT 1');
+        $stmt->execute([$userRecord['id']]);
+        if ($row = $stmt->fetch()) {
+            $userRecord = array_merge($userRecord, $row);
+        }
+    } elseif (!empty($userRecord['unique_code'])) {
+        $stmt = $pdo->prepare('SELECT name, email, department, unique_code, attendance_status, location_preference, department_scope, department_focus, meeting_summary FROM meeting_users WHERE unique_code = ? LIMIT 1');
+        $stmt->execute([$userRecord['unique_code']]);
+        if ($row = $stmt->fetch()) {
+            $userRecord = array_merge($userRecord, $row);
+        }
+    }
+} catch (PDOException $exception) {
+    // Keep session values if the database is not reachable.
+}
+
+$hasProfile = !empty($userRecord['name']);
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Meeting Brief Platform · Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="app app--dashboard">
+    <div class="app__backdrop" aria-hidden="true"></div>
+    <header class="app-header">
+        <div class="app-header__brand">
+            <span class="app-header__icon">🗂️</span>
+            <div>
+                <strong>Institutional Coordination Hub</strong>
+                <span>Comprehensive Meeting Brief 2024</span>
+            </div>
+        </div>
+        <nav class="app-header__nav">
+            <a href="#dashboard">Dashboard</a>
+            <a href="#update">Attendance</a>
+            <a href="#summary">Summary</a>
+            <a href="#locations">Venues</a>
+        </nav>
+        <div class="app-header__cta">
+            <a class="btn btn--ghost" href="index.php">Overview</a>
+            <?php if ($hasProfile): ?>
+                <a class="btn btn--primary" href="#update">Update Attendance</a>
+            <?php else: ?>
+                <a class="btn btn--primary" href="login.php">Sign In</a>
+            <?php endif; ?>
+        </div>
+    </header>
+
+    <?php if (!empty($flash)): ?>
+        <aside class="toast toast--<?= htmlspecialchars($flash['type'], ENT_QUOTES, 'UTF-8') ?>" role="alert">
+            <div class="toast__header">
+                <strong><?= htmlspecialchars($flash['title'], ENT_QUOTES, 'UTF-8') ?></strong>
+                <button type="button" class="toast__close" data-dismiss-toast aria-label="Close">×</button>
+            </div>
+            <p><?= htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8') ?></p>
+        </aside>
+    <?php endif; ?>
+
+    <main class="layout">
+        <aside class="sidebar">
+            <section class="sidebar__panel">
+                <header>
+                    <h2>Participating Departments</h2>
+                    <span><?= count($departments) ?> departments</span>
+                </header>
+                <ul class="department-list">
+                    <?php foreach ($departments as $department): ?>
+                        <li>
+                            <span class="department-list__badge"></span>
+                            <span><?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </section>
+
+            <section class="sidebar__panel">
+                <header>
+                    <h2>Quick Indicators</h2>
+                </header>
+                <div class="stats">
+                    <article class="stat">
+                        <strong>13</strong>
+                        <span>Invited departments</span>
+                    </article>
+                    <article class="stat">
+                        <strong>09</strong>
+                        <span>Key sessions</span>
+                    </article>
+                    <article class="stat">
+                        <strong>04</strong>
+                        <span>Specialized workshops</span>
+                    </article>
+                </div>
+            </section>
+
+            <section class="sidebar__panel">
+                <header>
+                    <h2>Today's Sessions</h2>
+                    <span>Riyadh time</span>
+                </header>
+                <ul class="agenda-mini">
+                    <?php foreach ($todayMeetings as $slot): ?>
+                        <li>
+                            <div>
+                                <strong><?= htmlspecialchars($slot['time'], ENT_QUOTES, 'UTF-8') ?></strong>
+                                <span><?= htmlspecialchars($slot['title'], ENT_QUOTES, 'UTF-8') ?></span>
+                            </div>
+                            <span class="agenda-mini__tag"><?= htmlspecialchars($slot['tag'], ENT_QUOTES, 'UTF-8') ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </section>
+        </aside>
+
+        <section class="content" id="dashboard">
+            <div class="content__hero">
+                <div>
+                    <span class="content__eyebrow">Tuesday, 25 July 2024 · 09:00 AM - 02:30 PM</span>
+                    <h1>Meeting Brief Command Center</h1>
+                    <p>
+                        Track every department's engagement, confirm attendance with your accreditation code, and capture executive talking points before the meeting convenes.
+                    </p>
+                    <div class="content__actions">
+                        <a class="btn btn--primary" href="#update">Manage Attendance</a>
+                        <a class="btn btn--ghost" href="#summary">View Summary</a>
+                    </div>
+                </div>
+                <div class="content__card">
+                    <header>
+                        <strong>Accreditation Code</strong>
+                        <?php if (!empty($userRecord['unique_code'])): ?>
+                            <button type="button" class="link" data-copy="<?= htmlspecialchars($userRecord['unique_code'], ENT_QUOTES, 'UTF-8') ?>">Copy Code</button>
+                        <?php endif; ?>
+                    </header>
+                    <div class="content__code">
+                        <?php if (!empty($userRecord['unique_code'])): ?>
+                            <span><?= htmlspecialchars($userRecord['unique_code'], ENT_QUOTES, 'UTF-8') ?></span>
+                        <?php else: ?>
+                            <span class="content__placeholder">Sign in or register to receive your personalized accreditation code.</span>
+                        <?php endif; ?>
+                    </div>
+                    <footer>
+                        <?php if ($hasProfile && !empty($userRecord['name'])): ?>
+                            <span>Welcome back, <?= htmlspecialchars($userRecord['name'], ENT_QUOTES, 'UTF-8') ?>.</span>
+                        <?php else: ?>
+                            <span>The accreditation code is the official reference for confirming registration and updating attendance status.</span>
+                        <?php endif; ?>
+                    </footer>
+                </div>
+            </div>
+
+            <section class="cards-grid cards-grid--wide">
+                <?php foreach ($todayMeetings as $slot): ?>
+                    <article class="meeting-card">
+                        <header>
+                            <span class="meeting-card__time"><?= htmlspecialchars($slot['time'], ENT_QUOTES, 'UTF-8') ?></span>
+                            <span class="meeting-card__tag"><?= htmlspecialchars($slot['tag'], ENT_QUOTES, 'UTF-8') ?></span>
+                        </header>
+                        <h3><?= htmlspecialchars($slot['title'], ENT_QUOTES, 'UTF-8') ?></h3>
+                        <p><?= htmlspecialchars($slot['summary'], ENT_QUOTES, 'UTF-8') ?></p>
+                        <footer>
+                            <span>Lead department: <?= htmlspecialchars($slot['department'], ENT_QUOTES, 'UTF-8') ?></span>
+                            <span>Location: <?= htmlspecialchars($slot['location'], ENT_QUOTES, 'UTF-8') ?></span>
+                        </footer>
+                    </article>
+                <?php endforeach; ?>
+            </section>
+
+            <section class="panel" id="update">
+                <header class="panel__header">
+                    <div>
+                        <h2>Update attendance status</h2>
+                        <p>Use your accreditation code to set attendance, preferred venue, and participation scope.</p>
+                    </div>
+                </header>
+                <div class="panel__body">
+                    <form class="update" action="auth.php" method="post">
+                        <input type="hidden" name="action" value="update">
+                        <div class="grid">
+                            <div class="field">
+                                <label for="update-code">Accreditation code</label>
+                                <input id="update-code" name="unique_code" type="text" value="<?= htmlspecialchars($userRecord['unique_code'] ?? '', ENT_QUOTES, 'UTF-8') ?>" placeholder="e.g., RM8F2A6C4" required>
+                            </div>
+                            <div class="field">
+                                <label for="update-status">Attendance status</label>
+                                <select id="update-status" name="attendance_status" required>
+                                    <?php foreach ($attendanceLabels as $value => $label): ?>
+                                        <option value="<?= htmlspecialchars($value, ENT_QUOTES, 'UTF-8') ?>"<?= $userRecord['attendance_status'] === $value ? ' selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="field">
+                                <label for="update-location">Preferred location</label>
+                                <select id="update-location" name="location_preference">
+                                    <option value="">To be coordinated later</option>
+                                    <?php foreach ($locations as $location): ?>
+                                        <option value="<?= htmlspecialchars($location, ENT_QUOTES, 'UTF-8') ?>"<?= $userRecord['location_preference'] === $location ? ' selected' : '' ?>><?= htmlspecialchars($location, ENT_QUOTES, 'UTF-8') ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <fieldset class="field field--inline">
+                                <legend>Participation scope</legend>
+                                <label class="chip">
+                                    <input type="radio" name="department_scope" value="all"<?= $userRecord['department_scope'] !== 'specific' ? ' checked' : '' ?>>
+                                    <span>All departments</span>
+                                </label>
+                                <label class="chip">
+                                    <input type="radio" name="department_scope" value="specific"<?= $userRecord['department_scope'] === 'specific' ? ' checked' : '' ?>>
+                                    <span>Specific department</span>
+                                </label>
+                            </fieldset>
+                            <div class="field" data-scope-target>
+                                <label for="update-focus">Target department</label>
+                                <select id="update-focus" name="department_focus"<?= $userRecord['department_scope'] === 'specific' ? '' : ' disabled' ?>>
+                                    <option value="">Select a department</option>
+                                    <?php foreach ($departments as $department): ?>
+                                        <option value="<?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?>"<?= $userRecord['department_focus'] === $department ? ' selected' : '' ?>><?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="field">
+                            <label for="update-summary">Meeting summary</label>
+                            <textarea id="update-summary" name="meeting_summary" rows="4" maxlength="600" data-counter><?= htmlspecialchars($userRecord['meeting_summary'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+                            <small class="field__hint">Share the key decisions or discussion points you plan to emphasize.</small>
+                        </div>
+                        <button type="submit" class="btn btn--accent">Save updates</button>
+                    </form>
+                </div>
+            </section>
+
+            <section class="panel" id="summary">
+                <header class="panel__header">
+                    <div>
+                        <h2>Rapid executive summary</h2>
+                        <p>Key insights and preliminary decisions compiled so far.</p>
+                    </div>
+                </header>
+                <div class="panel__body panel__body--columns">
+                    <div class="summary">
+                        <h3>Today's highlights</h3>
+                        <ul>
+                            <?php foreach ($summaryHighlights as $item): ?>
+                                <li><?= htmlspecialchars($item, ENT_QUOTES, 'UTF-8') ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                    <div class="summary summary--outline">
+                        <h3>Latest departmental updates</h3>
+                        <dl>
+                            <?php foreach ($attendanceBoard as $row): ?>
+                                <div>
+                                    <dt><?= htmlspecialchars($row['department'], ENT_QUOTES, 'UTF-8') ?></dt>
+                                    <dd><?= htmlspecialchars($attendanceLabels[$row['status']], ENT_QUOTES, 'UTF-8') ?> · <?= htmlspecialchars((string) $row['representatives'], ENT_QUOTES, 'UTF-8') ?> representatives · <?= htmlspecialchars($row['location'], ENT_QUOTES, 'UTF-8') ?></dd>
+                                </div>
+                            <?php endforeach; ?>
+                        </dl>
+                    </div>
+                </div>
+            </section>
+
+            <section class="panel" id="locations">
+                <header class="panel__header">
+                    <div>
+                        <h2>Meeting venues</h2>
+                        <p>Approved options for on-site attendance or virtual participation.</p>
+                    </div>
+                </header>
+                <div class="locations">
+                    <?php foreach ($locationsGrid as $location): ?>
+                        <article class="location-card">
+                            <header>
+                                <h3><?= htmlspecialchars($location['name'], ENT_QUOTES, 'UTF-8') ?></h3>
+                                <span>Capacity <?= htmlspecialchars((string) $location['capacity'], ENT_QUOTES, 'UTF-8') ?> seats</span>
+                            </header>
+                            <p>Session facilitator: <?= htmlspecialchars($location['facilitator'], ENT_QUOTES, 'UTF-8') ?></p>
+                            <footer>
+                                <span>Interactive presentation ready</span>
+                                <span>Live streaming available</span>
+                            </footer>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+            </section>
+
+            <section class="panel">
+                <header class="panel__header">
+                    <div>
+                        <h2>Attendance &amp; regrets roster</h2>
+                        <p>Live overview of departmental responses to the official invitation.</p>
+                    </div>
+                </header>
+                <div class="table">
+                    <div class="table__head">
+                        <span>Department</span>
+                        <span>Status</span>
+                        <span>Attendees</span>
+                        <span>Location</span>
+                    </div>
+                    <div class="table__body">
+                        <?php foreach ($attendanceBoard as $row): ?>
+                            <div class="table__row">
+                                <span><?= htmlspecialchars($row['department'], ENT_QUOTES, 'UTF-8') ?></span>
+                                <span class="badge badge--<?= htmlspecialchars($row['status'], ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($attendanceLabels[$row['status']], ENT_QUOTES, 'UTF-8') ?></span>
+                                <span><?= htmlspecialchars((string) $row['representatives'], ENT_QUOTES, 'UTF-8') ?></span>
+                                <span><?= htmlspecialchars($row['location'], ENT_QUOTES, 'UTF-8') ?></span>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            </section>
+        </section>
+    </main>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/data.php
+++ b/data.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+function meeting_departments(): array
+{
+    return [
+        'General Administration of Information Technology',
+        'Cybersecurity Department',
+        'Investment Agency',
+        'Public Gardens and Beautification Department',
+        'Internal Audit Department',
+        'Operations and Emergency Department',
+        'Security and Safety Department',
+        'Central Unit for Plan Approvals',
+        'Land Management Department',
+        'Environmental Health Department',
+        'Public Cleaning Department',
+        'Central City Municipality',
+        'North Municipality',
+    ];
+}
+
+function meeting_locations(): array
+{
+    return [
+        'Innovation Hall - Headquarters',
+        'Executive Meeting Hall - Tower A',
+        'Command & Control Center - Third Floor',
+        'Virtual Platform via Microsoft Teams',
+    ];
+}
+
+function meeting_attendance_labels(): array
+{
+    return [
+        'pending' => 'Pending Confirmation',
+        'attend' => 'Attending',
+        'decline' => 'Declined',
+    ];
+}
+
+function meeting_today_agenda(): array
+{
+    return [
+        [
+            'title' => 'Digital Transformation Roadmap Review',
+            'time' => '09:30 AM',
+            'tag' => 'Strategic',
+            'department' => 'General Administration of Information Technology',
+            'location' => 'Innovation Hall - Headquarters',
+            'summary' => 'Align the digital roadmap with current infrastructure projects and cybersecurity initiatives.',
+        ],
+        [
+            'title' => 'Cybersecurity Preparedness Assessment',
+            'time' => '11:15 AM',
+            'tag' => 'Risk',
+            'department' => 'Cybersecurity Department',
+            'location' => 'Command & Control Center - Third Floor',
+            'summary' => 'Present penetration test results and assign remediation actions with a clear timeline.',
+        ],
+        [
+            'title' => 'Activating Joint Investment Projects',
+            'time' => '01:00 PM',
+            'tag' => 'Executive',
+            'department' => 'Investment Agency',
+            'location' => 'Executive Meeting Hall - Tower A',
+            'summary' => 'Review cross-functional investment opportunities and confirm the funding schedule.',
+        ],
+    ];
+}
+
+function meeting_attendance_board(): array
+{
+    return [
+        [
+            'department' => 'General Administration of Information Technology',
+            'status' => 'attend',
+            'representatives' => 12,
+            'location' => 'Innovation Hall - Headquarters',
+        ],
+        [
+            'department' => 'Cybersecurity Department',
+            'status' => 'attend',
+            'representatives' => 8,
+            'location' => 'Command & Control Center - Third Floor',
+        ],
+        [
+            'department' => 'Investment Agency',
+            'status' => 'pending',
+            'representatives' => 6,
+            'location' => 'Executive Meeting Hall - Tower A',
+        ],
+        [
+            'department' => 'Public Gardens and Beautification Department',
+            'status' => 'decline',
+            'representatives' => 4,
+            'location' => 'Virtual Platform via Microsoft Teams',
+        ],
+    ];
+}
+
+function meeting_summary_highlights(): array
+{
+    return [
+        'Interactive deck for the digital transformation roadmap is 92% complete.',
+        'Attendance confirmed by 9 departments so far with unified logistics in place.',
+        'Departments are requested to submit final remarks by Monday at 12:00 PM.',
+    ];
+}
+
+function meeting_locations_grid(): array
+{
+    $locations = meeting_locations();
+    $capacities = [220, 30, 45, 500];
+    $facilitators = [
+        'Innovation Hall - Headquarters' => 'Eng. Nasser Al-Hamzani',
+        'Executive Meeting Hall - Tower A' => 'Ms. Sarah Al-Humeidhi',
+        'Command & Control Center - Third Floor' => 'Eng. Ibrahim Al-Dughaither',
+        'Virtual Platform via Microsoft Teams' => 'Ms. Lama Al-Assaf',
+    ];
+
+    $grid = [];
+    foreach ($locations as $index => $location) {
+        $grid[] = [
+            'name' => $location,
+            'capacity' => $capacities[$index] ?? 40,
+            'facilitator' => $facilitators[$location] ?? 'Coordination Team',
+        ];
+    }
+
+    return $grid;
+}

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,30 @@
+CREATE DATABASE IF NOT EXISTS meeting_portal CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE meeting_portal;
+
+CREATE TABLE IF NOT EXISTS meeting_users (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(120) NOT NULL,
+    department VARCHAR(120) NOT NULL,
+    email VARCHAR(160) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    unique_code CHAR(10) NOT NULL UNIQUE,
+    attendance_status ENUM('pending', 'attend', 'decline') DEFAULT 'pending',
+    location_preference VARCHAR(160) DEFAULT '',
+    department_scope ENUM('all', 'specific') DEFAULT 'all',
+    department_focus VARCHAR(160) DEFAULT '',
+    meeting_summary TEXT NULL,
+    responded_at TIMESTAMP NULL DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO meeting_users (name, department, email, password_hash, unique_code, attendance_status)
+VALUES
+    (
+        'System Administrator',
+        'General Administration of Information Technology',
+        'admin@company.com',
+        '$2y$12$91.F9ZjKoD9RgZbuJLXUM.qBLmNkIzH.5CoRY9GrZJkGljYu7GNlC',
+        'ADM0000001',
+        'attend'
+    );

--- a/index.php
+++ b/index.php
@@ -1,0 +1,283 @@
+<?php
+session_start();
+
+require_once __DIR__ . '/data.php';
+
+$flash = $_SESSION['flash'] ?? [];
+unset($_SESSION['flash']);
+
+$departments = meeting_departments();
+$todayMeetings = meeting_today_agenda();
+$attendanceBoard = meeting_attendance_board();
+$attendanceLabels = meeting_attendance_labels();
+$summaryHighlights = meeting_summary_highlights();
+$locationsGrid = meeting_locations_grid();
+
+$user = $_SESSION['user'] ?? [];
+$hasAccount = isset($user['id']);
+$uniqueCode = $user['unique_code'] ?? '';
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Meeting Brief Platform · Overview</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="app app--landing">
+    <div class="app__backdrop" aria-hidden="true"></div>
+    <header class="app-header">
+        <div class="app-header__brand">
+            <span class="app-header__icon">🗂️</span>
+            <div>
+                <strong>Institutional Coordination Hub</strong>
+                <span>Comprehensive Meeting Brief 2024</span>
+            </div>
+        </div>
+        <nav class="app-header__nav">
+            <a href="#overview">Overview</a>
+            <a href="#agenda">Agenda</a>
+            <a href="#summary">Highlights</a>
+            <a href="#locations">Venues</a>
+        </nav>
+        <div class="app-header__cta">
+            <a class="btn btn--ghost" href="register.php">Create Account</a>
+            <?php if ($hasAccount): ?>
+                <a class="btn btn--primary" href="dashboard.php">Open Dashboard</a>
+            <?php else: ?>
+                <a class="btn btn--primary" href="login.php">Sign In</a>
+            <?php endif; ?>
+        </div>
+    </header>
+
+    <?php if (!empty($flash)): ?>
+        <aside class="toast toast--<?= htmlspecialchars($flash['type'], ENT_QUOTES, 'UTF-8') ?>" role="alert">
+            <div class="toast__header">
+                <strong><?= htmlspecialchars($flash['title'], ENT_QUOTES, 'UTF-8') ?></strong>
+                <button type="button" class="toast__close" data-dismiss-toast aria-label="Close">×</button>
+            </div>
+            <p><?= htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8') ?></p>
+        </aside>
+    <?php endif; ?>
+
+    <main class="layout">
+        <aside class="sidebar">
+            <section class="sidebar__panel">
+                <header>
+                    <h2>Participating Departments</h2>
+                    <span><?= count($departments) ?> departments</span>
+                </header>
+                <ul class="department-list">
+                    <?php foreach ($departments as $department): ?>
+                        <li>
+                            <span class="department-list__badge"></span>
+                            <span><?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </section>
+
+            <section class="sidebar__panel">
+                <header>
+                    <h2>Quick Indicators</h2>
+                </header>
+                <div class="stats">
+                    <article class="stat">
+                        <strong>13</strong>
+                        <span>Invited departments</span>
+                    </article>
+                    <article class="stat">
+                        <strong>09</strong>
+                        <span>Key sessions</span>
+                    </article>
+                    <article class="stat">
+                        <strong>04</strong>
+                        <span>Specialized workshops</span>
+                    </article>
+                </div>
+            </section>
+
+            <section class="sidebar__panel">
+                <header>
+                    <h2>Today's Sessions</h2>
+                    <span>Riyadh time</span>
+                </header>
+                <ul class="agenda-mini">
+                    <?php foreach ($todayMeetings as $slot): ?>
+                        <li>
+                            <div>
+                                <strong><?= htmlspecialchars($slot['time'], ENT_QUOTES, 'UTF-8') ?></strong>
+                                <span><?= htmlspecialchars($slot['title'], ENT_QUOTES, 'UTF-8') ?></span>
+                            </div>
+                            <span class="agenda-mini__tag"><?= htmlspecialchars($slot['tag'], ENT_QUOTES, 'UTF-8') ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </section>
+        </aside>
+
+        <section class="content" id="overview">
+            <div class="content__hero">
+                <div>
+                    <span class="content__eyebrow">Tuesday, 25 July 2024 · 09:00 AM - 02:30 PM</span>
+                    <h1>Unified briefing for every department</h1>
+                    <p>
+                        Welcome to the command center that gathers agendas, attendance statuses, and venue readiness for the institutional coordination meeting. Access the dedicated sign-in and registration pages to manage your participation seamlessly.
+                    </p>
+                    <div class="content__actions">
+                        <a class="btn btn--primary" href="dashboard.php">View Dashboard</a>
+                        <a class="btn btn--ghost" href="register.php">Create Account</a>
+                    </div>
+                </div>
+                <div class="content__card">
+                    <header>
+                        <strong>Accreditation Code</strong>
+                        <?php if ($uniqueCode): ?>
+                            <button type="button" class="link" data-copy="<?= htmlspecialchars($uniqueCode, ENT_QUOTES, 'UTF-8') ?>">Copy Code</button>
+                        <?php endif; ?>
+                    </header>
+                    <div class="content__code">
+                        <?php if ($uniqueCode): ?>
+                            <span><?= htmlspecialchars($uniqueCode, ENT_QUOTES, 'UTF-8') ?></span>
+                        <?php else: ?>
+                            <span class="content__placeholder">Sign in to reveal the accreditation code assigned to you.</span>
+                        <?php endif; ?>
+                    </div>
+                    <footer>
+                        <span>The accreditation code is required when confirming attendance on the dashboard.</span>
+                    </footer>
+                </div>
+            </div>
+
+            <section class="cards-grid cards-grid--wide" id="agenda">
+                <?php foreach ($todayMeetings as $slot): ?>
+                    <article class="meeting-card">
+                        <header>
+                            <span class="meeting-card__time"><?= htmlspecialchars($slot['time'], ENT_QUOTES, 'UTF-8') ?></span>
+                            <span class="meeting-card__tag"><?= htmlspecialchars($slot['tag'], ENT_QUOTES, 'UTF-8') ?></span>
+                        </header>
+                        <h3><?= htmlspecialchars($slot['title'], ENT_QUOTES, 'UTF-8') ?></h3>
+                        <p><?= htmlspecialchars($slot['summary'], ENT_QUOTES, 'UTF-8') ?></p>
+                        <footer>
+                            <span>Lead department: <?= htmlspecialchars($slot['department'], ENT_QUOTES, 'UTF-8') ?></span>
+                            <span>Location: <?= htmlspecialchars($slot['location'], ENT_QUOTES, 'UTF-8') ?></span>
+                        </footer>
+                    </article>
+                <?php endforeach; ?>
+            </section>
+
+            <section class="panel" id="attendance">
+                <header class="panel__header">
+                    <div>
+                        <h2>Attendance &amp; accreditations</h2>
+                        <p>Registration, sign-in, and attendance updates now live on dedicated pages.</p>
+                    </div>
+                </header>
+                <div class="panel__body panel__body--columns">
+                    <div class="summary">
+                        <h3>Participation checklist</h3>
+                        <ul>
+                            <li>Create an account to receive your personalized accreditation code.</li>
+                            <li>Sign in to review department responsibilities and confirm attendance.</li>
+                            <li>Visit the dashboard to submit attendance responses or summaries at any time.</li>
+                        </ul>
+                    </div>
+                    <div class="summary summary--cta">
+                        <h3>Quick access</h3>
+                        <a class="btn btn--primary btn--full" href="login.php">Sign In</a>
+                        <a class="btn btn--ghost btn--full" href="register.php">Create Account</a>
+                        <a class="btn btn--accent btn--full" href="dashboard.php#update">Manage Attendance</a>
+                    </div>
+                </div>
+            </section>
+
+            <section class="panel" id="summary">
+                <header class="panel__header">
+                    <div>
+                        <h2>Rapid executive summary</h2>
+                        <p>Key insights and preliminary decisions compiled so far.</p>
+                    </div>
+                </header>
+                <div class="panel__body panel__body--columns">
+                    <div class="summary">
+                        <h3>Today's highlights</h3>
+                        <ul>
+                            <?php foreach ($summaryHighlights as $item): ?>
+                                <li><?= htmlspecialchars($item, ENT_QUOTES, 'UTF-8') ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                    <div class="summary summary--outline">
+                        <h3>Latest departmental updates</h3>
+                        <dl>
+                            <?php foreach ($attendanceBoard as $row): ?>
+                                <div>
+                                    <dt><?= htmlspecialchars($row['department'], ENT_QUOTES, 'UTF-8') ?></dt>
+                                    <dd><?= htmlspecialchars($attendanceLabels[$row['status']], ENT_QUOTES, 'UTF-8') ?> · <?= htmlspecialchars((string) $row['representatives'], ENT_QUOTES, 'UTF-8') ?> representatives · <?= htmlspecialchars($row['location'], ENT_QUOTES, 'UTF-8') ?></dd>
+                                </div>
+                            <?php endforeach; ?>
+                        </dl>
+                    </div>
+                </div>
+            </section>
+
+            <section class="panel" id="locations">
+                <header class="panel__header">
+                    <div>
+                        <h2>Meeting venues</h2>
+                        <p>Approved options for on-site attendance or virtual participation.</p>
+                    </div>
+                </header>
+                <div class="locations">
+                    <?php foreach ($locationsGrid as $location): ?>
+                        <article class="location-card">
+                            <header>
+                                <h3><?= htmlspecialchars($location['name'], ENT_QUOTES, 'UTF-8') ?></h3>
+                                <span>Capacity <?= htmlspecialchars((string) $location['capacity'], ENT_QUOTES, 'UTF-8') ?> seats</span>
+                            </header>
+                            <p>Session facilitator: <?= htmlspecialchars($location['facilitator'], ENT_QUOTES, 'UTF-8') ?></p>
+                            <footer>
+                                <span>Interactive presentation ready</span>
+                                <span>Live streaming available</span>
+                            </footer>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+            </section>
+
+            <section class="panel">
+                <header class="panel__header">
+                    <div>
+                        <h2>Attendance &amp; regrets roster</h2>
+                        <p>Live overview of departmental responses to the official invitation.</p>
+                    </div>
+                </header>
+                <div class="table">
+                    <div class="table__head">
+                        <span>Department</span>
+                        <span>Status</span>
+                        <span>Attendees</span>
+                        <span>Location</span>
+                    </div>
+                    <div class="table__body">
+                        <?php foreach ($attendanceBoard as $row): ?>
+                            <div class="table__row">
+                                <span><?= htmlspecialchars($row['department'], ENT_QUOTES, 'UTF-8') ?></span>
+                                <span class="badge badge--<?= htmlspecialchars($row['status'], ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($attendanceLabels[$row['status']], ENT_QUOTES, 'UTF-8') ?></span>
+                                <span><?= htmlspecialchars((string) $row['representatives'], ENT_QUOTES, 'UTF-8') ?></span>
+                                <span><?= htmlspecialchars($row['location'], ENT_QUOTES, 'UTF-8') ?></span>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            </section>
+        </section>
+    </main>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,78 @@
+<?php
+session_start();
+
+require_once __DIR__ . '/data.php';
+
+if (isset($_SESSION['user']['id'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+$flash = $_SESSION['flash'] ?? [];
+unset($_SESSION['flash']);
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Meeting Brief Platform · Sign In</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="app app--auth page--login">
+    <div class="app__backdrop" aria-hidden="true"></div>
+    <header class="app-header app-header--compact">
+        <div class="app-header__brand">
+            <span class="app-header__icon">🗂️</span>
+            <div>
+                <strong>Institutional Coordination Hub</strong>
+                <span>Comprehensive Meeting Brief 2024</span>
+            </div>
+        </div>
+        <nav class="app-header__nav">
+            <a href="index.php">Overview</a>
+            <a href="register.php">Create Account</a>
+        </nav>
+    </header>
+
+    <?php if (!empty($flash)): ?>
+        <aside class="toast toast--<?= htmlspecialchars($flash['type'], ENT_QUOTES, 'UTF-8') ?>" role="alert">
+            <div class="toast__header">
+                <strong><?= htmlspecialchars($flash['title'], ENT_QUOTES, 'UTF-8') ?></strong>
+                <button type="button" class="toast__close" data-dismiss-toast aria-label="Close">×</button>
+            </div>
+            <p><?= htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8') ?></p>
+        </aside>
+    <?php endif; ?>
+
+    <main class="auth-shell">
+        <section class="auth auth--standalone" aria-labelledby="sign-in-heading">
+            <header class="auth__header">
+                <h1 id="sign-in-heading">Sign in to continue</h1>
+                <p>Enter your credentials to retrieve your accreditation code and manage attendance responses.</p>
+            </header>
+            <form action="auth.php" method="post" class="auth__form">
+                <input type="hidden" name="action" value="login">
+                <div class="field">
+                    <label for="login-email">Email address</label>
+                    <input id="login-email" name="email" type="email" autocomplete="email" required>
+                </div>
+                <div class="field">
+                    <label for="login-password">Password</label>
+                    <input id="login-password" name="password" type="password" autocomplete="current-password" required>
+                </div>
+                <button type="submit" class="btn btn--primary btn--full">Sign In</button>
+            </form>
+            <footer class="auth__footer">
+                <span>Need an account?</span>
+                <a class="link" href="register.php">Create one now</a>
+            </footer>
+        </section>
+    </main>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,92 @@
+<?php
+session_start();
+
+require_once __DIR__ . '/data.php';
+
+$flash = $_SESSION['flash'] ?? [];
+unset($_SESSION['flash']);
+
+$departments = meeting_departments();
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Meeting Brief Platform · Create Account</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="app app--auth page--register">
+    <div class="app__backdrop" aria-hidden="true"></div>
+    <header class="app-header app-header--compact">
+        <div class="app-header__brand">
+            <span class="app-header__icon">🗂️</span>
+            <div>
+                <strong>Institutional Coordination Hub</strong>
+                <span>Comprehensive Meeting Brief 2024</span>
+            </div>
+        </div>
+        <nav class="app-header__nav">
+            <a href="index.php">Overview</a>
+            <a href="login.php">Sign In</a>
+        </nav>
+    </header>
+
+    <?php if (!empty($flash)): ?>
+        <aside class="toast toast--<?= htmlspecialchars($flash['type'], ENT_QUOTES, 'UTF-8') ?>" role="alert">
+            <div class="toast__header">
+                <strong><?= htmlspecialchars($flash['title'], ENT_QUOTES, 'UTF-8') ?></strong>
+                <button type="button" class="toast__close" data-dismiss-toast aria-label="Close">×</button>
+            </div>
+            <p><?= htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8') ?></p>
+        </aside>
+    <?php endif; ?>
+
+    <main class="auth-shell">
+        <section class="auth auth--standalone" aria-labelledby="register-heading">
+            <header class="auth__header">
+                <h1 id="register-heading">Create an account</h1>
+                <p>Register your department lead to obtain an accreditation code and unlock the attendance dashboard.</p>
+            </header>
+            <form id="auth-register" action="auth.php" method="post" class="auth__form" novalidate>
+                <input type="hidden" name="action" value="register">
+                <div class="field">
+                    <label for="register-name">Full name</label>
+                    <input id="register-name" name="name" type="text" autocomplete="name" required>
+                </div>
+                <div class="field">
+                    <label for="register-department">Department</label>
+                    <select id="register-department" name="department" required>
+                        <option value="" disabled selected>Select a department</option>
+                        <?php foreach ($departments as $department): ?>
+                            <option value="<?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="field">
+                    <label for="register-email">Corporate email</label>
+                    <input id="register-email" name="email" type="email" autocomplete="email" required>
+                </div>
+                <div class="field">
+                    <label for="register-password">Password</label>
+                    <input id="register-password" name="password" type="password" autocomplete="new-password" minlength="8" required>
+                </div>
+                <div class="field">
+                    <label for="register-confirm">Confirm password</label>
+                    <input id="register-confirm" name="confirm" type="password" autocomplete="new-password" minlength="8" required>
+                </div>
+                <button type="submit" class="btn btn--primary btn--full">Create account &amp; issue code</button>
+            </form>
+            <footer class="auth__footer">
+                <span>Already registered?</span>
+                <a class="link" href="login.php">Sign in here</a>
+            </footer>
+        </section>
+    </main>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,109 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const registerForm = document.querySelector('form#auth-register');
+    const passwordInput = document.getElementById('register-password');
+    const confirmInput = document.getElementById('register-confirm');
+
+    const clearFieldMessage = (field) => {
+        if (!field) return;
+        const container = field.closest('.field');
+        const message = container?.querySelector('.field__error');
+        if (message) {
+            message.remove();
+        }
+    };
+
+    const showFieldMessage = (input, message) => {
+        const container = input.closest('.field');
+        if (!container) return;
+        clearFieldMessage(input);
+        const hint = document.createElement('small');
+        hint.className = 'field__error';
+        hint.textContent = message;
+        container.appendChild(hint);
+    };
+
+    if (registerForm && passwordInput && confirmInput) {
+        const validateMatch = () => {
+            clearFieldMessage(confirmInput);
+            confirmInput.setCustomValidity('');
+            if (passwordInput.value && confirmInput.value && passwordInput.value !== confirmInput.value) {
+                confirmInput.setCustomValidity('Passwords do not match');
+                showFieldMessage(confirmInput, 'Passwords do not match, please review and try again.');
+            }
+        };
+
+        passwordInput.addEventListener('input', validateMatch);
+        confirmInput.addEventListener('input', validateMatch);
+
+        registerForm.addEventListener('submit', (event) => {
+            validateMatch();
+            if (!registerForm.checkValidity()) {
+                event.preventDefault();
+                registerForm.reportValidity();
+            }
+        });
+    }
+
+    document.querySelectorAll('[data-dismiss-toast]').forEach((button) => {
+        button.addEventListener('click', () => {
+            const toast = button.closest('.toast');
+            if (toast) {
+                toast.classList.add('toast--hide');
+                setTimeout(() => toast.remove(), 300);
+            }
+        });
+    });
+
+    document.querySelectorAll('[data-copy]').forEach((button) => {
+        button.addEventListener('click', async () => {
+            const value = button.getAttribute('data-copy');
+            if (!value) return;
+            try {
+                await navigator.clipboard.writeText(value);
+                button.textContent = 'Copied';
+                button.classList.add('link--success');
+                setTimeout(() => {
+                    button.textContent = 'Copy Code';
+                    button.classList.remove('link--success');
+                }, 2000);
+            } catch (error) {
+                button.textContent = 'Copy failed';
+            }
+        });
+    });
+
+    const scopeRadios = document.querySelectorAll('input[name="department_scope"]');
+    const scopeSelect = document.querySelector('[data-scope-target] select');
+    const scopeField = document.querySelector('[data-scope-target]');
+
+    if (scopeRadios.length && scopeSelect && scopeField) {
+        const syncScopeState = () => {
+            const selected = document.querySelector('input[name="department_scope"]:checked');
+            const isSpecific = selected?.value === 'specific';
+            scopeSelect.disabled = !isSpecific;
+            scopeField.classList.toggle('field--disabled', !isSpecific);
+            if (!isSpecific) {
+                scopeSelect.value = '';
+            }
+        };
+
+        scopeRadios.forEach((radio) => {
+            radio.addEventListener('change', syncScopeState);
+        });
+
+        syncScopeState();
+    }
+
+    document.querySelectorAll('textarea[data-counter]').forEach((textarea) => {
+        const counter = document.createElement('div');
+        counter.className = 'field__counter';
+        textarea.after(counter);
+
+        const updateCounter = () => {
+            counter.textContent = `${textarea.value.length} / ${textarea.maxLength || 600}`;
+        };
+
+        textarea.addEventListener('input', updateCounter);
+        updateCounter();
+    });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,908 @@
+:root {
+    color-scheme: light;
+    font-family: 'Cairo', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --bg: #f5f7fb;
+    --surface: #ffffff;
+    --surface-alt: #f0f4ff;
+    --border: #e1e6f0;
+    --primary: #574bff;
+    --primary-dark: #3b31b4;
+    --accent: #ff8a65;
+    --text: #1a1c23;
+    --text-muted: #5b6070;
+    --shadow: 0 24px 60px -30px rgba(37, 50, 92, 0.35);
+    --radius-lg: 28px;
+    --radius-md: 16px;
+    --radius-sm: 12px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body.app {
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(circle at top left, rgba(87, 75, 255, 0.12), transparent 55%), var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+.app__backdrop {
+    position: fixed;
+    inset: 0;
+    background: linear-gradient(130deg, rgba(103, 86, 255, 0.16), rgba(255, 255, 255, 0));
+    pointer-events: none;
+    z-index: 0;
+}
+
+.app-header {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.5rem 2rem;
+    background: rgba(245, 247, 251, 0.85);
+    backdrop-filter: blur(18px);
+    border-bottom: 1px solid rgba(225, 230, 240, 0.6);
+}
+
+.app-header__brand {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+}
+
+.app-header__brand strong {
+    font-size: 1rem;
+    display: block;
+}
+
+.app-header__brand span {
+    display: block;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.app-header__icon {
+    width: 48px;
+    height: 48px;
+    display: grid;
+    place-items: center;
+    border-radius: 16px;
+    background: var(--surface);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 10px 20px rgba(87, 75, 255, 0.12);
+    font-size: 1.4rem;
+}
+
+.app-header__nav {
+    display: flex;
+    gap: 1.5rem;
+    align-items: center;
+}
+
+.app-header__nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+    font-weight: 500;
+    transition: color 0.2s ease;
+}
+
+.app-header__nav a:hover,
+.app-header__nav a:focus {
+    color: var(--primary);
+}
+
+.app-header__cta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.app-header--compact {
+    position: static;
+    padding: 1.2rem 1.8rem;
+}
+
+.app-header--compact .app-header__nav {
+    gap: 1rem;
+}
+
+.app-header__cta .btn {
+    font-size: 0.9rem;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    border-radius: 999px;
+    padding: 0.7rem 1.5rem;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn--primary {
+    background: linear-gradient(135deg, var(--primary), #6c63ff);
+    color: #fff;
+    box-shadow: 0 18px 30px -16px rgba(87, 75, 255, 0.7);
+}
+
+.btn--primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 24px 38px -18px rgba(87, 75, 255, 0.55);
+}
+
+.btn--ghost {
+    background: rgba(87, 75, 255, 0.08);
+    color: var(--primary);
+}
+
+.app--auth .app-header {
+    position: static;
+}
+
+.btn--accent {
+    background: linear-gradient(135deg, var(--accent), #ff7043);
+    color: #fff;
+    padding: 0.85rem 1.9rem;
+    font-size: 1rem;
+    box-shadow: 0 20px 36px -18px rgba(255, 138, 101, 0.55);
+}
+
+.btn--full {
+    width: 100%;
+}
+
+.btn--ghost:hover {
+    transform: translateY(-1px);
+}
+
+.link {
+    border: none;
+    background: transparent;
+    color: var(--primary);
+    font-weight: 600;
+    cursor: pointer;
+    padding: 0;
+}
+
+.link--success {
+    color: #2e7d32;
+}
+
+.layout {
+    position: relative;
+    z-index: 10;
+    display: grid;
+    grid-template-columns: 320px minmax(0, 1fr);
+    gap: 2rem;
+    padding: 2.5rem;
+}
+
+.sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.sidebar__panel {
+    background: rgba(255, 255, 255, 0.88);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(225, 230, 240, 0.8);
+    padding: 1.6rem;
+    box-shadow: var(--shadow);
+}
+
+.sidebar__panel header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 1.2rem;
+}
+
+.sidebar__panel header h2 {
+    margin: 0;
+    font-size: 1.05rem;
+}
+
+.sidebar__panel header span {
+    color: var(--primary);
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.department-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.department-list li {
+    display: grid;
+    grid-template-columns: 12px auto;
+    gap: 0.75rem;
+    align-items: center;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.department-list__badge {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, rgba(87, 75, 255, 0.6), rgba(163, 140, 255, 0.6));
+}
+
+.stats {
+    display: grid;
+    gap: 1rem;
+}
+
+.stat {
+    display: flex;
+    flex-direction: column;
+    background: rgba(87, 75, 255, 0.06);
+    border-radius: var(--radius-md);
+    padding: 1.1rem;
+}
+
+.stat strong {
+    font-size: 1.4rem;
+    color: var(--primary);
+}
+
+.stat span {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.agenda-mini {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.9rem;
+}
+
+.agenda-mini li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.9rem;
+    border-radius: var(--radius-md);
+    background: rgba(240, 244, 255, 0.8);
+}
+
+.agenda-mini strong {
+    display: block;
+    font-size: 0.95rem;
+    color: var(--text);
+}
+
+.agenda-mini__tag {
+    font-size: 0.75rem;
+    padding: 0.3rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(87, 75, 255, 0.12);
+    color: var(--primary);
+}
+
+.content {
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+}
+
+.content__hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 320px;
+    gap: 2rem;
+    align-items: stretch;
+}
+
+.content__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(87, 75, 255, 0.12);
+    color: var(--primary);
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    margin-bottom: 0.9rem;
+}
+
+.content__hero h1 {
+    margin: 0 0 0.6rem;
+    font-size: 2.1rem;
+}
+
+.content__hero p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.content__actions {
+    margin-top: 1.4rem;
+    display: flex;
+    gap: 0.75rem;
+}
+
+.content__card {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(225, 230, 240, 0.6);
+    padding: 1.6rem;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.content__card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: var(--text-muted);
+    font-weight: 600;
+}
+
+.content__code {
+    min-height: 96px;
+    border-radius: var(--radius-md);
+    background: linear-gradient(135deg, rgba(87, 75, 255, 0.08), rgba(108, 99, 255, 0.18));
+    display: grid;
+    place-items: center;
+    font-size: 1.6rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: var(--primary-dark);
+    text-transform: uppercase;
+    padding: 0 1rem;
+    text-align: center;
+}
+
+.content__placeholder {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    letter-spacing: 0;
+}
+
+.content__card footer {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.cards-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.cards-grid--wide {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.meeting-card {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: var(--radius-lg);
+    padding: 1.8rem;
+    border: 1px solid rgba(225, 230, 240, 0.8);
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.meeting-card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: var(--text-muted);
+}
+
+.meeting-card__time {
+    font-weight: 700;
+    color: var(--text);
+}
+
+.meeting-card__tag {
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(87, 75, 255, 0.12);
+    color: var(--primary);
+    font-size: 0.75rem;
+}
+
+.meeting-card footer {
+    display: flex;
+    justify-content: space-between;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+}
+
+.panel {
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(225, 230, 240, 0.7);
+    box-shadow: var(--shadow);
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.panel__header h2 {
+    margin: 0 0 0.3rem;
+    font-size: 1.5rem;
+}
+
+.panel__header p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.panel__body {
+    display: grid;
+    gap: 2rem;
+}
+
+.panel__body--columns {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.auth {
+    background: rgba(240, 244, 255, 0.55);
+    border: 1px solid rgba(87, 75, 255, 0.18);
+    border-radius: var(--radius-lg);
+    padding: 1.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.auth__tabs {
+    display: inline-flex;
+    background: rgba(255, 255, 255, 0.7);
+    padding: 0.3rem;
+    border-radius: 999px;
+}
+
+.auth__tab {
+    border: none;
+    background: transparent;
+    padding: 0.55rem 1.3rem;
+    border-radius: 999px;
+    font-weight: 600;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.auth__tab--active {
+    background: linear-gradient(135deg, var(--primary), #6c63ff);
+    color: #fff;
+    box-shadow: 0 12px 26px -18px rgba(87, 75, 255, 0.65);
+}
+
+.auth__panels {
+    position: relative;
+}
+
+.auth__panel {
+    display: none;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.auth__panel--active {
+    display: flex;
+}
+
+.auth-shell {
+    min-height: calc(100vh - 140px);
+    display: grid;
+    place-items: center;
+    padding: 4rem 1.5rem;
+}
+
+.auth--standalone {
+    width: min(520px, 100%);
+    background: rgba(240, 244, 255, 0.72);
+    border: 1px solid rgba(87, 75, 255, 0.18);
+    border-radius: var(--radius-lg);
+    padding: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    box-shadow: var(--shadow);
+}
+
+.auth__header h1 {
+    margin: 0 0 0.5rem;
+    font-size: 1.75rem;
+}
+
+.auth__header p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.auth__form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+}
+
+.auth__footer {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+
+.auth__footer .link {
+    font-weight: 600;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.field label,
+.field legend {
+    font-weight: 600;
+    color: var(--text);
+}
+
+.field input,
+.field select,
+.field textarea {
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    padding: 0.75rem 1rem;
+    font-family: inherit;
+    font-size: 0.95rem;
+    background: rgba(255, 255, 255, 0.92);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus,
+.field select:focus,
+.field textarea:focus {
+    outline: none;
+    border-color: rgba(87, 75, 255, 0.6);
+    box-shadow: 0 0 0 4px rgba(87, 75, 255, 0.12);
+}
+
+.field__hint {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}
+
+.field__error {
+    color: #d32f2f;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.field__counter {
+    align-self: flex-end;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.field--inline {
+    border: 1px dashed rgba(87, 75, 255, 0.24);
+    border-radius: var(--radius-md);
+    padding: 1rem;
+    gap: 0.8rem;
+}
+
+.field--disabled {
+    opacity: 0.5;
+}
+
+.chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.45rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(87, 75, 255, 0.08);
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+.chip input {
+    accent-color: var(--primary);
+}
+
+.update {
+    background: rgba(255, 255, 255, 0.78);
+    border: 1px solid rgba(225, 230, 240, 0.8);
+    border-radius: var(--radius-lg);
+    padding: 1.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.update__header h3 {
+    margin: 0 0 0.4rem;
+    font-size: 1.3rem;
+}
+
+.update__header p {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.grid {
+    display: grid;
+    gap: 1.2rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.summary {
+    background: rgba(240, 244, 255, 0.65);
+    border-radius: var(--radius-lg);
+    padding: 1.6rem;
+    border: 1px solid rgba(225, 230, 240, 0.7);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.summary--cta {
+    gap: 1.2rem;
+}
+
+.summary--cta .btn {
+    justify-content: flex-start;
+}
+
+.summary h3 {
+    margin: 0;
+}
+
+.summary ul {
+    margin: 0;
+    padding-right: 1.1rem;
+    color: var(--text-muted);
+}
+
+.summary--outline {
+    background: rgba(255, 255, 255, 0.8);
+}
+
+.summary dl {
+    margin: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.summary dt {
+    font-weight: 700;
+}
+
+.summary dd {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.locations {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.location-card {
+    border-radius: var(--radius-lg);
+    padding: 1.6rem;
+    border: 1px solid rgba(225, 230, 240, 0.8);
+    background: rgba(255, 255, 255, 0.9);
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+}
+
+.location-card header {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    align-items: baseline;
+}
+
+.location-card header span {
+    font-size: 0.85rem;
+    color: var(--primary);
+    font-weight: 700;
+}
+
+.location-card footer {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.table {
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(225, 230, 240, 0.8);
+    overflow: hidden;
+}
+
+.table__head,
+.table__row {
+    display: grid;
+    grid-template-columns: 2fr repeat(3, 1fr);
+    padding: 1rem 1.3rem;
+    align-items: center;
+    gap: 1rem;
+}
+
+.table__head {
+    background: rgba(87, 75, 255, 0.08);
+    font-weight: 700;
+}
+
+.table__body {
+    display: grid;
+}
+
+.table__row:nth-child(even) {
+    background: rgba(240, 244, 255, 0.6);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.badge--attend {
+    background: rgba(46, 125, 50, 0.12);
+    color: #2e7d32;
+}
+
+.badge--pending {
+    background: rgba(255, 152, 0, 0.12);
+    color: #f57c00;
+}
+
+.badge--decline {
+    background: rgba(211, 47, 47, 0.12);
+    color: #d32f2f;
+}
+
+.toast {
+    position: fixed;
+    top: 96px;
+    right: 2.5rem;
+    max-width: 360px;
+    background: #fff;
+    border-radius: var(--radius-md);
+    box-shadow: 0 30px 60px -20px rgba(0, 0, 0, 0.35);
+    padding: 1.2rem 1.4rem;
+    z-index: 30;
+    border-right: 4px solid var(--primary);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.toast--success {
+    border-right-color: #2e7d32;
+}
+
+.toast--error {
+    border-right-color: #d32f2f;
+}
+
+.toast--hide {
+    opacity: 0;
+    transform: translateY(-10px);
+}
+
+.toast__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.toast__header strong {
+    font-size: 1rem;
+}
+
+.toast__close {
+    border: none;
+    background: transparent;
+    font-size: 1.2rem;
+    cursor: pointer;
+    color: var(--text-muted);
+}
+
+@media (max-width: 1200px) {
+    .layout {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .sidebar {
+        flex-direction: row;
+        overflow-x: auto;
+    }
+
+    .sidebar__panel {
+        min-width: 260px;
+    }
+
+    .content__hero {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .app-header {
+        flex-direction: column;
+        gap: 1rem;
+        align-items: flex-start;
+    }
+
+    .app-header__nav {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+    }
+
+    .layout {
+        padding: 1.5rem;
+    }
+
+    .panel {
+        padding: 1.5rem;
+    }
+
+    .table__head,
+    .table__row {
+        grid-template-columns: 1.5fr repeat(3, minmax(90px, 1fr));
+    }
+}
+
+@media (max-width: 540px) {
+    .table__head,
+    .table__row {
+        grid-template-columns: 1.5fr 1fr;
+        gap: 0.6rem;
+    }
+
+    .table__head span:nth-child(n+3),
+    .table__row span:nth-child(n+3) {
+        display: none;
+    }
+
+    .sidebar {
+        flex-direction: column;
+    }
+}

--- a/تحميل السكربت.md
+++ b/تحميل السكربت.md
@@ -1,16 +1,17 @@
 # tatarwar
-سكربت حرب التتار نسخة سيرفرات النخبة مجانا
-بعد انتشار لهذه النسخة بسعر كبير اقدم لكن نسخة سيرفر النخبة الان مجانا
 
-امثلة على النسخة
-www.tatar.ae 
-www.viptatar.com
-www.satatar.com 
+Tatar War elite server script — free download
 
-صاحب النسخة الاساسي
-احمد علان 00962780094101 
-www.viptwar.com
+This package was previously sold widely for a high price, so here's the elite server edition available at no cost.
 
+Example deployments:
+- www.tatar.ae
+- www.viptatar.com
+- www.satatar.com
 
-رابط التحميل من هنا 
+Original author:
+- Ahmad Allan — +962 7 8009 4101
+- www.viptwar.com
+
+Download link:
 https://www.mediafire.com/file/y9g1zm2xkroxcn0/tatarvip.rar/file

--- a/خطوات تنفيذ المنصة.md
+++ b/خطوات تنفيذ المنصة.md
@@ -1,0 +1,72 @@
+# Step-by-step guide for building the meeting brief platform
+
+> **Starting point:** Work with the files that already exist in the project root (`index.php`, `styles.css`, `script.js`, `auth.php`, `config.php`, `database.sql`). Do not spin up a new project—everything you need is prepared in these files for customization and enhancement.
+
+## 1. Prepare the database (SQL)
+1. Open `database.sql` and review the `meeting_users` table structure so you understand the required fields for attendance status, department, meeting summary, and the unique accreditation code.
+2. Create a new database in your MySQL server (for example: `meeting_portal`).
+3. Execute the commands in `database.sql` against the new database to create the table. You can use phpMyAdmin or the `mysql` command line.
+4. Add any indexes or adjustments you might need later (such as enforcing a unique email) before you jump into the interface work.
+
+## 2. Configure the backend connection (PHP)
+1. Edit `config.php` and provide the database connection details (`DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASS`).
+2. Make sure the `get_pdo()` function returns a valid connection (you can test it by running `php -l config.php` and then a short script that calls the function).
+3. In `auth.php`, review the functions responsible for registration and login:
+   - The registration routine validates fields, generates the unique code, and stores the initial attendance status.
+   - The login routine checks the email and password and restores the user data to the session.
+4. Add temporary logging (`error_log`) while developing so you can confirm that requests arrive and errors are handled properly.
+
+## 3. Understand the current interface (HTML + PHP)
+1. `index.php` now works as the public overview page with the hero section, agenda highlights, and calls to open the dashboard or create an account.
+2. `dashboard.php` is the primary working area that contains the meeting cards, attendance board, and the accreditation update form.
+3. `login.php` and `register.php` provide dedicated flows for authentication—both pages reuse the same styling but focus on a single form per page.
+4. Before making changes, copy the overall layout of each section so you can revert quickly if needed. The shared visual identity (hero cards, panels, tables) is consistent across all pages.
+5. Customize the required areas (attendance/regrets board, meeting venues, department-wide or specific scope toggle, meeting summary field) within the existing components on the dashboard.
+6. Shared reference data (departments, agenda slots, venues) lives in `data.php` so every page stays consistent; update that file when you need to adjust the defaults.
+
+## 4. Refine the look & feel (CSS)
+1. Open `styles.css` and locate the comment blocks for each group (for example `.app`, `.agenda`, `.auth-card`).
+2. If you want to adjust colors or fonts, tweak the custom properties defined under the `:root` selector so the update cascades across the whole interface.
+3. Preserve the glassmorphism aesthetic by keeping properties like `backdrop-filter` and semi-transparent `rgba` values. Adjust them gradually and check the page in the browser.
+4. Test every change by refreshing the page, and rely on DevTools to monitor element sizing now that the layout is left-to-right.
+
+## 5. Front-end interactions (JavaScript)
+1. `script.js` ensures the password confirmation matches on the registration page, toggles the department scope selector on the dashboard, and handles clipboard/counter helpers.
+2. If you add new form fields (such as selecting a department or expanding the meeting summary), make sure the script updates counters or inline validation accordingly.
+3. Ensure any `submit` handler only prevents default submission when there are errors; otherwise allow the request to reach `auth.php`.
+
+## 6. Test the full journey
+1. Run a local PHP server with `php -S localhost:8000` from the project directory.
+2. Register a new user and confirm the record is inserted into the database.
+3. Sign in with the same credentials and verify that the session retains attendance and location preferences.
+4. Manually edit records in the database to confirm that changes propagate to the interface (for example, switching the attendance status to `decline`).
+
+## 7. Suggested future enhancements
+- Bind the attendance board on the interface to live data from the database instead of static placeholders.
+- Add an admin dashboard to approve department responses and write overarching notes.
+- Create an email notification system that uses the `unique_code` for each user to send invitations and follow-up reminders.
+
+Following these steps will help you move from the existing project files through database setup, interface customization, and end-to-end testing with confidence.
+
+---
+
+## Appendix: How to copy the project code
+
+If you only need to copy the code so you can use it in another project or share it with teammates, choose the method that fits your workflow:
+
+### Option A — Copy straight from the editor
+1. Open the file you want (for example `index.php`) in your code editor or the web-based viewer.
+2. Use the global *Select All* shortcut (`Ctrl + A` on Windows/Linux or `Cmd + A` on macOS) to highlight the entire file.
+3. Copy the highlighted text (`Ctrl/Cmd + C`) and paste it where you need it (`Ctrl/Cmd + V`).
+
+### Option B — Download the repository as a ZIP
+1. In GitHub (or your Git hosting platform), navigate to the repository home page.
+2. Click **Code** ▸ **Download ZIP**.
+3. Extract the downloaded archive on your machine and open the files locally.
+
+### Option C — Clone with Git
+1. Install Git if you do not already have it.
+2. Run `git clone <repository-url>` in your terminal to fetch the project to your device.
+3. Enter the folder (`cd tatarwar`) and open the files in your preferred editor. You can now copy any portion of the codebase.
+
+These approaches give you complete copies of the HTML, CSS, PHP, SQL, and JavaScript files so you can reuse or adapt them without rewriting everything manually.


### PR DESCRIPTION
## Summary
- break the monolithic interface into an overview landing page, dedicated dashboard, and separate sign-in and registration screens backed by a shared data set
- update the authentication workflow, JavaScript helpers, and styling to support the page split while keeping accreditation management intact
- refresh the implementation guide to explain the new multi-page structure and shared data source

## Testing
- php -l index.php
- php -l dashboard.php
- php -l login.php
- php -l register.php
- php -l auth.php
- php -l data.php
- php -l config.php

------
https://chatgpt.com/codex/tasks/task_e_68dcc1622c14832c99d76f8c5fba1028