### PR TITLE
Harden database integration and surface setup guidance

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,174 @@
+<?php
+session_start();
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/repository.php';
+
+$departments = meeting_departments();
+$locations = meeting_locations();
+
+function redirect_with_flash(string $type, string $title, string $message, string $target = 'login.php'): void
+{
+    $_SESSION['flash'] = [
+        'type' => $type,
+        'title' => $title,
+        'message' => $message,
+    ];
+    header('Location: ' . $target);
+    exit;
+}
+
+$action = $_POST['action'] ?? '';
+if (!in_array($action, ['login', 'register', 'update'], true)) {
+    redirect_with_flash('error', 'Unknown request', 'Please use the designated forms within the platform.');
+}
+
+try {
+    $pdo = get_pdo();
+} catch (PDOException $exception) {
+    $target = $action === 'register' ? 'register.php' : ($action === 'update' ? 'dashboard.php?view=updates#attendance-update' : 'login.php');
+    redirect_with_flash('error', 'Database connection failed', 'Verify the connection settings in config.php and try again.', $target);
+}
+
+function generate_unique_code(PDO $pdo): string
+{
+    do {
+        $candidate = 'RM' . strtoupper(bin2hex(random_bytes(4)));
+        $stmt = $pdo->prepare('SELECT id FROM meeting_users WHERE unique_code = ? LIMIT 1');
+        $stmt->execute([$candidate]);
+        $exists = $stmt->fetch();
+    } while ($exists);
+
+    return $candidate;
+}
+
+if ($action === 'register') {
+    $name = trim($_POST['name'] ?? '');
+    $department = trim($_POST['department'] ?? '');
+    $email = strtolower(trim($_POST['email'] ?? ''));
+    $password = $_POST['password'] ?? '';
+    $confirm = $_POST['confirm'] ?? '';
+
+    if ($name === '' || $department === '' || $email === '' || $password === '') {
+        redirect_with_flash('error', 'Missing fields', 'Please complete all required fields to create your account.', 'register.php');
+    }
+
+    if (!in_array($department, $departments, true)) {
+        redirect_with_flash('error', 'Unknown department', 'Select a department from the approved list.', 'register.php');
+    }
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        redirect_with_flash('error', 'Invalid email', 'Enter a valid corporate email address.', 'register.php');
+    }
+
+    if ($password !== $confirm) {
+        redirect_with_flash('error', 'Passwords do not match', 'Ensure the password matches its confirmation.', 'register.php');
+    }
+
+    if (strlen($password) < 8) {
+        redirect_with_flash('error', 'Password too short', 'Use at least 8 characters to strengthen security.', 'register.php');
+    }
+
+    $stmt = $pdo->prepare('SELECT id FROM meeting_users WHERE email = ? LIMIT 1');
+    $stmt->execute([$email]);
+    if ($stmt->fetch()) {
+        redirect_with_flash('error', 'Email already used', 'This email is already registered. Sign in or use another address.', 'register.php');
+    }
+
+    $hash = password_hash($password, PASSWORD_BCRYPT);
+    $uniqueCode = generate_unique_code($pdo);
+
+    $insert = $pdo->prepare('INSERT INTO meeting_users (name, department, email, password_hash, unique_code) VALUES (?, ?, ?, ?, ?)');
+    $insert->execute([$name, $department, $email, $hash, $uniqueCode]);
+
+    $message = sprintf('Account created successfully. Your approved accreditation code: %s — keep it safe to confirm your attendance.', $uniqueCode);
+    redirect_with_flash('success', 'New account ready', $message, 'login.php');
+}
+
+if ($action === 'login') {
+    $email = strtolower(trim($_POST['email'] ?? ''));
+    $password = $_POST['password'] ?? '';
+
+    if ($email === '' || $password === '') {
+        redirect_with_flash('error', 'Credentials required', 'Enter both your email address and password.', 'login.php');
+    }
+
+    $stmt = $pdo->prepare('SELECT id, name, password_hash, unique_code, department, attendance_status, location_preference, department_scope, department_focus, meeting_summary FROM meeting_users WHERE email = ? LIMIT 1');
+    $stmt->execute([$email]);
+    $user = $stmt->fetch();
+
+    if (!$user || !password_verify($password, $user['password_hash'])) {
+        redirect_with_flash('error', 'Invalid credentials', 'We could not verify the provided details. Please try again.', 'login.php');
+    }
+
+    session_regenerate_id(true);
+    $_SESSION['user'] = [
+        'id' => $user['id'],
+        'name' => $user['name'],
+        'email' => $email,
+        'unique_code' => $user['unique_code'],
+        'department' => $user['department'],
+        'attendance_status' => $user['attendance_status'],
+        'location_preference' => $user['location_preference'],
+        'department_scope' => $user['department_scope'],
+        'department_focus' => $user['department_focus'],
+        'meeting_summary' => $user['meeting_summary'],
+    ];
+
+    $message = sprintf('Signed in successfully. Your accreditation code: %s.', $user['unique_code']);
+    redirect_with_flash('success', 'Welcome back', $message, 'dashboard.php');
+}
+
+if ($action === 'update') {
+    $uniqueCode = strtoupper(trim($_POST['unique_code'] ?? ''));
+    $attendance = $_POST['attendance_status'] ?? 'pending';
+    $location = trim($_POST['location_preference'] ?? '');
+    $scope = $_POST['department_scope'] ?? 'all';
+    $focus = trim($_POST['department_focus'] ?? '');
+    $summary = trim($_POST['meeting_summary'] ?? '');
+
+    if ($uniqueCode === '') {
+        redirect_with_flash('error', 'Accreditation code required', 'Provide your approved accreditation code to manage attendance.', 'dashboard.php?view=updates#attendance-update');
+    }
+
+    if (!in_array($attendance, ['pending', 'attend', 'decline'], true)) {
+        redirect_with_flash('error', 'Invalid status', 'Choose a valid attendance status from the list.', 'dashboard.php?view=updates#attendance-update');
+    }
+
+    if ($location !== '' && !in_array($location, $locations, true)) {
+        redirect_with_flash('error', 'Unknown location', 'Select a meeting venue from the approved list.', 'dashboard.php?view=updates#attendance-update');
+    }
+
+    if (!in_array($scope, ['all', 'specific'], true)) {
+        redirect_with_flash('error', 'Invalid scope', 'Specify whether participation includes all departments or a specific one.', 'dashboard.php?view=updates#attendance-update');
+    }
+
+    if ($scope === 'specific') {
+        if (!in_array($focus, $departments, true)) {
+            redirect_with_flash('error', 'Department not found', 'Choose the target department from the list.', 'dashboard.php?view=updates#attendance-update');
+        }
+    } else {
+        $focus = '';
+    }
+
+    $stmt = $pdo->prepare('UPDATE meeting_users SET attendance_status = ?, location_preference = ?, department_scope = ?, department_focus = ?, meeting_summary = ?, responded_at = NOW() WHERE unique_code = ?');
+    $stmt->execute([$attendance, $location, $scope, $focus, $summary === '' ? null : $summary, $uniqueCode]);
+
+    if ($stmt->rowCount() === 0) {
+        redirect_with_flash('error', 'Account not found', 'No record matched the accreditation code provided.', 'dashboard.php?view=updates#attendance-update');
+    }
+
+    if (!isset($_SESSION['user']) || !is_array($_SESSION['user'])) {
+        $_SESSION['user'] = [
+            'unique_code' => $uniqueCode,
+        ];
+    }
+
+    $_SESSION['user']['unique_code'] = $uniqueCode;
+    $_SESSION['user']['attendance_status'] = $attendance;
+    $_SESSION['user']['location_preference'] = $location;
+    $_SESSION['user']['department_scope'] = $scope;
+    $_SESSION['user']['department_focus'] = $focus;
+    $_SESSION['user']['meeting_summary'] = $summary;
+
+    redirect_with_flash('success', 'Attendance updated', 'Your preferences and meeting summary were saved successfully.', 'dashboard.php?view=updates');
+}

--- a/config.php
+++ b/config.php
@@ -1,0 +1,23 @@
+<?php
+const DB_HOST = 'localhost';
+const DB_NAME = 'meeting_portal';
+const DB_USER = 'root';
+const DB_PASS = '';
+
+function get_pdo(): PDO
+{
+    static $pdo = null;
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+
+    $dsn = sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4', DB_HOST, DB_NAME);
+    $options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ];
+
+    $pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
+    return $pdo;
+}

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,653 @@
+<?php
+session_start();
+
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/repository.php';
+
+$flash = $_SESSION['flash'] ?? [];
+unset($_SESSION['flash']);
+
+$departments = meeting_departments();
+$locations = meeting_locations();
+$attendanceLabels = meeting_attendance_labels();
+$todayMeetings = meeting_today_agenda();
+$attendanceBoard = meeting_attendance_board();
+$summaryHighlights = meeting_summary_highlights();
+$locationsGrid = meeting_locations_grid();
+$updatesFeed = meeting_updates_feed();
+$repositoryErrors = meeting_repository_errors();
+$repositoryConnected = meeting_repository_connected();
+
+$viewNavigation = [
+    'agenda' => 'Agenda focus',
+    'updates' => 'Attendance & briefing updates',
+    'summary' => 'Executive summary',
+    'venues' => 'Meeting venues',
+    'attendance' => 'Attendance roster',
+];
+
+$viewConfig = [
+    'agenda' => [
+        'title' => 'Agenda focus',
+        'lede' => 'Review the sessions locked for the coordination meeting and add new topics when needed.',
+        'actions' => [
+            ['href' => '#add-meeting', 'label' => 'Add meeting', 'class' => 'btn btn--primary'],
+            ['href' => 'dashboard.php?view=updates#post-update', 'label' => 'Post update', 'class' => 'btn btn--ghost'],
+        ],
+    ],
+    'updates' => [
+        'title' => 'Attendance & briefing updates',
+        'lede' => 'Confirm participation details, log department notes, and keep everyone in sync.',
+        'actions' => [
+            ['href' => '#attendance-update', 'label' => 'Update attendance', 'class' => 'btn btn--primary'],
+            ['href' => '#post-update', 'label' => 'Share briefing note', 'class' => 'btn btn--ghost'],
+        ],
+    ],
+    'summary' => [
+        'title' => 'Executive summary',
+        'lede' => 'Track the highlights shaping the meeting narrative and monitor incoming confirmations.',
+        'actions' => [
+            ['href' => 'dashboard.php?view=attendance', 'label' => 'View roster', 'class' => 'btn btn--ghost'],
+        ],
+    ],
+    'venues' => [
+        'title' => 'Meeting venues',
+        'lede' => 'Explore approved rooms and virtual channels to assign your delegates accordingly.',
+        'actions' => [
+            ['href' => 'dashboard.php?view=agenda', 'label' => 'Back to agenda', 'class' => 'btn btn--ghost'],
+        ],
+    ],
+    'attendance' => [
+        'title' => 'Attendance roster',
+        'lede' => 'See how each department is responding and coordinate final confirmations.',
+        'actions' => [
+            ['href' => 'dashboard.php?view=updates#attendance-update', 'label' => 'Manage responses', 'class' => 'btn btn--ghost'],
+        ],
+    ],
+];
+
+$requestedView = strtolower((string) ($_GET['view'] ?? 'agenda'));
+$view = array_key_exists($requestedView, $viewNavigation) ? $requestedView : 'agenda';
+$currentView = $viewConfig[$view];
+
+$now = new DateTimeImmutable('now');
+$defaultMeetingDate = $now->format('Y-m-d');
+$defaultMeetingTime = $now->format('H:i');
+
+$userSession = $_SESSION['user'] ?? [];
+
+$userRecord = [
+    'id' => $userSession['id'] ?? null,
+    'name' => $userSession['name'] ?? null,
+    'email' => $userSession['email'] ?? null,
+    'department' => $userSession['department'] ?? null,
+    'unique_code' => $userSession['unique_code'] ?? null,
+    'attendance_status' => $userSession['attendance_status'] ?? 'pending',
+    'location_preference' => $userSession['location_preference'] ?? '',
+    'department_scope' => $userSession['department_scope'] ?? 'all',
+    'department_focus' => $userSession['department_focus'] ?? '',
+    'meeting_summary' => $userSession['meeting_summary'] ?? '',
+];
+
+try {
+    $pdo = get_pdo();
+    if ($userRecord['id']) {
+        $stmt = $pdo->prepare('SELECT name, email, department, unique_code, attendance_status, location_preference, department_scope, department_focus, meeting_summary FROM meeting_users WHERE id = ? LIMIT 1');
+        $stmt->execute([$userRecord['id']]);
+        if ($row = $stmt->fetch()) {
+            $userRecord = array_merge($userRecord, $row);
+        }
+    } elseif (!empty($userRecord['unique_code'])) {
+        $stmt = $pdo->prepare('SELECT name, email, department, unique_code, attendance_status, location_preference, department_scope, department_focus, meeting_summary FROM meeting_users WHERE unique_code = ? LIMIT 1');
+        $stmt->execute([$userRecord['unique_code']]);
+        if ($row = $stmt->fetch()) {
+            $userRecord = array_merge($userRecord, $row);
+        }
+    }
+} catch (PDOException $exception) {
+    // Keep session values if the database is not reachable.
+}
+
+$hasProfile = !empty($userRecord['name']);
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Meeting Brief Platform · Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="app app--dashboard">
+    <div class="app__backdrop" aria-hidden="true"></div>
+
+    <?php if (!empty($flash)): ?>
+        <aside class="toast toast--<?= htmlspecialchars($flash['type'], ENT_QUOTES, 'UTF-8') ?>" role="alert">
+            <div class="toast__header">
+                <strong><?= htmlspecialchars($flash['title'], ENT_QUOTES, 'UTF-8') ?></strong>
+                <button type="button" class="toast__close" data-dismiss-toast aria-label="Close">×</button>
+            </div>
+            <p><?= htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8') ?></p>
+        </aside>
+    <?php endif; ?>
+
+    <main class="workspace workspace--dashboard">
+        <aside class="workspace__sidebar" aria-label="Dashboard navigation">
+            <div class="sidebar__logo">
+                <span class="sidebar__icon">🗂️</span>
+                <div>
+                    <strong>Meeting Portal</strong>
+                    <span>Department Coordination</span>
+                </div>
+            </div>
+            <nav class="sidebar__section">
+                <span class="sidebar__title">Overview</span>
+                <ul class="sidebar__list sidebar__list--actions">
+                    <?php foreach ($viewNavigation as $key => $label): ?>
+                        <li>
+                            <a class="<?= $view === $key ? 'is-active' : '' ?>" href="dashboard.php?view=<?= htmlspecialchars($key, ENT_QUOTES, 'UTF-8') ?>">
+                                <?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?>
+                            </a>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </nav>
+            <div class="sidebar__section">
+                <span class="sidebar__title">Departments</span>
+                <ul class="sidebar__list">
+                    <?php foreach ($departments as $department): ?>
+                        <li><span><?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?></span></li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+            <footer class="sidebar__footer">
+                <a class="btn btn--secondary btn--full" href="index.php">Return to Overview</a>
+                <?php if (!$hasProfile): ?>
+                    <a class="btn btn--ghost btn--full" href="login.php">Sign In</a>
+                <?php endif; ?>
+            </footer>
+        </aside>
+
+        <div class="workspace__content">
+            <?php if (!$repositoryConnected && !empty($repositoryErrors)): ?>
+                <div class="alert alert--error">
+                    <strong>Database connection required</strong>
+                    <ul>
+                        <?php foreach ($repositoryErrors as $error): ?>
+                            <li><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></li>
+                        <?php endforeach; ?>
+                    </ul>
+                    <p class="alert__hint">Import <code>database.sql</code>, confirm the tables exist, and update <code>config.php</code> with your MySQL credentials to enable dashboard actions.</p>
+                </div>
+            <?php endif; ?>
+            <header class="workspace__header">
+                <div>
+                    <p class="eyebrow">Tuesday, 25 July 2024 · 09:00 AM – 02:30 PM</p>
+                    <h1><?= htmlspecialchars($currentView['title'], ENT_QUOTES, 'UTF-8') ?></h1>
+                    <p class="workspace__lede"><?= htmlspecialchars($currentView['lede'], ENT_QUOTES, 'UTF-8') ?></p>
+                </div>
+                <div class="workspace__actions">
+                    <?php foreach ($currentView['actions'] as $action): ?>
+                        <a class="<?= htmlspecialchars($action['class'], ENT_QUOTES, 'UTF-8') ?>" href="<?= htmlspecialchars($action['href'], ENT_QUOTES, 'UTF-8') ?>">
+                            <?= htmlspecialchars($action['label'], ENT_QUOTES, 'UTF-8') ?>
+                        </a>
+                    <?php endforeach; ?>
+                </div>
+            </header>
+
+            <div class="workspace__grid">
+                <section class="workspace__main">
+                    <?php if ($view === 'agenda'): ?>
+                        <div class="chip-group" role="tablist" aria-label="Agenda filters">
+                            <button type="button" class="chip is-active">All meetings</button>
+                            <button type="button" class="chip">Strategic</button>
+                            <button type="button" class="chip">Operations</button>
+                            <button type="button" class="chip">Workshops</button>
+                        </div>
+
+                        <div class="meeting-feed">
+                            <?php foreach ($todayMeetings as $slot): ?>
+                                <article class="meeting-card">
+                                    <header>
+                                        <span class="meeting-card__time"><?= htmlspecialchars($slot['time'], ENT_QUOTES, 'UTF-8') ?></span>
+                                        <span class="badge badge--<?= strtolower(htmlspecialchars($slot['tag'], ENT_QUOTES, 'UTF-8')) ?>"><?= htmlspecialchars($slot['tag'], ENT_QUOTES, 'UTF-8') ?></span>
+                                    </header>
+                                    <h3><?= htmlspecialchars($slot['title'], ENT_QUOTES, 'UTF-8') ?></h3>
+                                    <p><?= htmlspecialchars($slot['summary'], ENT_QUOTES, 'UTF-8') ?></p>
+                                    <footer>
+                                        <span><?= htmlspecialchars($slot['department'], ENT_QUOTES, 'UTF-8') ?></span>
+                                        <span><?= htmlspecialchars($slot['location'], ENT_QUOTES, 'UTF-8') ?></span>
+                                    </footer>
+                                </article>
+                            <?php endforeach; ?>
+                        </div>
+
+                        <section class="panel panel--form" id="add-meeting">
+                            <header class="panel__header">
+                                <div>
+                                    <h2>Add meeting</h2>
+                                    <p>Capture a new session so it appears in the shared agenda immediately.</p>
+                                </div>
+                            </header>
+                            <div class="panel__body">
+                                <?php if (!$hasProfile): ?>
+                                    <div class="empty-state">
+                                        <strong>Sign in to add meetings</strong>
+                                        <span>Use the coordinator account or create one to publish new agenda items.</span>
+                                    </div>
+                                <?php elseif (!$repositoryConnected): ?>
+                                    <div class="empty-state">
+                                        <strong>Connect the database</strong>
+                                        <span>Import <code>database.sql</code> and update <code>config.php</code> to enable agenda publishing.</span>
+                                    </div>
+                                <?php else: ?>
+                                    <form action="manage.php" method="post" class="update">
+                                        <input type="hidden" name="action" value="create_meeting">
+                                        <div class="grid">
+                                            <div class="field">
+                                                <label for="meeting-title">Title</label>
+                                                <input id="meeting-title" name="title" type="text" placeholder="e.g., Operations readiness review" required>
+                                            </div>
+                                            <div class="field">
+                                                <label for="meeting-date">Date</label>
+                                                <input id="meeting-date" name="scheduled_date" type="date" value="<?= htmlspecialchars($defaultMeetingDate, ENT_QUOTES, 'UTF-8') ?>" required>
+                                            </div>
+                                            <div class="field">
+                                                <label for="meeting-time">Time</label>
+                                                <input id="meeting-time" name="scheduled_time" type="time" value="<?= htmlspecialchars($defaultMeetingTime, ENT_QUOTES, 'UTF-8') ?>" required>
+                                            </div>
+                                            <div class="field">
+                                                <label for="meeting-tag">Tag</label>
+                                                <input id="meeting-tag" name="tag" type="text" placeholder="Strategic, Workshop, Update" required>
+                                            </div>
+                                            <div class="field">
+                                                <label for="meeting-department">Department</label>
+                                                <select id="meeting-department" name="department" required<?= empty($departments) ? ' disabled' : '' ?>>
+                                                    <option value=""><?= empty($departments) ? 'Add departments in the database first' : 'Select department' ?></option>
+                                                    <?php foreach ($departments as $department): ?>
+                                                        <option value="<?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?></option>
+                                                    <?php endforeach; ?>
+                                                </select>
+                                            </div>
+                                            <div class="field">
+                                                <label for="meeting-location">Location</label>
+                                                <select id="meeting-location" name="location" required<?= empty($locations) ? ' disabled' : '' ?>>
+                                                    <option value=""><?= empty($locations) ? 'Add venues in the database first' : 'Choose location' ?></option>
+                                                    <?php foreach ($locations as $location): ?>
+                                                        <option value="<?= htmlspecialchars($location, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($location, ENT_QUOTES, 'UTF-8') ?></option>
+                                                    <?php endforeach; ?>
+                                                </select>
+                                            </div>
+                                        </div>
+                                        <div class="field">
+                                            <label for="meeting-summary">Summary</label>
+                                            <textarea id="meeting-summary" name="summary" rows="4" maxlength="600" data-counter placeholder="Key talking points and desired outcomes"></textarea>
+                                        </div>
+                                        <button type="submit" class="btn btn--primary">Save meeting</button>
+                                    </form>
+                                <?php endif; ?>
+                            </div>
+                        </section>
+                    <?php elseif ($view === 'updates'): ?>
+                        <section class="panel">
+                            <header class="panel__header">
+                                <div>
+                                    <h2>Briefing updates</h2>
+                                    <p>Latest notes submitted by coordinators and department leads.</p>
+                                </div>
+                            </header>
+                            <div class="timeline">
+                                <?php foreach ($updatesFeed as $update): ?>
+                                    <?php
+                                    $timestamp = $update['created_at'] ?? '';
+                                    try {
+                                        $postedAt = $timestamp ? (new DateTimeImmutable($timestamp))->format('d M Y · h:i A') : 'Recently';
+                                    } catch (Exception $exception) {
+                                        $postedAt = $timestamp ?: 'Recently';
+                                    }
+                                    ?>
+                                    <article class="timeline__item">
+                                        <header>
+                                            <h3><?= htmlspecialchars($update['headline'], ENT_QUOTES, 'UTF-8') ?></h3>
+                                            <span><?= htmlspecialchars($postedAt, ENT_QUOTES, 'UTF-8') ?></span>
+                                        </header>
+                                        <p><?= nl2br(htmlspecialchars($update['body'], ENT_QUOTES, 'UTF-8')) ?></p>
+                                        <footer>
+                                            <?php if (!empty($update['department'])): ?>
+                                                <span><?= htmlspecialchars($update['department'], ENT_QUOTES, 'UTF-8') ?></span>
+                                            <?php endif; ?>
+                                            <?php if (!empty($update['author'])): ?>
+                                                <span>By <?= htmlspecialchars($update['author'], ENT_QUOTES, 'UTF-8') ?></span>
+                                            <?php endif; ?>
+                                        </footer>
+                                    </article>
+                                <?php endforeach; ?>
+                            </div>
+                        </section>
+
+                        <section class="panel" id="attendance-update">
+                            <header class="panel__header">
+                                <div>
+                                    <h2>Attendance response</h2>
+                                    <p>Confirm your participation details and share the summary you will brief.</p>
+                                </div>
+                            </header>
+                            <div class="panel__body">
+                                <?php if (!$repositoryConnected): ?>
+                                    <div class="empty-state">
+                                        <strong>Connect the database</strong>
+                                        <span>Import <code>database.sql</code> to enable saving attendance responses.</span>
+                                    </div>
+                                <?php else: ?>
+                                    <form class="update" action="auth.php" method="post">
+                                        <input type="hidden" name="action" value="update">
+                                        <div class="grid">
+                                            <div class="field">
+                                                <label for="update-code">Accreditation code</label>
+                                                <input id="update-code" name="unique_code" type="text" value="<?= htmlspecialchars($userRecord['unique_code'] ?? '', ENT_QUOTES, 'UTF-8') ?>" placeholder="e.g., RM8F2A6C4" required>
+                                            </div>
+                                            <div class="field">
+                                                <label for="update-status">Attendance status</label>
+                                                <select id="update-status" name="attendance_status" required>
+                                                    <?php foreach ($attendanceLabels as $value => $label): ?>
+                                                        <option value="<?= htmlspecialchars($value, ENT_QUOTES, 'UTF-8') ?>"<?= $userRecord['attendance_status'] === $value ? ' selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?></option>
+                                                    <?php endforeach; ?>
+                                                </select>
+                                            </div>
+                                            <div class="field">
+                                                <label for="update-location">Preferred location</label>
+                                                <select id="update-location" name="location_preference"<?= empty($locations) ? ' disabled' : '' ?>>
+                                                    <option value=""><?= empty($locations) ? 'Add venues in the database first' : 'To be coordinated later' ?></option>
+                                                    <?php foreach ($locations as $location): ?>
+                                                        <option value="<?= htmlspecialchars($location, ENT_QUOTES, 'UTF-8') ?>"<?= $userRecord['location_preference'] === $location ? ' selected' : '' ?>><?= htmlspecialchars($location, ENT_QUOTES, 'UTF-8') ?></option>
+                                                    <?php endforeach; ?>
+                                                </select>
+                                            </div>
+                                            <fieldset class="field field--inline">
+                                                <legend>Participation scope</legend>
+                                                <label class="chip">
+                                                    <input type="radio" name="department_scope" value="all"<?= $userRecord['department_scope'] !== 'specific' ? ' checked' : '' ?>>
+                                                    <span>All departments</span>
+                                                </label>
+                                                <label class="chip">
+                                                    <input type="radio" name="department_scope" value="specific"<?= $userRecord['department_scope'] === 'specific' ? ' checked' : '' ?>>
+                                                    <span>Specific department</span>
+                                                </label>
+                                            </fieldset>
+                                            <div class="field" data-scope-target>
+                                                <label for="update-focus">Target department</label>
+                                                <select id="update-focus" name="department_focus"<?= $userRecord['department_scope'] === 'specific' && !empty($departments) ? '' : ' disabled' ?>>
+                                                    <option value=""><?= empty($departments) ? 'Add departments in the database first' : 'Select a department' ?></option>
+                                                    <?php foreach ($departments as $department): ?>
+                                                        <option value="<?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?>"<?= $userRecord['department_focus'] === $department ? ' selected' : '' ?>><?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?></option>
+                                                    <?php endforeach; ?>
+                                                </select>
+                                            </div>
+                                        </div>
+                                        <div class="field">
+                                            <label for="update-summary">Meeting summary</label>
+                                            <textarea id="update-summary" name="meeting_summary" rows="4" maxlength="600" data-counter><?= htmlspecialchars($userRecord['meeting_summary'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+                                            <small class="field__hint">Share the key decisions or discussion points you plan to emphasize.</small>
+                                        </div>
+                                        <button type="submit" class="btn btn--primary">Save updates</button>
+                                    </form>
+                                <?php endif; ?>
+                            </div>
+                        </section>
+
+                        <section class="panel panel--form" id="post-update">
+                            <header class="panel__header">
+                                <div>
+                                    <h2>Share a meeting update</h2>
+                                    <p>Publish logistics notes or briefing changes for all attendees.</p>
+                                </div>
+                            </header>
+                            <div class="panel__body">
+                                <?php if (!$hasProfile): ?>
+                                    <div class="empty-state">
+                                        <strong>Sign in to share updates</strong>
+                                        <span>Use the dashboard sign-in to publish coordination briefings.</span>
+                                    </div>
+                                <?php elseif (!$repositoryConnected): ?>
+                                    <div class="empty-state">
+                                        <strong>Connect the database</strong>
+                                        <span>Import <code>database.sql</code> so new updates can be stored.</span>
+                                    </div>
+                                <?php else: ?>
+                                    <form action="manage.php" method="post" class="update">
+                                        <input type="hidden" name="action" value="post_update">
+                                        <div class="grid">
+                                            <div class="field">
+                                                <label for="update-headline">Headline</label>
+                                                <input id="update-headline" name="headline" type="text" placeholder="e.g., Updated arrival protocol" required>
+                                            </div>
+                                            <div class="field">
+                                                <label for="update-department">Department</label>
+                                                <select id="update-department" name="department"<?= empty($departments) ? ' disabled' : '' ?>>
+                                                    <option value=""><?= empty($departments) ? 'Add departments in the database first' : 'Applies to all' ?></option>
+                                                    <?php foreach ($departments as $department): ?>
+                                                        <option value="<?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?></option>
+                                                    <?php endforeach; ?>
+                                                </select>
+                                            </div>
+                                            <div class="field">
+                                                <label for="update-author">Author</label>
+                                                <input id="update-author" name="author" type="text" placeholder="e.g., Meeting Secretariat">
+                                            </div>
+                                        </div>
+                                        <div class="field">
+                                            <label for="update-body">Details</label>
+                                            <textarea id="update-body" name="body" rows="4" maxlength="600" data-counter placeholder="Outline the change, the reason, and the expected action." required></textarea>
+                                        </div>
+                                        <button type="submit" class="btn btn--primary">Publish update</button>
+                                    </form>
+                                <?php endif; ?>
+                            </div>
+                        </section>
+                    <?php elseif ($view === 'summary'): ?>
+                        <section class="panel">
+                            <header class="panel__header">
+                                <div>
+                                    <h2>Highlights</h2>
+                                    <p>Signals guiding executive decision making.</p>
+                                </div>
+                            </header>
+                            <div class="panel__body panel__body--split">
+                                <div class="summary-list">
+                                    <h3>Key points</h3>
+                                    <ul>
+                                        <?php foreach ($summaryHighlights as $highlight): ?>
+                                            <li><?= htmlspecialchars($highlight, ENT_QUOTES, 'UTF-8') ?></li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                </div>
+                                <div class="summary-board">
+                                    <h3>Department sentiment</h3>
+                                    <ul>
+                                        <?php foreach ($attendanceBoard as $row): ?>
+                                            <li>
+                                                <span><?= htmlspecialchars($row['department'], ENT_QUOTES, 'UTF-8') ?></span>
+                                                <span class="badge badge--<?= htmlspecialchars($row['status'], ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($attendanceLabels[$row['status']], ENT_QUOTES, 'UTF-8') ?></span>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                </div>
+                            </div>
+                        </section>
+
+                        <section class="panel">
+                            <header class="panel__header">
+                                <div>
+                                    <h2>Update log</h2>
+                                    <p>Recent additions that influence the executive story.</p>
+                                </div>
+                            </header>
+                            <div class="timeline timeline--compact">
+                                <?php foreach (array_slice($updatesFeed, 0, 4) as $update): ?>
+                                    <div class="timeline__item">
+                                        <header>
+                                            <h3><?= htmlspecialchars($update['headline'], ENT_QUOTES, 'UTF-8') ?></h3>
+                                        </header>
+                                        <p><?= htmlspecialchars(mb_strimwidth($update['body'], 0, 160, '…'), ENT_QUOTES, 'UTF-8') ?></p>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                        </section>
+                    <?php elseif ($view === 'venues'): ?>
+                        <section class="panel">
+                            <header class="panel__header">
+                                <div>
+                                    <h2>Venue directory</h2>
+                                    <p>Assign teams to rooms based on capacity and facilitation support.</p>
+                                </div>
+                            </header>
+                            <div class="locations-grid">
+                                <?php foreach ($locationsGrid as $location): ?>
+                                    <article class="location-card">
+                                        <header>
+                                            <h3><?= htmlspecialchars($location['name'], ENT_QUOTES, 'UTF-8') ?></h3>
+                                            <span><?= htmlspecialchars((string) $location['capacity'], ENT_QUOTES, 'UTF-8') ?> seats</span>
+                                        </header>
+                                        <p>Facilitated by <?= htmlspecialchars($location['facilitator'], ENT_QUOTES, 'UTF-8') ?></p>
+                                        <?php if (!empty($location['notes'])): ?>
+                                            <p class="location-card__notes"><?= htmlspecialchars($location['notes'], ENT_QUOTES, 'UTF-8') ?></p>
+                                        <?php endif; ?>
+                                        <footer>
+                                            <span>Hybrid ready</span>
+                                            <span>Support on standby</span>
+                                        </footer>
+                                    </article>
+                                <?php endforeach; ?>
+                            </div>
+                        </section>
+                    <?php elseif ($view === 'attendance'): ?>
+                        <section class="panel">
+                            <header class="panel__header">
+                                <div>
+                                    <h2>Department roster</h2>
+                                    <p>Live responses from every invited unit.</p>
+                                </div>
+                            </header>
+                            <div class="table">
+                                <div class="table__head">
+                                    <span>Department</span>
+                                    <span>Status</span>
+                                    <span>Attendees</span>
+                                    <span>Location</span>
+                                </div>
+                                <div class="table__body">
+                                    <?php foreach ($attendanceBoard as $row): ?>
+                                        <div class="table__row">
+                                            <span><?= htmlspecialchars($row['department'], ENT_QUOTES, 'UTF-8') ?></span>
+                                            <span class="badge badge--<?= htmlspecialchars($row['status'], ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($attendanceLabels[$row['status']], ENT_QUOTES, 'UTF-8') ?></span>
+                                            <span><?= htmlspecialchars((string) $row['representatives'], ENT_QUOTES, 'UTF-8') ?></span>
+                                            <span><?= htmlspecialchars($row['location'], ENT_QUOTES, 'UTF-8') ?></span>
+                                        </div>
+                                    <?php endforeach; ?>
+                                </div>
+                            </div>
+                        </section>
+
+                        <section class="panel">
+                            <header class="panel__header">
+                                <div>
+                                    <h2>Status breakdown</h2>
+                                    <p>Snapshot of confirmations across the organisation.</p>
+                                </div>
+                            </header>
+                            <div class="stat-list stat-list--inline">
+                                <?php
+                                $statusCounts = ['attend' => 0, 'pending' => 0, 'decline' => 0];
+                                foreach ($attendanceBoard as $row) {
+                                    $status = $row['status'];
+                                    if (!isset($statusCounts[$status])) {
+                                        $statusCounts[$status] = 0;
+                                    }
+                                    $statusCounts[$status]++;
+                                }
+                                ?>
+                                <div>
+                                    <strong><?= htmlspecialchars((string) ($statusCounts['attend'] ?? 0), ENT_QUOTES, 'UTF-8') ?></strong>
+                                    <span>Attending</span>
+                                </div>
+                                <div>
+                                    <strong><?= htmlspecialchars((string) ($statusCounts['pending'] ?? 0), ENT_QUOTES, 'UTF-8') ?></strong>
+                                    <span>Pending</span>
+                                </div>
+                                <div>
+                                    <strong><?= htmlspecialchars((string) ($statusCounts['decline'] ?? 0), ENT_QUOTES, 'UTF-8') ?></strong>
+                                    <span>Declined</span>
+                                </div>
+                            </div>
+                        </section>
+                    <?php endif; ?>
+                </section>
+
+                <aside class="workspace__rail">
+                    <section class="card">
+                        <header>
+                            <div>
+                                <h2>Welcome<?= $hasProfile ? ', ' . htmlspecialchars($userRecord['name'], ENT_QUOTES, 'UTF-8') : '' ?></h2>
+                                <p><?= $hasProfile ? htmlspecialchars($userRecord['department'] ?? 'Lead delegate', ENT_QUOTES, 'UTF-8') : 'Sign in to manage attendance' ?></p>
+                            </div>
+                        </header>
+                        <div class="card__code">
+                            <?php if (!empty($userRecord['unique_code'])): ?>
+                                <span class="label">Accreditation code</span>
+                                <div class="code-row">
+                                    <strong><?= htmlspecialchars($userRecord['unique_code'], ENT_QUOTES, 'UTF-8') ?></strong>
+                                    <button type="button" class="link" data-copy="<?= htmlspecialchars($userRecord['unique_code'], ENT_QUOTES, 'UTF-8') ?>">Copy</button>
+                                </div>
+                            <?php else: ?>
+                                <span class="placeholder">Register to receive an accreditation code.</span>
+                            <?php endif; ?>
+                        </div>
+                    </section>
+
+                    <section class="card">
+                        <header>
+                            <div>
+                                <h2>Quick stats</h2>
+                                <p>Realtime meeting pulse</p>
+                            </div>
+                        </header>
+                        <ul class="stat-list">
+                            <li>
+                                <strong><?= htmlspecialchars((string) count($departments), ENT_QUOTES, 'UTF-8') ?></strong>
+                                <span>Departments invited</span>
+                            </li>
+                            <li>
+                                <strong><?= htmlspecialchars((string) count($todayMeetings), ENT_QUOTES, 'UTF-8') ?></strong>
+                                <span>Agenda items</span>
+                            </li>
+                            <li>
+                                <strong><?= htmlspecialchars((string) count($updatesFeed), ENT_QUOTES, 'UTF-8') ?></strong>
+                                <span>Updates logged</span>
+                            </li>
+                        </ul>
+                    </section>
+
+                    <section class="card">
+                        <header>
+                            <div>
+                                <h2>Latest notes</h2>
+                                <p>Highlights from departments</p>
+                            </div>
+                        </header>
+                        <ul class="note-list">
+                            <?php foreach (array_slice($summaryHighlights, 0, 6) as $highlight): ?>
+                                <li><?= htmlspecialchars($highlight, ENT_QUOTES, 'UTF-8') ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </section>
+                </aside>
+            </div>
+        </div>
+    </main>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,149 @@
+CREATE DATABASE IF NOT EXISTS meeting_portal CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE meeting_portal;
+
+-- Default coordinator credentials
+-- Email: admin@company.com
+-- Password: Portal@2024!
+
+CREATE TABLE IF NOT EXISTS meeting_users (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(120) NOT NULL,
+    department VARCHAR(120) NOT NULL,
+    email VARCHAR(160) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    unique_code CHAR(10) NOT NULL UNIQUE,
+    attendance_status ENUM('pending', 'attend', 'decline') DEFAULT 'pending',
+    location_preference VARCHAR(160) DEFAULT '',
+    department_scope ENUM('all', 'specific') DEFAULT 'all',
+    department_focus VARCHAR(160) DEFAULT '',
+    meeting_summary TEXT NULL,
+    responded_at TIMESTAMP NULL DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS meeting_departments (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(160) NOT NULL UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS meeting_agenda (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    scheduled_at DATETIME NOT NULL,
+    tag VARCHAR(60) NOT NULL,
+    department VARCHAR(160) NOT NULL,
+    location VARCHAR(160) NOT NULL,
+    summary TEXT DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_meeting_agenda_title_time (title, scheduled_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS meeting_updates (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    headline VARCHAR(255) NOT NULL,
+    body TEXT NOT NULL,
+    department VARCHAR(160) DEFAULT NULL,
+    author VARCHAR(160) DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS meeting_highlights (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    highlight TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS meeting_venues (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(160) NOT NULL,
+    capacity INT DEFAULT 0,
+    facilitator VARCHAR(160) DEFAULT NULL,
+    notes TEXT DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_meeting_venues_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS meeting_attendance_roster (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    department VARCHAR(160) NOT NULL,
+    status ENUM('pending', 'attend', 'decline') DEFAULT 'pending',
+    representatives INT DEFAULT 0,
+    location VARCHAR(160) DEFAULT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_meeting_attendance_department (department)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO meeting_departments (name)
+VALUES
+    ('Central City Municipality'),
+    ('Central Unit for Plan Approvals'),
+    ('Cybersecurity Department'),
+    ('Environmental Health Department'),
+    ('General Administration of Information Technology'),
+    ('Internal Audit Department'),
+    ('Investment Agency'),
+    ('Land Management Department'),
+    ('North Municipality'),
+    ('Operations and Emergency Department'),
+    ('Public Cleaning Department'),
+    ('Public Gardens and Beautification Department'),
+    ('Security and Safety Department')
+ON DUPLICATE KEY UPDATE name = VALUES(name);
+
+INSERT INTO meeting_users (name, department, email, password_hash, unique_code, attendance_status)
+VALUES
+    (
+        'System Administrator',
+        'General Administration of Information Technology',
+        'admin@company.com',
+        '$2y$12$XDvDBBsNL5FH2SKfhQa3ee9h8D3z5ZqOE.vHcltde9McDhObOpag2',
+        'ADM0000001',
+        'attend'
+    )
+ON DUPLICATE KEY UPDATE
+    name = VALUES(name),
+    department = VALUES(department),
+    password_hash = VALUES(password_hash),
+    unique_code = VALUES(unique_code),
+    attendance_status = VALUES(attendance_status);
+
+INSERT INTO meeting_agenda (title, scheduled_at, tag, department, location, summary) VALUES
+    ('Digital Transformation Roadmap Review', '2024-07-25 09:30:00', 'Strategic', 'General Administration of Information Technology', 'Innovation Hall - Headquarters', 'Align the digital roadmap with current infrastructure projects and cybersecurity initiatives.'),
+    ('Cybersecurity Preparedness Assessment', '2024-07-25 11:15:00', 'Risk', 'Cybersecurity Department', 'Command & Control Center - Third Floor', 'Present penetration test results and assign remediation actions with a clear timeline.'),
+    ('Activating Joint Investment Projects', '2024-07-25 13:00:00', 'Executive', 'Investment Agency', 'Executive Meeting Hall - Tower A', 'Review cross-functional investment opportunities and confirm the funding schedule.')
+ON DUPLICATE KEY UPDATE
+    tag = VALUES(tag),
+    department = VALUES(department),
+    location = VALUES(location),
+    summary = VALUES(summary);
+
+INSERT INTO meeting_updates (headline, body, department, author) VALUES
+    ('Logistics confirmation', 'Transportation shuttles will run every 20 minutes between the central garage and the headquarters entrance.', 'Operations and Emergency Department', 'Logistics Desk'),
+    ('Presentation deadline', 'Submit final presentation decks by Monday at noon to be included in the consolidated briefing.', 'General Administration of Information Technology', 'Meeting Secretariat');
+
+INSERT INTO meeting_highlights (highlight) VALUES
+    ('Interactive deck for the digital transformation roadmap is 92% complete.'),
+    ('Attendance confirmed by 9 departments so far with unified logistics in place.'),
+    ('Departments are requested to submit final remarks by Monday at 12:00 PM.');
+
+INSERT INTO meeting_venues (name, capacity, facilitator, notes) VALUES
+    ('Innovation Hall - Headquarters', 220, 'Eng. Nasser Al-Hamzani', 'Primary plenary space with hybrid meeting capability.'),
+    ('Executive Meeting Hall - Tower A', 30, 'Ms. Sarah Al-Humeidhi', 'Reserved for executive briefings and strategy alignment.'),
+    ('Command & Control Center - Third Floor', 45, 'Eng. Ibrahim Al-Dughaither', 'Equipped with live monitoring dashboards for operations.'),
+    ('Virtual Platform via Microsoft Teams', 500, 'Ms. Lama Al-Assaf', 'Digital access with simultaneous translation available.')
+ON DUPLICATE KEY UPDATE
+    capacity = VALUES(capacity),
+    facilitator = VALUES(facilitator),
+    notes = VALUES(notes);
+
+INSERT INTO meeting_attendance_roster (department, status, representatives, location) VALUES
+    ('General Administration of Information Technology', 'attend', 12, 'Innovation Hall - Headquarters'),
+    ('Cybersecurity Department', 'attend', 8, 'Command & Control Center - Third Floor'),
+    ('Investment Agency', 'pending', 6, 'Executive Meeting Hall - Tower A'),
+    ('Public Gardens and Beautification Department', 'decline', 4, 'Virtual Platform via Microsoft Teams')
+ON DUPLICATE KEY UPDATE
+    status = VALUES(status),
+    representatives = VALUES(representatives),
+    location = VALUES(location);

--- a/index.php
+++ b/index.php
@@ -1,0 +1,257 @@
+<?php
+session_start();
+
+require_once __DIR__ . '/repository.php';
+
+$flash = $_SESSION['flash'] ?? [];
+unset($_SESSION['flash']);
+
+$departments = meeting_departments();
+$todayMeetings = meeting_today_agenda();
+$attendanceBoard = meeting_attendance_board();
+$attendanceLabels = meeting_attendance_labels();
+$summaryHighlights = meeting_summary_highlights();
+$locationsGrid = meeting_locations_grid();
+$updatesFeed = meeting_updates_feed();
+
+$user = $_SESSION['user'] ?? [];
+$hasAccount = isset($user['id']);
+$uniqueCode = $user['unique_code'] ?? '';
+$repositoryErrors = meeting_repository_errors();
+$repositoryConnected = meeting_repository_connected();
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Meeting Brief Platform · Overview</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="app app--landing">
+    <div class="app__backdrop" aria-hidden="true"></div>
+
+    <?php if (!empty($flash)): ?>
+        <aside class="toast toast--<?= htmlspecialchars($flash['type'], ENT_QUOTES, 'UTF-8') ?>" role="alert">
+            <div class="toast__header">
+                <strong><?= htmlspecialchars($flash['title'], ENT_QUOTES, 'UTF-8') ?></strong>
+                <button type="button" class="toast__close" data-dismiss-toast aria-label="Close">×</button>
+            </div>
+            <p><?= htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8') ?></p>
+        </aside>
+    <?php endif; ?>
+
+    <main class="workspace">
+        <aside class="workspace__sidebar" aria-label="Primary navigation">
+            <div class="sidebar__logo">
+                <span class="sidebar__icon">🗂️</span>
+                <div>
+                    <strong>Meeting Portal</strong>
+                    <span>Department Coordination</span>
+                </div>
+            </div>
+            <nav class="sidebar__section">
+                <span class="sidebar__title">Departments</span>
+                <ul class="sidebar__list">
+                    <li><a class="is-active" href="#">All Departments</a></li>
+                    <?php foreach ($departments as $department): ?>
+                        <li><a href="#overview-<?= md5($department) ?>"><?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?></a></li>
+                    <?php endforeach; ?>
+                </ul>
+            </nav>
+            <div class="sidebar__section">
+                <span class="sidebar__title">Shortcuts</span>
+                <ul class="sidebar__list sidebar__list--actions">
+                    <li><a href="dashboard.php">Attendance Dashboard</a></li>
+                    <li><a href="#venues">Venue Directory</a></li>
+                    <li><a href="#summary">Executive Summary</a></li>
+                </ul>
+            </div>
+            <footer class="sidebar__footer">
+                <?php if ($hasAccount): ?>
+                    <a class="btn btn--secondary btn--full" href="dashboard.php">Go to Dashboard</a>
+                <?php else: ?>
+                    <a class="btn btn--secondary btn--full" href="register.php">Create Account</a>
+                    <a class="btn btn--ghost btn--full" href="login.php">Sign In</a>
+                <?php endif; ?>
+            </footer>
+        </aside>
+
+        <div class="workspace__content" id="overview">
+            <?php if (!$repositoryConnected && !empty($repositoryErrors)): ?>
+                <div class="alert alert--error">
+                    <strong>Database connection required</strong>
+                    <ul>
+                        <?php foreach ($repositoryErrors as $error): ?>
+                            <li><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></li>
+                        <?php endforeach; ?>
+                    </ul>
+                    <p class="alert__hint">Import <code>database.sql</code> and update <code>config.php</code> with your MySQL credentials, then refresh the page.</p>
+                </div>
+            <?php endif; ?>
+            <header class="workspace__header">
+                <div>
+                    <p class="eyebrow">Tuesday, 25 July 2024 · 09:00 AM – 02:30 PM</p>
+                    <h1>Unified Meeting Overview</h1>
+                    <p class="workspace__lede">
+                        Review the agenda, track departmental confirmations, and explore approved venues before joining the coordination meeting.
+                    </p>
+                </div>
+                <div class="workspace__actions">
+                    <a class="btn btn--primary" href="dashboard.php#update">Schedule Meeting</a>
+                    <?php if ($hasAccount): ?>
+                        <a class="btn btn--ghost" href="dashboard.php">Open Dashboard</a>
+                    <?php else: ?>
+                        <a class="btn btn--ghost" href="register.php">Create Account</a>
+                    <?php endif; ?>
+                </div>
+            </header>
+
+            <div class="workspace__grid">
+                <section class="workspace__main" aria-labelledby="agenda-heading">
+                    <div class="chip-group" role="tablist" aria-label="Agenda filters">
+                        <button type="button" class="chip is-active">All meetings</button>
+                        <button type="button" class="chip">Strategic</button>
+                        <button type="button" class="chip">Operations</button>
+                        <button type="button" class="chip">Workshops</button>
+                    </div>
+
+                    <div class="meeting-feed">
+                        <h2 id="agenda-heading" class="section-title">Today’s sessions</h2>
+                        <?php foreach ($todayMeetings as $slot): ?>
+                            <article class="meeting-card">
+                                <header>
+                                    <span class="meeting-card__time"><?= htmlspecialchars($slot['time'], ENT_QUOTES, 'UTF-8') ?></span>
+                                    <span class="badge badge--<?= strtolower(htmlspecialchars($slot['tag'], ENT_QUOTES, 'UTF-8')) ?>"><?= htmlspecialchars($slot['tag'], ENT_QUOTES, 'UTF-8') ?></span>
+                                </header>
+                                <h3><?= htmlspecialchars($slot['title'], ENT_QUOTES, 'UTF-8') ?></h3>
+                                <p><?= htmlspecialchars($slot['summary'], ENT_QUOTES, 'UTF-8') ?></p>
+                                <footer>
+                                    <span><?= htmlspecialchars($slot['department'], ENT_QUOTES, 'UTF-8') ?></span>
+                                    <span><?= htmlspecialchars($slot['location'], ENT_QUOTES, 'UTF-8') ?></span>
+                                </footer>
+                            </article>
+                        <?php endforeach; ?>
+                    </div>
+
+                    <section class="panel panel--wide" id="summary">
+                        <header class="panel__header">
+                            <div>
+                                <h2>Executive highlights</h2>
+                                <p>Snapshot of decisions and preparations reported ahead of the meeting.</p>
+                            </div>
+                        </header>
+                        <div class="panel__body panel__body--split">
+                            <div class="summary-list">
+                                <h3>Brief highlights</h3>
+                                <ul>
+                                    <?php foreach ($summaryHighlights as $highlight): ?>
+                                        <li><?= htmlspecialchars($highlight, ENT_QUOTES, 'UTF-8') ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                            <div class="summary-board">
+                                <h3>Attendance board</h3>
+                                <ul>
+                                    <?php foreach ($attendanceBoard as $row): ?>
+                                        <li>
+                                            <span><?= htmlspecialchars($row['department'], ENT_QUOTES, 'UTF-8') ?></span>
+                                            <span class="badge badge--<?= htmlspecialchars($row['status'], ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($attendanceLabels[$row['status']], ENT_QUOTES, 'UTF-8') ?></span>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="panel panel--wide" id="venues">
+                        <header class="panel__header">
+                            <div>
+                                <h2>Approved venues</h2>
+                                <p>Explore the available rooms and remote options configured for the coordination meeting.</p>
+                            </div>
+                        </header>
+                        <div class="locations-grid">
+                            <?php foreach ($locationsGrid as $location): ?>
+                                <article class="location-card">
+                                    <header>
+                                        <h3><?= htmlspecialchars($location['name'], ENT_QUOTES, 'UTF-8') ?></h3>
+                                        <span><?= htmlspecialchars((string) $location['capacity'], ENT_QUOTES, 'UTF-8') ?> seats</span>
+                                    </header>
+                                    <p>Facilitated by <?= htmlspecialchars($location['facilitator'], ENT_QUOTES, 'UTF-8') ?></p>
+                                    <footer>
+                                        <span>Hybrid ready</span>
+                                        <span>Support on standby</span>
+                                    </footer>
+                                </article>
+                            <?php endforeach; ?>
+                        </div>
+                    </section>
+                </section>
+
+                <aside class="workspace__rail" aria-labelledby="insights-heading">
+                    <section class="card" id="accreditation">
+                        <header>
+                            <div>
+                                <h2>Accreditation code</h2>
+                                <p>Required when confirming attendance</p>
+                            </div>
+                            <?php if ($uniqueCode): ?>
+                                <button type="button" class="link" data-copy="<?= htmlspecialchars($uniqueCode, ENT_QUOTES, 'UTF-8') ?>">Copy</button>
+                            <?php endif; ?>
+                        </header>
+                        <div class="card__code">
+                            <?php if ($uniqueCode): ?>
+                                <span><?= htmlspecialchars($uniqueCode, ENT_QUOTES, 'UTF-8') ?></span>
+                            <?php else: ?>
+                                <span class="placeholder">Sign in to reveal your personal accreditation code.</span>
+                            <?php endif; ?>
+                        </div>
+                    </section>
+
+                    <section class="card" aria-labelledby="insights-heading">
+                        <header>
+                            <div>
+                                <h2 id="insights-heading">Quick stats</h2>
+                                <p>Live participation pulse</p>
+                            </div>
+                        </header>
+                        <ul class="stat-list">
+                            <li>
+                                <strong><?= htmlspecialchars((string) count($departments), ENT_QUOTES, 'UTF-8') ?></strong>
+                                <span>Departments invited</span>
+                            </li>
+                            <li>
+                                <strong><?= htmlspecialchars((string) count($todayMeetings), ENT_QUOTES, 'UTF-8') ?></strong>
+                                <span>Agenda items</span>
+                            </li>
+                            <li>
+                                <strong><?= htmlspecialchars((string) count($updatesFeed), ENT_QUOTES, 'UTF-8') ?></strong>
+                                <span>Briefing updates</span>
+                            </li>
+                        </ul>
+                    </section>
+
+                    <section class="card">
+                        <header>
+                            <div>
+                                <h2>Need access?</h2>
+                                <p>Register to manage your attendance.</p>
+                            </div>
+                        </header>
+                        <div class="card__actions">
+                            <a class="btn btn--primary btn--full" href="register.php">Create account</a>
+                            <a class="btn btn--ghost btn--full" href="login.php">Sign in</a>
+                        </div>
+                    </section>
+                </aside>
+            </div>
+        </div>
+    </main>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,94 @@
+<?php
+session_start();
+
+require_once __DIR__ . '/repository.php';
+
+if (isset($_SESSION['user']['id'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+$flash = $_SESSION['flash'] ?? [];
+unset($_SESSION['flash']);
+$repositoryErrors = meeting_repository_errors();
+$repositoryConnected = meeting_repository_connected();
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Meeting Brief Platform · Sign In</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="app app--auth page--login">
+    <div class="app__backdrop" aria-hidden="true"></div>
+
+    <?php if (!empty($flash)): ?>
+        <aside class="toast toast--<?= htmlspecialchars($flash['type'], ENT_QUOTES, 'UTF-8') ?>" role="alert">
+            <div class="toast__header">
+                <strong><?= htmlspecialchars($flash['title'], ENT_QUOTES, 'UTF-8') ?></strong>
+                <button type="button" class="toast__close" data-dismiss-toast aria-label="Close">×</button>
+            </div>
+            <p><?= htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8') ?></p>
+        </aside>
+    <?php endif; ?>
+
+    <main class="auth-shell auth-shell--split">
+        <section class="auth-intro">
+            <div class="auth-intro__brand">
+                <span class="sidebar__icon">🗂️</span>
+                <div>
+                    <strong>Meeting Portal</strong>
+                    <span>Department Coordination</span>
+                </div>
+            </div>
+            <h1>Welcome back</h1>
+            <p>Sign in to retrieve your accreditation code, confirm attendance, and stay aligned with every department.</p>
+            <a class="link" href="index.php">Return to overview</a>
+        </section>
+        <section class="auth auth--card" aria-labelledby="sign-in-heading">
+            <header class="auth__header">
+                <h2 id="sign-in-heading">Sign in to continue</h2>
+                <p>Enter your credentials to access the coordination dashboard.</p>
+            </header>
+            <?php if (!$repositoryConnected && !empty($repositoryErrors)): ?>
+                <div class="alert alert--error">
+                    <strong>Database connection required</strong>
+                    <ul>
+                        <?php foreach ($repositoryErrors as $error): ?>
+                            <li><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></li>
+                        <?php endforeach; ?>
+                    </ul>
+                    <p class="alert__hint">Finish the MySQL setup before attempting to sign in.</p>
+                </div>
+            <?php endif; ?>
+            <form action="auth.php" method="post" class="auth__form">
+                <input type="hidden" name="action" value="login">
+                <div class="field">
+                    <label for="login-email">Email address</label>
+                    <input id="login-email" name="email" type="email" autocomplete="email" required>
+                </div>
+                <div class="field">
+                    <label for="login-password">Password</label>
+                    <input id="login-password" name="password" type="password" autocomplete="current-password" required>
+                </div>
+                <button type="submit" class="btn btn--primary btn--full">Sign In</button>
+            </form>
+            <div class="empty-state">
+                <strong>Default coordinator account</strong>
+                <span>Use <code>admin@company.com</code> with the password <code>Portal@2024!</code> after importing the database.</span>
+            </div>
+            <footer class="auth__footer">
+                <span>Need an account?</span>
+                <a class="link" href="register.php">Create one now</a>
+            </footer>
+        </section>
+    </main>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/manage.php
+++ b/manage.php
@@ -1,0 +1,102 @@
+<?php
+session_start();
+
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/repository.php';
+
+function manage_redirect(string $type, string $title, string $message, string $target): void
+{
+    $_SESSION['flash'] = [
+        'type' => $type,
+        'title' => $title,
+        'message' => $message,
+    ];
+
+    header('Location: ' . $target);
+    exit;
+}
+
+$action = $_POST['action'] ?? '';
+if (!in_array($action, ['create_meeting', 'post_update'], true)) {
+    manage_redirect('error', 'Unknown request', 'Please submit updates from the dashboard forms provided.', 'dashboard.php');
+}
+
+if (empty($_SESSION['user'])) {
+    manage_redirect('error', 'Sign in required', 'Please sign in to manage meeting content.', 'login.php');
+}
+
+try {
+    $pdo = get_pdo();
+} catch (PDOException $exception) {
+    manage_redirect('error', 'Database unavailable', 'Unable to reach the database. Please try again later.', 'dashboard.php');
+}
+
+$departments = meeting_departments();
+$locations = meeting_locations();
+
+if ($action === 'create_meeting') {
+    $title = trim($_POST['title'] ?? '');
+    $date = trim($_POST['scheduled_date'] ?? '');
+    $time = trim($_POST['scheduled_time'] ?? '');
+    $tag = trim($_POST['tag'] ?? '');
+    $department = trim($_POST['department'] ?? '');
+    $location = trim($_POST['location'] ?? '');
+    $summary = trim($_POST['summary'] ?? '');
+
+    if ($title === '' || $date === '' || $time === '' || $tag === '' || $department === '' || $location === '') {
+        manage_redirect('error', 'Missing information', 'Fill in all mandatory fields before saving the meeting.', 'dashboard.php?view=agenda#add-meeting');
+    }
+
+    if (!in_array($department, $departments, true)) {
+        manage_redirect('error', 'Department not recognised', 'Select a department from the official list.', 'dashboard.php?view=agenda#add-meeting');
+    }
+
+    if (!in_array($location, $locations, true)) {
+        manage_redirect('error', 'Location not recognised', 'Choose an approved meeting venue.', 'dashboard.php?view=agenda#add-meeting');
+    }
+
+    try {
+        $scheduledAt = new DateTimeImmutable(sprintf('%s %s', $date, $time));
+    } catch (Exception $exception) {
+        manage_redirect('error', 'Invalid schedule', 'Provide a valid date and time for the session.', 'dashboard.php?view=agenda#add-meeting');
+    }
+
+    $stmt = $pdo->prepare('INSERT INTO meeting_agenda (title, scheduled_at, tag, department, location, summary) VALUES (?, ?, ?, ?, ?, ?)');
+    $stmt->execute([
+        $title,
+        $scheduledAt->format('Y-m-d H:i:s'),
+        $tag,
+        $department,
+        $location,
+        $summary === '' ? null : $summary,
+    ]);
+
+    manage_redirect('success', 'Meeting added', 'The new agenda item has been published to the dashboard.', 'dashboard.php?view=agenda');
+}
+
+if ($action === 'post_update') {
+    $headline = trim($_POST['headline'] ?? '');
+    $body = trim($_POST['body'] ?? '');
+    $department = trim($_POST['department'] ?? '');
+    $author = trim($_POST['author'] ?? '');
+
+    if ($headline === '' || $body === '') {
+        manage_redirect('error', 'Missing details', 'Provide both a headline and the update details.', 'dashboard.php?view=updates#post-update');
+    }
+
+    if ($department !== '' && !in_array($department, $departments, true)) {
+        manage_redirect('error', 'Unknown department', 'Select the department the update applies to.', 'dashboard.php?view=updates#post-update');
+    }
+
+    $stmt = $pdo->prepare('INSERT INTO meeting_updates (headline, body, department, author) VALUES (?, ?, ?, ?)');
+    $stmt->execute([
+        $headline,
+        $body,
+        $department === '' ? null : $department,
+        $author === '' ? null : $author,
+    ]);
+
+    manage_redirect('success', 'Update shared', 'Your meeting update is now visible to the coordination team.', 'dashboard.php?view=updates');
+}
+
+manage_redirect('error', 'Unhandled request', 'Please retry your action.', 'dashboard.php');

--- a/register.php
+++ b/register.php
@@ -1,0 +1,110 @@
+<?php
+session_start();
+
+require_once __DIR__ . '/repository.php';
+
+$flash = $_SESSION['flash'] ?? [];
+unset($_SESSION['flash']);
+
+$departments = meeting_departments();
+$repositoryErrors = meeting_repository_errors();
+$repositoryConnected = meeting_repository_connected();
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Meeting Brief Platform · Create Account</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="app app--auth page--register">
+    <div class="app__backdrop" aria-hidden="true"></div>
+
+    <?php if (!empty($flash)): ?>
+        <aside class="toast toast--<?= htmlspecialchars($flash['type'], ENT_QUOTES, 'UTF-8') ?>" role="alert">
+            <div class="toast__header">
+                <strong><?= htmlspecialchars($flash['title'], ENT_QUOTES, 'UTF-8') ?></strong>
+                <button type="button" class="toast__close" data-dismiss-toast aria-label="Close">×</button>
+            </div>
+            <p><?= htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8') ?></p>
+        </aside>
+    <?php endif; ?>
+
+    <main class="auth-shell auth-shell--split">
+        <section class="auth-intro">
+            <div class="auth-intro__brand">
+                <span class="sidebar__icon">🗂️</span>
+                <div>
+                    <strong>Meeting Portal</strong>
+                    <span>Department Coordination</span>
+                </div>
+            </div>
+            <h1>Issue an accreditation code</h1>
+            <p>Register your department lead to generate a unique accreditation code and unlock the attendance dashboard.</p>
+            <a class="link" href="index.php">Return to overview</a>
+        </section>
+        <section class="auth auth--card" aria-labelledby="register-heading">
+            <header class="auth__header">
+                <h2 id="register-heading">Create an account</h2>
+                <p>Provide the required details to coordinate meeting attendance.</p>
+            </header>
+            <?php if (!$repositoryConnected && !empty($repositoryErrors)): ?>
+                <div class="alert alert--error">
+                    <strong>Database connection required</strong>
+                    <ul>
+                        <?php foreach ($repositoryErrors as $error): ?>
+                            <li><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></li>
+                        <?php endforeach; ?>
+                    </ul>
+                    <p class="alert__hint">Finish the MySQL setup before onboarding department leads.</p>
+                </div>
+            <?php endif; ?>
+            <?php if ($repositoryConnected && empty($departments)): ?>
+                <div class="empty-state">
+                    <strong>Add departments first</strong>
+                    <span>Populate the <code>meeting_departments</code> table so coordinators can pick their unit during registration.</span>
+                </div>
+            <?php endif; ?>
+            <form id="auth-register" action="auth.php" method="post" class="auth__form" novalidate>
+                <input type="hidden" name="action" value="register">
+                <div class="field">
+                    <label for="register-name">Full name</label>
+                    <input id="register-name" name="name" type="text" autocomplete="name" required>
+                </div>
+                <div class="field">
+                    <label for="register-department">Department</label>
+                    <select id="register-department" name="department" required <?= empty($departments) ? 'disabled' : '' ?>>
+                        <option value="" disabled selected><?= empty($departments) ? 'Add departments in the database first' : 'Select a department' ?></option>
+                        <?php foreach ($departments as $department): ?>
+                            <option value="<?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($department, ENT_QUOTES, 'UTF-8') ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="field">
+                    <label for="register-email">Corporate email</label>
+                    <input id="register-email" name="email" type="email" autocomplete="email" required>
+                </div>
+                <div class="field">
+                    <label for="register-password">Password</label>
+                    <input id="register-password" name="password" type="password" autocomplete="new-password" minlength="8" required>
+                </div>
+                <div class="field">
+                    <label for="register-confirm">Confirm password</label>
+                    <input id="register-confirm" name="confirm" type="password" autocomplete="new-password" minlength="8" required>
+                </div>
+                <button type="submit" class="btn btn--primary btn--full">Create account &amp; issue code</button>
+            </form>
+            <footer class="auth__footer">
+                <span>Already registered?</span>
+                <a class="link" href="login.php">Sign in here</a>
+            </footer>
+        </section>
+    </main>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/repository.php
+++ b/repository.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/config.php';
+
+const MEETING_REPOSITORY_CONTEXT_LABELS = [
+    'departments' => 'department list',
+    'venues' => 'meeting venues',
+    'agenda' => 'agenda items',
+    'attendance' => 'attendance roster',
+    'highlights' => 'executive highlights',
+    'updates' => 'briefing updates',
+];
+
+const MEETING_FALLBACK_DEPARTMENTS = [
+    'General Administration of Information Technology',
+    'Cybersecurity Department',
+    'Investment Agency',
+    'Public Gardens and Beautification Department',
+    'Internal Audit Department',
+    'Operations and Emergency Department',
+    'Security and Safety Department',
+    'Central Unit for Plan Approvals',
+    'Land Management Department',
+    'Environmental Health Department',
+    'Public Cleaning Department',
+    'Central City Municipality',
+    'North Municipality',
+];
+
+const MEETING_FALLBACK_LOCATIONS_GRID = [
+    [
+        'name' => 'Innovation Hall - Headquarters',
+        'capacity' => 220,
+        'facilitator' => 'Eng. Nasser Al-Hamzani',
+        'notes' => 'Primary plenary space with hybrid meeting capability.',
+    ],
+    [
+        'name' => 'Executive Meeting Hall - Tower A',
+        'capacity' => 30,
+        'facilitator' => 'Ms. Sarah Al-Humeidhi',
+        'notes' => 'Reserved for executive briefings and strategy alignment.',
+    ],
+    [
+        'name' => 'Command & Control Center - Third Floor',
+        'capacity' => 45,
+        'facilitator' => 'Eng. Ibrahim Al-Dughaither',
+        'notes' => 'Equipped with live monitoring dashboards for operations.',
+    ],
+    [
+        'name' => 'Virtual Platform via Microsoft Teams',
+        'capacity' => 500,
+        'facilitator' => 'Ms. Lama Al-Assaf',
+        'notes' => 'Digital access with simultaneous translation available.',
+    ],
+];
+
+const MEETING_FALLBACK_AGENDA = [
+    [
+        'title' => 'Digital Transformation Roadmap Review',
+        'time' => '09:30 AM',
+        'tag' => 'Strategic',
+        'department' => 'General Administration of Information Technology',
+        'location' => 'Innovation Hall - Headquarters',
+        'summary' => 'Align the digital roadmap with current infrastructure projects and cybersecurity initiatives.',
+    ],
+    [
+        'title' => 'Cybersecurity Preparedness Assessment',
+        'time' => '11:15 AM',
+        'tag' => 'Risk',
+        'department' => 'Cybersecurity Department',
+        'location' => 'Command & Control Center - Third Floor',
+        'summary' => 'Present penetration test results and assign remediation actions with a clear timeline.',
+    ],
+    [
+        'title' => 'Activating Joint Investment Projects',
+        'time' => '01:00 PM',
+        'tag' => 'Executive',
+        'department' => 'Investment Agency',
+        'location' => 'Executive Meeting Hall - Tower A',
+        'summary' => 'Review cross-functional investment opportunities and confirm the funding schedule.',
+    ],
+];
+
+const MEETING_FALLBACK_ATTENDANCE = [
+    [
+        'department' => 'General Administration of Information Technology',
+        'status' => 'attend',
+        'representatives' => 12,
+        'location' => 'Innovation Hall - Headquarters',
+    ],
+    [
+        'department' => 'Cybersecurity Department',
+        'status' => 'attend',
+        'representatives' => 8,
+        'location' => 'Command & Control Center - Third Floor',
+    ],
+    [
+        'department' => 'Investment Agency',
+        'status' => 'pending',
+        'representatives' => 6,
+        'location' => 'Executive Meeting Hall - Tower A',
+    ],
+    [
+        'department' => 'Public Gardens and Beautification Department',
+        'status' => 'decline',
+        'representatives' => 4,
+        'location' => 'Virtual Platform via Microsoft Teams',
+    ],
+];
+
+const MEETING_FALLBACK_HIGHLIGHTS = [
+    'Interactive deck for the digital transformation roadmap is 92% complete.',
+    'Attendance confirmed by 9 departments so far with unified logistics in place.',
+    'Departments are requested to submit final remarks by Monday at 12:00 PM.',
+];
+
+const MEETING_FALLBACK_UPDATES = [
+    [
+        'headline' => 'Logistics confirmation',
+        'body' => 'Transportation shuttles will run every 20 minutes between the central garage and the headquarters entrance.',
+        'department' => 'Operations and Emergency Department',
+        'author' => 'Logistics Desk',
+        'created_at' => '2024-07-21 10:00:00',
+    ],
+    [
+        'headline' => 'Presentation deadline',
+        'body' => 'Submit final presentation decks by Monday at noon to be included in the consolidated briefing.',
+        'department' => 'General Administration of Information Technology',
+        'author' => 'Meeting Secretariat',
+        'created_at' => '2024-07-20 09:30:00',
+    ],
+];
+
+if (!isset($GLOBALS['MEETING_REPOSITORY_STATE'])) {
+    $GLOBALS['MEETING_REPOSITORY_STATE'] = [
+        'connected' => true,
+        'errors' => [],
+    ];
+}
+
+/**
+ * Execute a callback and return a fallback value if the database is unavailable.
+ *
+ * @template TValue
+ * @param callable():TValue $callback
+ * @param TValue $fallback
+ * @param string $context
+ * @return TValue
+ */
+function meeting_try(callable $callback, $fallback, string $context)
+{
+    try {
+        return $callback();
+    } catch (\Throwable $throwable) {
+        meeting_repository_record_error($context, $throwable);
+        return $fallback;
+    }
+}
+
+function meeting_repository_state(): array
+{
+    return $GLOBALS['MEETING_REPOSITORY_STATE'] ?? ['connected' => true, 'errors' => []];
+}
+
+function meeting_repository_connected(): bool
+{
+    $state = meeting_repository_state();
+    return $state['connected'];
+}
+
+function meeting_repository_errors(): array
+{
+    $state = meeting_repository_state();
+    return array_values($state['errors']);
+}
+
+function meeting_repository_record_error(string $context, \Throwable $throwable): void
+{
+    $state = meeting_repository_state();
+    $state['connected'] = false;
+
+    $label = MEETING_REPOSITORY_CONTEXT_LABELS[$context] ?? $context;
+    $state['errors'][$context] = sprintf(
+        'Unable to load the %s from the database. Confirm your connection settings in config.php and seed data from database.sql.',
+        $label
+    );
+
+    $GLOBALS['MEETING_REPOSITORY_STATE'] = $state;
+
+    error_log(sprintf('[Meeting Portal] %s error: %s', ucfirst($context), $throwable->getMessage()));
+}
+
+function meeting_departments(): array
+{
+    return meeting_try(function () {
+        $pdo = get_pdo();
+        $stmt = $pdo->query('SELECT name FROM meeting_departments ORDER BY name');
+        $rows = $stmt->fetchAll();
+
+        return array_map(static fn ($row) => $row['name'], $rows);
+    }, meeting_fallback_departments(), 'departments');
+}
+
+function meeting_fallback_departments(): array
+{
+    return MEETING_FALLBACK_DEPARTMENTS;
+}
+
+function meeting_locations(): array
+{
+    return meeting_try(function () {
+        $pdo = get_pdo();
+        $stmt = $pdo->query('SELECT name FROM meeting_venues ORDER BY name');
+        $rows = $stmt->fetchAll();
+
+        return array_map(static fn ($row) => $row['name'], $rows);
+    }, meeting_fallback_locations(), 'venues');
+}
+
+function meeting_fallback_locations(): array
+{
+    return array_map(static fn (array $venue) => $venue['name'], MEETING_FALLBACK_LOCATIONS_GRID);
+}
+
+function meeting_attendance_labels(): array
+{
+    return [
+        'pending' => 'Pending Confirmation',
+        'attend' => 'Attending',
+        'decline' => 'Declined',
+    ];
+}
+
+function meeting_today_agenda(): array
+{
+    return meeting_try(function () {
+        $pdo = get_pdo();
+        $stmt = $pdo->query('SELECT title, scheduled_at, tag, department, location, summary FROM meeting_agenda ORDER BY scheduled_at');
+        $rows = $stmt->fetchAll();
+
+        return array_map(static function ($row) {
+            $time = (new DateTimeImmutable($row['scheduled_at']))->format('h:i A');
+
+            return [
+                'title' => $row['title'],
+                'time' => $time,
+                'tag' => $row['tag'],
+                'department' => $row['department'],
+                'location' => $row['location'],
+                'summary' => $row['summary'] ?? '',
+            ];
+        }, $rows);
+    }, meeting_fallback_agenda(), 'agenda');
+}
+
+function meeting_fallback_agenda(): array
+{
+    return MEETING_FALLBACK_AGENDA;
+}
+
+function meeting_attendance_board(): array
+{
+    return meeting_try(function () {
+        $pdo = get_pdo();
+        $stmt = $pdo->query('SELECT department, status, representatives, location FROM meeting_attendance_roster ORDER BY department');
+        $rows = $stmt->fetchAll();
+
+        return array_map(static fn ($row) => [
+            'department' => $row['department'],
+            'status' => $row['status'],
+            'representatives' => (int) $row['representatives'],
+            'location' => $row['location'] ?? '',
+        ], $rows);
+    }, meeting_fallback_attendance(), 'attendance');
+}
+
+function meeting_fallback_attendance(): array
+{
+    return MEETING_FALLBACK_ATTENDANCE;
+}
+
+function meeting_summary_highlights(): array
+{
+    return meeting_try(function () {
+        $pdo = get_pdo();
+        $stmt = $pdo->query('SELECT highlight FROM meeting_highlights ORDER BY created_at DESC');
+        $rows = $stmt->fetchAll();
+
+        return array_map(static fn ($row) => $row['highlight'], $rows);
+    }, meeting_fallback_highlights(), 'highlights');
+}
+
+function meeting_fallback_highlights(): array
+{
+    return MEETING_FALLBACK_HIGHLIGHTS;
+}
+
+function meeting_locations_grid(): array
+{
+    return meeting_try(function () {
+        $pdo = get_pdo();
+        $stmt = $pdo->query('SELECT name, capacity, facilitator, notes FROM meeting_venues ORDER BY name');
+        $rows = $stmt->fetchAll();
+
+        return array_map(static fn ($row) => [
+            'name' => $row['name'],
+            'capacity' => (int) $row['capacity'],
+            'facilitator' => $row['facilitator'] ?? 'Coordination Team',
+            'notes' => $row['notes'] ?? '',
+        ], $rows);
+    }, meeting_fallback_locations_grid(), 'venues');
+}
+
+function meeting_fallback_locations_grid(): array
+{
+    return MEETING_FALLBACK_LOCATIONS_GRID;
+}
+
+function meeting_updates_feed(): array
+{
+    return meeting_try(function () {
+        $pdo = get_pdo();
+        $stmt = $pdo->query('SELECT headline, body, department, author, created_at FROM meeting_updates ORDER BY created_at DESC');
+        $rows = $stmt->fetchAll();
+
+        return array_map(static fn ($row) => [
+            'headline' => $row['headline'],
+            'body' => $row['body'],
+            'department' => $row['department'] ?? '',
+            'author' => $row['author'] ?? '',
+            'created_at' => $row['created_at'],
+        ], $rows);
+    }, meeting_fallback_updates(), 'updates');
+}
+
+function meeting_fallback_updates(): array
+{
+    return MEETING_FALLBACK_UPDATES;
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,110 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const registerForm = document.querySelector('form#auth-register');
+    const passwordInput = document.getElementById('register-password');
+    const confirmInput = document.getElementById('register-confirm');
+
+    const clearFieldMessage = (field) => {
+        if (!field) return;
+        const container = field.closest('.field');
+        const message = container?.querySelector('.field__error');
+        if (message) {
+            message.remove();
+        }
+    };
+
+    const showFieldMessage = (input, message) => {
+        const container = input.closest('.field');
+        if (!container) return;
+        clearFieldMessage(input);
+        const hint = document.createElement('small');
+        hint.className = 'field__error';
+        hint.textContent = message;
+        container.appendChild(hint);
+    };
+
+    if (registerForm && passwordInput && confirmInput) {
+        const validateMatch = () => {
+            clearFieldMessage(confirmInput);
+            confirmInput.setCustomValidity('');
+            if (passwordInput.value && confirmInput.value && passwordInput.value !== confirmInput.value) {
+                confirmInput.setCustomValidity('Passwords do not match');
+                showFieldMessage(confirmInput, 'Passwords do not match, please review and try again.');
+            }
+        };
+
+        passwordInput.addEventListener('input', validateMatch);
+        confirmInput.addEventListener('input', validateMatch);
+
+        registerForm.addEventListener('submit', (event) => {
+            validateMatch();
+            if (!registerForm.checkValidity()) {
+                event.preventDefault();
+                registerForm.reportValidity();
+            }
+        });
+    }
+
+    document.querySelectorAll('[data-dismiss-toast]').forEach((button) => {
+        button.addEventListener('click', () => {
+            const toast = button.closest('.toast');
+            if (toast) {
+                toast.classList.add('toast--hide');
+                setTimeout(() => toast.remove(), 300);
+            }
+        });
+    });
+
+    document.querySelectorAll('[data-copy]').forEach((button) => {
+        const originalLabel = button.textContent.trim() || 'Copy';
+        button.addEventListener('click', async () => {
+            const value = button.getAttribute('data-copy');
+            if (!value) return;
+            try {
+                await navigator.clipboard.writeText(value);
+                button.textContent = 'Copied';
+                button.classList.add('link--success');
+                setTimeout(() => {
+                    button.textContent = originalLabel;
+                    button.classList.remove('link--success');
+                }, 2000);
+            } catch (error) {
+                button.textContent = 'Copy failed';
+            }
+        });
+    });
+
+    const scopeRadios = document.querySelectorAll('input[name="department_scope"]');
+    const scopeSelect = document.querySelector('[data-scope-target] select');
+    const scopeField = document.querySelector('[data-scope-target]');
+
+    if (scopeRadios.length && scopeSelect && scopeField) {
+        const syncScopeState = () => {
+            const selected = document.querySelector('input[name="department_scope"]:checked');
+            const isSpecific = selected?.value === 'specific';
+            scopeSelect.disabled = !isSpecific;
+            scopeField.classList.toggle('field--disabled', !isSpecific);
+            if (!isSpecific) {
+                scopeSelect.value = '';
+            }
+        };
+
+        scopeRadios.forEach((radio) => {
+            radio.addEventListener('change', syncScopeState);
+        });
+
+        syncScopeState();
+    }
+
+    document.querySelectorAll('textarea[data-counter]').forEach((textarea) => {
+        const counter = document.createElement('div');
+        counter.className = 'field__counter';
+        textarea.after(counter);
+
+        const updateCounter = () => {
+            counter.textContent = `${textarea.value.length} / ${textarea.maxLength || 600}`;
+        };
+
+        textarea.addEventListener('input', updateCounter);
+        updateCounter();
+    });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1102 @@
+:root {
+    color-scheme: light;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --bg: #f5f6fb;
+    --bg-accent: #eef1ff;
+    --surface: #ffffff;
+    --surface-alt: #f8f9ff;
+    --border: #e4e7f3;
+    --border-strong: #d3d8ed;
+    --primary: #3f37f0;
+    --primary-dark: #2c28b6;
+    --primary-soft: rgba(63, 55, 240, 0.12);
+    --accent: #ffb347;
+    --success: #2eae6c;
+    --warning: #f0a500;
+    --danger: #ef4665;
+    --text: #1f2333;
+    --text-muted: #5b6080;
+    --shadow-soft: 0 30px 80px -40px rgba(31, 35, 51, 0.35);
+    --radius-lg: 24px;
+    --radius-md: 18px;
+    --radius-sm: 12px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body.app {
+    margin: 0;
+    min-height: 100vh;
+    background: linear-gradient(160deg, rgba(63, 55, 240, 0.08), rgba(255, 255, 255, 0.3)), var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+.app__backdrop {
+    position: fixed;
+    inset: 0;
+    background: radial-gradient(circle at top left, rgba(63, 55, 240, 0.12), transparent 60%), radial-gradient(circle at bottom right, rgba(239, 70, 101, 0.08), transparent 55%);
+    pointer-events: none;
+    z-index: 0;
+}
+
+main, header, section, nav, aside {
+    position: relative;
+    z-index: 1;
+}
+
+.workspace {
+    display: grid;
+    grid-template-columns: 260px minmax(0, 1fr);
+    gap: 28px;
+    padding: 32px;
+}
+
+.workspace--dashboard {
+    grid-template-columns: 260px minmax(0, 1fr);
+}
+
+.workspace__sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+    background: rgba(255, 255, 255, 0.72);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(228, 231, 243, 0.75);
+    padding: 28px 22px;
+    box-shadow: var(--shadow-soft);
+    backdrop-filter: blur(18px);
+}
+
+.sidebar__logo {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+}
+
+.sidebar__icon {
+    width: 48px;
+    height: 48px;
+    display: grid;
+    place-items: center;
+    border-radius: 18px;
+    background: var(--surface);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 12px 30px rgba(63, 55, 240, 0.16);
+    font-size: 1.35rem;
+}
+
+.sidebar__logo strong {
+    display: block;
+    font-size: 1.05rem;
+}
+
+.sidebar__logo span {
+    display: block;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.sidebar__section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.sidebar__title {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-muted);
+    font-weight: 600;
+}
+
+.sidebar__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.sidebar__list li {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.sidebar__list a,
+.sidebar__list span {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border-radius: 12px;
+    text-decoration: none;
+    color: var(--text-muted);
+    font-weight: 500;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.sidebar__list a:hover,
+.sidebar__list a:focus {
+    background: var(--primary-soft);
+    color: var(--primary);
+}
+
+.sidebar__list .is-active {
+    background: var(--primary);
+    color: #fff;
+}
+
+.sidebar__list--actions a::before {
+    content: '•';
+    font-size: 1.4rem;
+    color: rgba(63, 55, 240, 0.4);
+}
+
+.sidebar__footer {
+    margin-top: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    border-radius: 999px;
+    padding: 0.75rem 1.7rem;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    text-decoration: none;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+    font-size: 0.95rem;
+}
+
+.btn--primary {
+    background: linear-gradient(135deg, var(--primary), #5d54ff);
+    color: #fff;
+    box-shadow: 0 22px 40px -20px rgba(63, 55, 240, 0.65);
+}
+
+.btn--primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 28px 50px -24px rgba(63, 55, 240, 0.55);
+}
+
+.btn--secondary {
+    background: var(--surface);
+    color: var(--primary);
+    border: 1px solid rgba(63, 55, 240, 0.15);
+}
+
+.btn--ghost {
+    background: rgba(63, 55, 240, 0.08);
+    color: var(--primary);
+}
+
+.btn--ghost:hover {
+    transform: translateY(-1px);
+}
+
+.btn--full {
+    width: 100%;
+}
+
+.link {
+    border: none;
+    background: transparent;
+    color: var(--primary);
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+    padding: 0;
+}
+
+.link--success {
+    color: var(--success);
+}
+
+.workspace__content {
+    background: rgba(255, 255, 255, 0.82);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(228, 231, 243, 0.7);
+    padding: 32px 36px;
+    box-shadow: var(--shadow-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 36px;
+}
+
+.workspace__header {
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
+    align-items: flex-start;
+}
+
+.workspace__header h1 {
+    margin: 6px 0 12px;
+    font-size: 2rem;
+    letter-spacing: -0.02em;
+}
+
+.workspace__lede {
+    margin: 0;
+    color: var(--text-muted);
+    max-width: 680px;
+}
+
+.workspace__actions {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin: 0;
+}
+
+.workspace__grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 320px;
+    gap: 32px;
+    align-items: start;
+}
+
+.workspace__main {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+}
+
+.workspace__rail {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.chip-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.chip {
+    border: 1px solid rgba(90, 96, 128, 0.2);
+    background: transparent;
+    color: var(--text-muted);
+    border-radius: 999px;
+    padding: 8px 18px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.chip.is-active,
+.chip:hover {
+    background: var(--primary-soft);
+    border-color: rgba(63, 55, 240, 0.4);
+    color: var(--primary);
+}
+
+.section-title {
+    margin: 0 0 16px;
+    font-size: 1.4rem;
+}
+
+.meeting-feed {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.meeting-card {
+    background: linear-gradient(130deg, rgba(255, 255, 255, 0.95), rgba(248, 250, 255, 0.6));
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(228, 231, 243, 0.8);
+    padding: 20px 24px;
+    box-shadow: 0 18px 40px -32px rgba(31, 35, 51, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.meeting-card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.meeting-card__time {
+    font-weight: 600;
+    color: var(--text);
+}
+
+.meeting-card h3 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.meeting-card p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.meeting-card footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    padding: 4px 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: capitalize;
+}
+
+.badge--strategic {
+    background: rgba(63, 55, 240, 0.12);
+    color: var(--primary);
+}
+
+.badge--risk {
+    background: rgba(239, 70, 101, 0.12);
+    color: var(--danger);
+}
+
+.badge--executive {
+    background: rgba(46, 174, 108, 0.12);
+    color: var(--success);
+}
+
+.badge--attend {
+    background: rgba(46, 174, 108, 0.15);
+    color: var(--success);
+}
+
+.badge--pending {
+    background: rgba(240, 165, 0, 0.16);
+    color: var(--warning);
+}
+
+.badge--decline {
+    background: rgba(239, 70, 101, 0.15);
+    color: var(--danger);
+}
+
+.card {
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.95), rgba(248, 250, 255, 0.85));
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(228, 231, 243, 0.75);
+    padding: 22px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    box-shadow: 0 18px 40px -34px rgba(31, 35, 51, 0.4);
+}
+
+.card header {
+    display: flex;
+    justify-content: space-between;
+    gap: 18px;
+}
+
+.card header h2 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.card header p {
+    margin: 4px 0 0;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.card__code {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    background: rgba(63, 55, 240, 0.04);
+    border-radius: var(--radius-sm);
+    border: 1px dashed rgba(63, 55, 240, 0.25);
+    padding: 16px;
+    color: var(--primary);
+    font-weight: 600;
+}
+
+.card__code .code-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.card__code .label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+}
+
+.placeholder {
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.stat-list,
+.note-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.stat-list li strong {
+    display: block;
+    font-size: 1.6rem;
+}
+
+.stat-list--inline {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 18px;
+    padding: 24px 28px 28px;
+}
+
+.stat-list--inline > div {
+    background: rgba(255, 255, 255, 0.85);
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(228, 231, 243, 0.75);
+    padding: 18px;
+    text-align: center;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+.note-list li {
+    position: relative;
+    padding-left: 16px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.note-list li::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.55em;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--primary);
+}
+
+.card__actions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.panel {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(248, 250, 255, 0.88));
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(228, 231, 243, 0.75);
+    box-shadow: 0 20px 46px -36px rgba(31, 35, 51, 0.45);
+}
+
+.panel--wide {
+    padding: 0;
+}
+
+.panel--form .panel__body {
+    gap: 18px;
+}
+
+.panel__header {
+    padding: 24px 28px 0;
+}
+
+.panel__header h2 {
+    margin: 0;
+}
+
+.panel__header p {
+    margin: 8px 0 0;
+    color: var(--text-muted);
+}
+
+.panel__body {
+    padding: 24px 28px 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 16px 18px;
+    background: rgba(248, 250, 255, 0.85);
+    border: 1px dashed rgba(124, 136, 176, 0.45);
+    border-radius: var(--radius-sm);
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+
+.empty-state strong {
+    color: var(--text);
+    font-weight: 600;
+}
+
+.empty-state code {
+    background: rgba(63, 55, 240, 0.08);
+    border-radius: 6px;
+    padding: 2px 6px;
+}
+
+.panel__body--split {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+}
+
+.panel__body--split ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.timeline {
+    padding: 24px 28px 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.timeline__item {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(228, 231, 243, 0.8);
+    padding: 20px 24px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.timeline__item header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+}
+
+.timeline__item header span {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.timeline__item footer {
+    display: flex;
+    gap: 12px;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    flex-wrap: wrap;
+}
+
+.timeline--compact {
+    padding: 0 28px 28px;
+}
+
+.timeline--compact .timeline__item {
+    padding: 16px 18px;
+}
+
+.summary-list li,
+.summary-board li {
+    padding: 16px;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(228, 231, 243, 0.7);
+    background: rgba(255, 255, 255, 0.75);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.summary-board li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.locations-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+    padding: 0 28px 28px;
+}
+
+.location-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(228, 231, 243, 0.8);
+    padding: 20px 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.location-card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: 600;
+}
+
+.location-card p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.location-card__notes {
+    font-size: 0.9rem;
+}
+
+.location-card footer {
+    display: flex;
+    gap: 12px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.table {
+    padding: 0 28px 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.table__head,
+.table__row {
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr 1.5fr;
+    align-items: center;
+    gap: 16px;
+}
+
+.table__head {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-muted);
+}
+
+.table__row {
+    background: rgba(255, 255, 255, 0.75);
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(228, 231, 243, 0.7);
+    padding: 16px 18px;
+}
+
+.table__row span:last-child {
+    color: var(--text-muted);
+}
+
+.update .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.field label,
+.field legend {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.field input,
+.field select,
+.field textarea {
+    border-radius: 12px;
+    border: 1px solid rgba(90, 96, 128, 0.15);
+    background: rgba(255, 255, 255, 0.9);
+    padding: 12px 14px;
+    font-size: 0.95rem;
+    font-family: inherit;
+    color: var(--text);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus,
+.field select:focus,
+.field textarea:focus {
+    outline: none;
+    border-color: rgba(63, 55, 240, 0.5);
+    box-shadow: 0 0 0 3px rgba(63, 55, 240, 0.12);
+}
+
+.field textarea {
+    resize: vertical;
+    min-height: 140px;
+}
+
+.field__hint {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.field__error {
+    color: var(--danger);
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.field__counter {
+    align-self: flex-end;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.field--inline {
+    border: 1px solid rgba(90, 96, 128, 0.15);
+    border-radius: 12px;
+    padding: 14px 16px;
+    gap: 12px;
+}
+
+.field--inline legend {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-muted);
+}
+
+.field--inline input {
+    display: none;
+}
+
+.field--inline .chip {
+    padding: 0;
+    border: none;
+    background: transparent;
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+}
+
+.field--inline .chip span {
+    pointer-events: none;
+    padding: 8px 18px;
+    border-radius: 999px;
+    border: 1px solid rgba(90, 96, 128, 0.2);
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.field--inline .chip:hover span {
+    border-color: rgba(63, 55, 240, 0.35);
+    color: var(--primary);
+}
+
+.field--inline .chip input:checked + span {
+    background: var(--primary-soft);
+    border-color: rgba(63, 55, 240, 0.45);
+    color: var(--primary);
+    font-weight: 600;
+}
+
+.field--disabled {
+    opacity: 0.55;
+}
+
+.auth-shell {
+    display: flex;
+    align-items: stretch;
+    justify-content: center;
+    padding: 64px 32px;
+}
+
+.auth-shell--split {
+    gap: 32px;
+    max-width: 1080px;
+    margin: 0 auto;
+}
+
+.auth-intro {
+    flex: 1;
+    background: linear-gradient(135deg, rgba(63, 55, 240, 0.12), rgba(63, 55, 240, 0.04));
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(228, 231, 243, 0.75);
+    padding: 48px 40px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    box-shadow: var(--shadow-soft);
+}
+
+.auth-intro h1 {
+    margin: 0;
+    font-size: 2rem;
+}
+
+.auth-intro p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.auth-intro__brand {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+.auth {
+    flex: 1;
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(228, 231, 243, 0.75);
+    padding: 48px 40px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    box-shadow: var(--shadow-soft);
+}
+
+.auth__header h2 {
+    margin: 0;
+    font-size: 1.5rem;
+}
+
+.auth__header p {
+    margin: 8px 0 0;
+    color: var(--text-muted);
+}
+
+.auth__form {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.auth__footer {
+    display: flex;
+    gap: 8px;
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+
+.toast {
+    position: fixed;
+    top: 24px;
+    right: 24px;
+    background: #fff;
+    border-radius: 16px;
+    box-shadow: 0 20px 50px -30px rgba(31, 35, 51, 0.4);
+    border: 1px solid var(--border);
+    padding: 20px 24px;
+    max-width: 360px;
+    z-index: 50;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.toast__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: 600;
+}
+
+.toast__close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.2rem;
+}
+
+.toast--success {
+    border-color: rgba(46, 174, 108, 0.3);
+}
+
+.toast--error {
+    border-color: rgba(239, 70, 101, 0.3);
+}
+
+.toast--hide {
+    opacity: 0;
+    transform: translateY(-10px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.toast ul {
+    margin: 0;
+    padding-left: 18px;
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.toast ul li {
+    list-style: disc;
+}
+
+.alert {
+    padding: 16px 20px;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(239, 70, 101, 0.24);
+    background: rgba(239, 70, 101, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: var(--text);
+}
+
+.alert strong {
+    font-size: 1rem;
+}
+
+.alert--error {
+    border-color: rgba(239, 70, 101, 0.35);
+    background: rgba(239, 70, 101, 0.18);
+}
+
+.alert ul {
+    margin: 0;
+    padding-left: 18px;
+    color: var(--text-muted);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.alert__hint {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+@media (max-width: 1200px) {
+    .workspace {
+        grid-template-columns: 220px minmax(0, 1fr);
+        padding: 24px;
+    }
+
+    .workspace__grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .workspace__rail {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .workspace__rail > * {
+        flex: 1 1 280px;
+    }
+}
+
+@media (max-width: 960px) {
+    .workspace {
+        grid-template-columns: 1fr;
+        padding: 20px;
+    }
+
+    .workspace__sidebar {
+        position: sticky;
+        top: 20px;
+        z-index: 10;
+    }
+
+    .workspace__actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .workspace__content {
+        padding: 28px;
+    }
+
+    .workspace__rail {
+        flex-direction: column;
+    }
+
+    .workspace__rail > * {
+        flex: 1 1 auto;
+    }
+
+    .workspace__header {
+        flex-direction: column;
+    }
+}
+
+@media (max-width: 720px) {
+    .auth-shell {
+        flex-direction: column;
+        padding: 48px 20px;
+    }
+
+    .auth-shell--split {
+        max-width: 640px;
+    }
+
+    .auth-intro,
+    .auth {
+        padding: 32px 26px;
+    }
+
+    .table__head,
+    .table__row {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        row-gap: 12px;
+    }
+}
+
+@media (max-width: 520px) {
+    .workspace {
+        padding: 16px;
+    }
+
+    .workspace__content {
+        padding: 22px;
+    }
+
+    .meeting-card footer {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+    }
+}

--- a/تحميل السكربت.md
+++ b/تحميل السكربت.md
@@ -1,16 +1,17 @@
 # tatarwar
-سكربت حرب التتار نسخة سيرفرات النخبة مجانا
-بعد انتشار لهذه النسخة بسعر كبير اقدم لكن نسخة سيرفر النخبة الان مجانا
 
-امثلة على النسخة
-www.tatar.ae 
-www.viptatar.com
-www.satatar.com 
+Tatar War elite server script — free download
 
-صاحب النسخة الاساسي
-احمد علان 00962780094101 
-www.viptwar.com
+This package was previously sold widely for a high price, so here's the elite server edition available at no cost.
 
+Example deployments:
+- www.tatar.ae
+- www.viptatar.com
+- www.satatar.com
 
-رابط التحميل من هنا 
+Original author:
+- Ahmad Allan — +962 7 8009 4101
+- www.viptwar.com
+
+Download link:
 https://www.mediafire.com/file/y9g1zm2xkroxcn0/tatarvip.rar/file

--- a/خطوات تنفيذ المنصة.md
+++ b/خطوات تنفيذ المنصة.md
@@ -1,0 +1,75 @@
+# Step-by-step guide for building the meeting brief platform
+
+> **Starting point:** Work with the files that already exist in the project root (`index.php`, `styles.css`, `script.js`, `auth.php`, `config.php`, `database.sql`). Do not spin up a new project—everything you need is prepared in these files for customization and enhancement.
+
+## 1. Prepare the database (SQL)
+1. Open `database.sql` and review the structures for `meeting_users`, `meeting_departments`, `meeting_agenda`, `meeting_updates`, `meeting_highlights`, `meeting_venues`, and `meeting_attendance_roster`. These tables power the dashboard views (agenda, updates, summary, venues, and roster).
+2. Create a new database in your MySQL server (for example: `meeting_portal`).
+3. Execute the commands in `database.sql` against the new database to create all tables and seed the starter data. You can use phpMyAdmin or the `mysql` command line.
+4. The script already defines unique keys for agenda items, venues, and roster entries so you can rerun it safely; add extra indexes later if your workflow requires them.
+5. After seeding, sign in with the default coordinator credentials (`admin@company.com` / `Portal@2024!`) to verify access and then replace them with your own account.
+
+## 2. Configure the backend connection (PHP)
+1. Edit `config.php` and provide the database connection details (`DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASS`).
+2. Make sure the `get_pdo()` function returns a valid connection (you can test it by running `php -l config.php` and then a short script that calls the function).
+3. In `auth.php`, review the functions responsible for registration and login:
+   - The registration routine validates fields, generates the unique code, and stores the initial attendance status.
+   - The login routine checks the email and password and restores the user data to the session.
+4. Add temporary logging (`error_log`) while developing so you can confirm that requests arrive and errors are handled properly.
+
+## 3. Understand the current interface (HTML + PHP)
+1. `index.php` now works as the public overview page with the hero section, agenda highlights, and calls to open the dashboard or create an account.
+2. `dashboard.php` is the primary working area with sidebar navigation. Each link loads a dedicated view: agenda focus, attendance & briefing updates, executive summary, meeting venues, and the attendance roster.
+3. `login.php` and `register.php` provide dedicated flows for authentication—both pages reuse the same styling but focus on a single form per page.
+4. Before making changes, copy the overall layout of each section so you can revert quickly if needed. The shared visual identity (hero cards, panels, tables) is consistent across all pages.
+5. Customize the required areas (agenda cards, attendance responses, meeting updates, venue directory, roster table) within their respective views. The forms for adding meetings and posting updates submit to `manage.php`.
+6. Shared reference data (departments, agenda slots, venues, highlights) now comes from the database through helper functions in `repository.php`. If the database is offline, the helpers fall back to the seeded samples and raise inline alerts so you can still preview the layout while finishing the connection.
+7. When the database connection is missing, the dashboard automatically disables submission forms (add meeting, attendance response, share update) until the connection is restored.
+
+## 4. Refine the look & feel (CSS)
+1. Open `styles.css` and locate the comment blocks for each group (for example `.app`, `.agenda`, `.auth-card`).
+2. If you want to adjust colors or fonts, tweak the custom properties defined under the `:root` selector so the update cascades across the whole interface.
+3. Preserve the glassmorphism aesthetic by keeping properties like `backdrop-filter` and semi-transparent `rgba` values. Adjust them gradually and check the page in the browser.
+4. Test every change by refreshing the page, and rely on DevTools to monitor element sizing now that the layout is left-to-right.
+
+## 5. Front-end interactions (JavaScript)
+1. `script.js` ensures the password confirmation matches on the registration page, toggles the department scope selector on the dashboard, and handles clipboard/counter helpers.
+2. If you add new form fields (such as selecting a department or expanding the meeting summary), make sure the script updates counters or inline validation accordingly.
+3. Ensure any `submit` handler only prevents default submission when there are errors; otherwise allow the request to reach `auth.php`.
+
+## 6. Test the full journey
+1. Run a local PHP server with `php -S localhost:8000` from the project directory.
+2. Register a new user and confirm the record is inserted into the database.
+3. Sign in with the same credentials and verify that the session retains attendance and location preferences.
+4. Navigate across the dashboard views and ensure they read from live database records (agenda entries, updates, highlights, venues, roster).
+5. Submit the “Add meeting” and “Share a meeting update” forms to confirm new records appear immediately.
+
+## 7. Suggested future enhancements
+- Extend role management so certain users can approve or archive agenda items directly from the dashboard.
+- Add an admin dashboard to approve department responses and write overarching notes.
+- Create an email notification system that uses the `unique_code` for each user to send invitations and follow-up reminders.
+
+Following these steps will help you move from the existing project files through database setup, interface customization, and end-to-end testing with confidence.
+
+---
+
+## Appendix: How to copy the project code
+
+If you only need to copy the code so you can use it in another project or share it with teammates, choose the method that fits your workflow:
+
+### Option A — Copy straight from the editor
+1. Open the file you want (for example `index.php`) in your code editor or the web-based viewer.
+2. Use the global *Select All* shortcut (`Ctrl + A` on Windows/Linux or `Cmd + A` on macOS) to highlight the entire file.
+3. Copy the highlighted text (`Ctrl/Cmd + C`) and paste it where you need it (`Ctrl/Cmd + V`).
+
+### Option B — Download the repository as a ZIP
+1. In GitHub (or your Git hosting platform), navigate to the repository home page.
+2. Click **Code** ▸ **Download ZIP**.
+3. Extract the downloaded archive on your machine and open the files locally.
+
+### Option C — Clone with Git
+1. Install Git if you do not already have it.
+2. Run `git clone <repository-url>` in your terminal to fetch the project to your device.
+3. Enter the folder (`cd tatarwar`) and open the files in your preferred editor. You can now copy any portion of the codebase.
+
+These approaches give you complete copies of the HTML, CSS, PHP, SQL, and JavaScript files so you can reuse or adapt them without rewriting everything manually.


### PR DESCRIPTION
## Summary
- add fallback data, connection state tracking, and error logging to repository.php so pages can detect database outages while still rendering sample content
- surface database alerts, disable submissions when offline, and document the default coordinator credentials across the dashboard, auth pages, and guide
- tighten the SQL seed script with unique keys, safe re-run inserts, and an updated admin password while extending the styles for alerts/empty states

## Testing
- php -l repository.php
- php -l index.php
- php -l dashboard.php
- php -l login.php
- php -l register.php
- php -l auth.php

------
https://chatgpt.com/codex/tasks/task_e_68dcc1622c14832c99d76f8c5fba1028