### PR TITLE
Add authentication and reorganize dashboard layout

### DIFF
--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -1,0 +1,79 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const searchInput = document.getElementById('search');
+    const departmentFilter = document.getElementById('filter-department');
+    const statusFilter = document.getElementById('filter-status');
+    const priorityFilter = document.getElementById('filter-priority');
+    const rows = Array.from(document.querySelectorAll('#tasks-table tbody tr'));
+
+    const applyFilters = () => {
+        const searchTerm = (searchInput?.value || '').toLowerCase();
+        const department = departmentFilter?.value || 'all';
+        const status = statusFilter?.value || 'all';
+        const priority = priorityFilter?.value || 'all';
+
+        rows.forEach(row => {
+            const title = row.querySelector('td strong')?.textContent.toLowerCase() || '';
+            const assignee = row.querySelector('td:nth-child(3)')?.textContent.toLowerCase() || '';
+            const description = row.querySelector('.description')?.textContent.toLowerCase() || '';
+
+            const matchesSearch = !searchTerm || title.includes(searchTerm) || assignee.includes(searchTerm) || description.includes(searchTerm);
+            const matchesDepartment = department === 'all' || row.dataset.department === department;
+            const matchesStatus = status === 'all' || row.dataset.status === status;
+            const matchesPriority = priority === 'all' || row.dataset.priority === priority;
+
+            row.style.display = (matchesSearch && matchesDepartment && matchesStatus && matchesPriority) ? '' : 'none';
+        });
+    };
+
+    [searchInput, departmentFilter, statusFilter, priorityFilter].forEach(element => {
+        element?.addEventListener('input', applyFilters);
+        element?.addEventListener('change', applyFilters);
+    });
+
+    const dueDates = document.querySelectorAll('.due-date');
+    const today = new Date();
+
+    const formatDays = (value) => {
+        const absolute = Math.abs(value);
+        return `${absolute} day${absolute === 1 ? '' : 's'}`;
+    };
+
+    dueDates.forEach(dueDateElement => {
+        const dueText = dueDateElement.getAttribute('datetime');
+        if (!dueText) {
+            return;
+        }
+
+        const dueDate = new Date(dueText + 'T00:00:00');
+        const diffTime = dueDate.getTime() - today.setHours(0, 0, 0, 0);
+        const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24));
+
+        const indicator = dueDateElement.nextElementSibling;
+        if (!(indicator instanceof HTMLElement)) {
+            return;
+        }
+
+        indicator.textContent = '';
+        indicator.classList.remove('overdue', 'soon', 'safe');
+
+        if (Number.isNaN(diffDays)) {
+            return;
+        }
+
+        if (diffDays < 0) {
+            indicator.textContent = `Overdue by ${formatDays(diffDays)}`;
+            indicator.classList.add('overdue');
+        } else if (diffDays === 0) {
+            indicator.textContent = 'Due today';
+            indicator.classList.add('soon');
+        } else if (diffDays <= 3) {
+            indicator.textContent = `Due in ${formatDays(diffDays)}`;
+            indicator.classList.add('soon');
+        } else {
+            indicator.textContent = `Due in ${formatDays(diffDays)}`;
+            indicator.classList.add('safe');
+        }
+    });
+
+    applyFilters();
+});

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,674 @@
+:root {
+    --background: #eef2ff;
+    --surface: #ffffff;
+    --primary: #1d4ed8;
+    --primary-dark: #1e3a8a;
+    --accent: #f59e0b;
+    --text: #0f172a;
+    --muted: #64748b;
+    --border: #e2e8f0;
+    --danger: #dc2626;
+    --success: #059669;
+    --info: #0ea5e9;
+    font-size: 16px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: linear-gradient(180deg, #eef2ff 0%, #f8fafc 100%);
+    color: var(--text);
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+.app-header {
+    background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.9), rgba(15, 23, 42, 0.95));
+    color: #fff;
+    padding: 3.5rem 0 4rem;
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 25px 60px -35px rgba(15, 23, 42, 0.7);
+}
+
+.app-header::after {
+    content: '';
+    position: absolute;
+    inset: 15% -20% auto 40%;
+    height: 140%;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.35), transparent 60%);
+    opacity: 0.6;
+    pointer-events: none;
+    filter: blur(0.5px);
+}
+
+.header-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 2.5rem;
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.header-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.user-chip {
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
+    padding: 0.45rem 1rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.9rem;
+    letter-spacing: 0.01em;
+}
+
+.ghost-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.55rem 1.2rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    color: #fff;
+    background: rgba(255, 255, 255, 0.08);
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ghost-btn:hover {
+    transform: translateY(-1px);
+    background: rgba(255, 255, 255, 0.18);
+    box-shadow: 0 14px 30px -22px rgba(15, 23, 42, 0.6);
+}
+
+.logout-form {
+    margin: 0;
+}
+
+.logout-form .ghost-btn {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.35);
+}
+
+.logout-form .ghost-btn:hover {
+    background: rgba(255, 255, 255, 0.22);
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    font-size: 0.75rem;
+    margin: 0;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.app-header h1 {
+    margin: 0;
+    font-size: 2.75rem;
+    font-weight: 700;
+}
+
+.app-header p {
+    margin: 0;
+    max-width: 620px;
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.flash-container {
+    max-width: 1240px;
+    margin: 1.5rem auto 0;
+    padding: 0 2.5rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.flash-message {
+    border-radius: 16px;
+    padding: 0.85rem 1.1rem;
+    font-weight: 600;
+    font-size: 0.95rem;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    background: rgba(148, 163, 184, 0.12);
+    color: var(--text);
+    box-shadow: 0 16px 36px -28px rgba(15, 23, 42, 0.45);
+}
+
+.flash-message.flash-success {
+    border-color: rgba(5, 150, 105, 0.35);
+    background: rgba(5, 150, 105, 0.12);
+    color: var(--success);
+}
+
+.flash-message.flash-error {
+    border-color: rgba(220, 38, 38, 0.35);
+    background: rgba(220, 38, 38, 0.12);
+    color: var(--danger);
+}
+
+.flash-message.flash-info {
+    border-color: rgba(14, 165, 233, 0.35);
+    background: rgba(14, 165, 233, 0.12);
+    color: var(--info);
+}
+
+.layout {
+    max-width: 1240px;
+    margin: -3.5rem auto 3rem;
+    display: grid;
+    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr) minmax(220px, 260px);
+    gap: 2rem;
+    padding: 0 2.5rem;
+    align-items: start;
+}
+
+.auth-layout {
+    max-width: 1100px;
+    margin: -3rem auto 4rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 2rem;
+    padding: 0 2.5rem;
+}
+
+.auth-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.auth-form {
+    display: grid;
+    gap: 1.15rem;
+}
+
+.auth-form .primary-btn {
+    width: 100%;
+    justify-self: stretch;
+    text-align: center;
+}
+
+.card-subtitle {
+    margin: 0.35rem 0 1.25rem;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.auth-subtitle {
+    margin-top: -0.25rem;
+}
+
+.side-column {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.department-card {
+    position: sticky;
+    top: 2rem;
+}
+
+.department-name {
+    flex: 1;
+    margin-right: 0.75rem;
+}
+
+.panel,
+.card {
+    background: var(--surface);
+    border-radius: 24px;
+    padding: 1.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    box-shadow: 0 30px 60px -40px rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(6px);
+}
+
+.panel h2,
+.card h2 {
+    margin-top: 0;
+    color: var(--primary-dark);
+    font-size: 1.35rem;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.75rem;
+}
+
+.stat-card {
+    background: linear-gradient(145deg, rgba(59, 130, 246, 0.1), rgba(59, 130, 246, 0.05));
+    border-radius: 18px;
+    padding: 1.15rem;
+    border: 1px solid rgba(37, 99, 235, 0.15);
+    display: grid;
+    gap: 0.35rem;
+}
+
+.stat-card h3 {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--muted);
+}
+
+.stat-number {
+    margin: 0;
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--primary-dark);
+}
+
+.alerts {
+    display: grid;
+    gap: 1.25rem;
+    margin-bottom: 2rem;
+}
+
+.alert-group {
+    border-radius: 18px;
+    padding: 1.15rem;
+    border: 1px solid var(--border);
+    background: #f8fafc;
+    display: grid;
+    gap: 0.65rem;
+}
+
+.alert-group h3 {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--text);
+}
+
+.alert-group p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.alert-group ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.alert-group li {
+    background: #fff;
+    padding: 0.85rem 1rem;
+    border-radius: 14px;
+    box-shadow: 0 18px 35px -28px rgba(15, 23, 42, 0.45);
+    display: grid;
+    gap: 0.35rem;
+    border: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+.alert-group.overdue {
+    border-color: rgba(220, 38, 38, 0.25);
+}
+
+.alert-group.overdue strong {
+    color: var(--danger);
+}
+
+.alert-group.upcoming {
+    border-color: rgba(245, 158, 11, 0.25);
+}
+
+.alert-group.upcoming strong {
+    color: var(--accent);
+}
+
+.alert-group time {
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.department-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.6rem;
+}
+
+.department-list li {
+    background: rgba(255, 255, 255, 0.75);
+    border-radius: 14px;
+    padding: 0.75rem 1rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: 600;
+    border: 1px solid rgba(226, 232, 240, 0.9);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.7rem;
+    border-radius: 999px;
+    background: rgba(29, 78, 216, 0.12);
+    color: var(--primary-dark);
+    font-size: 0.75rem;
+    font-weight: 600;
+    min-width: 2.1rem;
+}
+
+.card-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 1.5rem;
+    margin-bottom: 1.75rem;
+}
+
+.card-header p {
+    margin: 0.35rem 0 0;
+    color: var(--muted);
+}
+
+.filters {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+}
+
+label {
+    display: grid;
+    gap: 0.45rem;
+    font-weight: 600;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+input[type="text"],
+input[type="search"],
+input[type="date"],
+input[type="email"],
+input[type="password"],
+select,
+textarea {
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 0.7rem 0.85rem;
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    background: #fff;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+    transform: translateY(-1px);
+}
+
+textarea {
+    resize: vertical;
+}
+
+.task-form {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.form-grid {
+    display: grid;
+    gap: 1.15rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.primary-btn {
+    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+    color: #fff;
+    padding: 0.85rem 1.75rem;
+    border: none;
+    border-radius: 14px;
+    font-size: 1rem;
+    cursor: pointer;
+    font-weight: 600;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    justify-self: start;
+    box-shadow: 0 15px 30px -18px rgba(29, 78, 216, 0.8);
+}
+
+.primary-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 40px -20px rgba(29, 78, 216, 0.85);
+}
+
+.danger-btn {
+    background: rgba(220, 38, 38, 0.12);
+    color: var(--danger);
+    border: 1px solid rgba(220, 38, 38, 0.2);
+    border-radius: 12px;
+    padding: 0.55rem 0.8rem;
+    cursor: pointer;
+    font-weight: 600;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.danger-btn:hover {
+    background: rgba(220, 38, 38, 0.18);
+    transform: translateY(-1px);
+}
+
+.table-wrapper {
+    overflow-x: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 760px;
+}
+
+thead {
+    background: rgba(148, 163, 184, 0.12);
+}
+
+thead th {
+    text-align: left;
+    padding: 0.9rem;
+    font-size: 0.9rem;
+    color: var(--muted);
+    font-weight: 600;
+}
+
+tbody td {
+    padding: 1.05rem 0.9rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+}
+
+tbody tr:hover {
+    background: rgba(29, 78, 216, 0.05);
+}
+
+.description {
+    margin: 0.4rem 0 0;
+    color: var(--muted);
+    font-size: 0.92rem;
+}
+
+.tag {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.priority-high {
+    background: rgba(220, 38, 38, 0.12);
+    color: var(--danger);
+}
+
+.priority-normal {
+    background: rgba(29, 78, 216, 0.12);
+    color: var(--primary-dark);
+}
+
+.priority-low {
+    background: rgba(14, 165, 233, 0.12);
+    color: var(--info);
+}
+
+.status-pending {
+    background: rgba(245, 158, 11, 0.16);
+    color: var(--accent);
+}
+
+.status-in-progress {
+    background: rgba(14, 165, 233, 0.16);
+    color: var(--info);
+}
+
+.status-completed {
+    background: rgba(5, 150, 105, 0.16);
+    color: var(--success);
+}
+
+.actions {
+    display: grid;
+    gap: 0.6rem;
+}
+
+.inline-form select {
+    width: 100%;
+}
+
+.due-indicator {
+    display: inline-flex;
+    margin-top: 0.45rem;
+    padding: 0.3rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    background: rgba(15, 23, 42, 0.05);
+    color: var(--muted);
+}
+
+.due-indicator.overdue {
+    background: rgba(220, 38, 38, 0.12);
+    color: var(--danger);
+}
+
+.due-indicator.soon {
+    background: rgba(245, 158, 11, 0.15);
+    color: var(--accent);
+}
+
+.due-indicator.safe {
+    background: rgba(5, 150, 105, 0.15);
+    color: var(--success);
+}
+
+@media (max-width: 1200px) {
+    .layout {
+        grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+    }
+
+    .side-column {
+        grid-column: 1 / -1;
+    }
+}
+
+@media (max-width: 1100px) {
+    .layout {
+        grid-template-columns: 1fr;
+        margin-top: -2rem;
+        padding: 0 1.5rem;
+    }
+
+    .panel {
+        order: 2;
+    }
+
+    .content {
+        order: 1;
+    }
+
+    .side-column {
+        order: 3;
+        grid-column: 1 / -1;
+    }
+
+    .department-card {
+        position: static;
+    }
+
+    .auth-layout {
+        padding: 0 1.5rem;
+        margin-top: -2.5rem;
+    }
+
+    .flash-container {
+        padding: 0 1.5rem;
+    }
+}
+
+@media (max-width: 720px) {
+    .app-header {
+        padding: 2.75rem 0 3rem;
+    }
+
+    .header-content {
+        padding: 0 1.5rem;
+    }
+
+    .app-header h1 {
+        font-size: 2.2rem;
+    }
+
+    .layout {
+        padding: 0 1rem;
+    }
+
+    .auth-layout {
+        padding: 0 1rem;
+    }
+
+    .flash-container {
+        padding: 0 1rem;
+    }
+
+    .header-bar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+
+    table {
+        min-width: 100%;
+    }
+}

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS departments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    description TEXT,
+    department_id INTEGER NOT NULL,
+    assignee TEXT,
+    due_date DATE NOT NULL,
+    status TEXT NOT NULL DEFAULT 'Pending',
+    priority TEXT NOT NULL DEFAULT 'Normal',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (department_id) REFERENCES departments(id)
+);
+
+CREATE TRIGGER IF NOT EXISTS update_tasks_timestamp
+AFTER UPDATE ON tasks
+FOR EACH ROW
+BEGIN
+    UPDATE tasks SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+END;
+
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/index.php
+++ b/index.php
@@ -1,0 +1,722 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+$dbPath = __DIR__ . '/database/app.sqlite';
+$initialize = !file_exists($dbPath);
+$pdo = new PDO('sqlite:' . $dbPath);
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+if ($initialize) {
+    initializeDatabase($pdo);
+} else {
+    ensureSchema($pdo);
+}
+
+handlePostRequests($pdo);
+
+$currentUser = getAuthenticatedUser($pdo);
+$departments = [];
+$tasks = [];
+$summary = [
+    'total' => 0,
+    'status' => [
+        'Pending' => 0,
+        'In Progress' => 0,
+        'Completed' => 0,
+    ],
+    'by_department' => [],
+];
+$upcomingAlerts = [
+    'overdue' => [],
+    'upcoming' => [],
+];
+
+if ($currentUser !== null) {
+    $departments = fetchDepartments($pdo);
+    $tasks = fetchTasks($pdo);
+    $summary = buildSummary($tasks, $departments);
+    $upcomingAlerts = findUpcomingAlerts($tasks);
+}
+
+$flashMessages = consumeFlashMessages();
+
+function initializeDatabase(PDO $pdo): void
+{
+    $pdo->exec('PRAGMA foreign_keys = ON');
+    $schema = file_get_contents(__DIR__ . '/database/schema.sql');
+    if ($schema === false) {
+        throw new RuntimeException('Unable to read schema.sql file.');
+    }
+    $pdo->exec($schema);
+
+    $departments = [
+        'Office of the Secretary',
+        'General Directorate of Information Technology',
+        'Cybersecurity Department',
+        'Investment Agency',
+        'General Directorate of Gardens and Beautification',
+        'General Directorate of Internal Auditing',
+        'General Directorate of Operations and Emergencies',
+        'Security and Safety Department',
+        'Central Unit for Plan Approval',
+        'Land Department',
+        'Environmental Health Department',
+        'General Directorate of Cleanliness',
+        'Downtown Municipality',
+        'North Municipality',
+    ];
+
+    $stmt = $pdo->prepare('INSERT OR IGNORE INTO departments (name) VALUES (:name)');
+    foreach ($departments as $name) {
+        $stmt->execute([':name' => $name]);
+    }
+}
+
+function ensureSchema(PDO $pdo): void
+{
+    $pdo->exec('PRAGMA foreign_keys = ON');
+    $schema = file_get_contents(__DIR__ . '/database/schema.sql');
+    if ($schema === false) {
+        throw new RuntimeException('Unable to read schema.sql file.');
+    }
+    $pdo->exec($schema);
+}
+
+function handlePostRequests(PDO $pdo): void
+{
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        return;
+    }
+
+    $action = $_POST['action'] ?? '';
+    $anchor = '';
+
+    switch ($action) {
+        case 'register':
+            $anchor = '#register';
+            $name = trim($_POST['name'] ?? '');
+            $emailInput = trim($_POST['email'] ?? '');
+            $email = filter_var($emailInput, FILTER_VALIDATE_EMAIL);
+            $password = $_POST['password'] ?? '';
+            $confirmPassword = $_POST['confirm_password'] ?? '';
+
+            if ($name === '' || $email === false) {
+                addFlashMessage('error', 'Please provide your name and a valid email address.');
+                break;
+            }
+
+            if (strlen($password) < 8) {
+                addFlashMessage('error', 'Password must be at least 8 characters long.');
+                break;
+            }
+
+            if ($password !== $confirmPassword) {
+                addFlashMessage('error', 'Passwords do not match.');
+                break;
+            }
+
+            $normalizedEmail = strtolower((string)$email);
+
+            try {
+                $stmt = $pdo->prepare('INSERT INTO users (name, email, password_hash) VALUES (:name, :email, :password_hash)');
+                $stmt->execute([
+                    ':name' => $name,
+                    ':email' => $normalizedEmail,
+                    ':password_hash' => password_hash($password, PASSWORD_DEFAULT),
+                ]);
+                addFlashMessage('success', 'Account created successfully. You can now sign in.');
+                $anchor = '#login';
+            } catch (PDOException $exception) {
+                if ($exception->getCode() === '23000') {
+                    addFlashMessage('error', 'An account with this email already exists.');
+                } else {
+                    addFlashMessage('error', 'Unable to create account at the moment. Please try again.');
+                }
+            }
+            break;
+
+        case 'login':
+            $anchor = '#login';
+            $emailInput = trim($_POST['email'] ?? '');
+            $email = filter_var($emailInput, FILTER_VALIDATE_EMAIL);
+            $password = $_POST['password'] ?? '';
+
+            if ($email === false || $password === '') {
+                addFlashMessage('error', 'Enter both email and password to sign in.');
+                break;
+            }
+
+            $normalizedEmail = strtolower((string)$email);
+            $stmt = $pdo->prepare('SELECT id, name, password_hash FROM users WHERE email = :email');
+            $stmt->execute([':email' => $normalizedEmail]);
+            $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+            if ($user && password_verify($password, $user['password_hash'])) {
+                session_regenerate_id(true);
+                $_SESSION['user_id'] = (int)$user['id'];
+                addFlashMessage('success', 'Welcome back, ' . $user['name'] . '!');
+                $anchor = '';
+            } else {
+                addFlashMessage('error', 'Incorrect email or password.');
+            }
+            break;
+
+        case 'logout':
+            $_SESSION = [];
+            session_regenerate_id(true);
+            addFlashMessage('success', 'You have been signed out.');
+            break;
+
+        case 'create_task':
+            $anchor = '#create-task';
+            if (!isAuthenticated()) {
+                addFlashMessage('error', 'Please sign in to manage tasks.');
+                break;
+            }
+
+            $title = trim($_POST['title'] ?? '');
+            $description = trim($_POST['description'] ?? '');
+            $departmentId = (int)($_POST['department_id'] ?? 0);
+            $assignee = trim($_POST['assignee'] ?? '');
+            $dueDate = $_POST['due_date'] ?? '';
+            $status = $_POST['status'] ?? 'Pending';
+            $priority = $_POST['priority'] ?? 'Normal';
+
+            if ($title === '' || $departmentId <= 0 || !isValidDate($dueDate)) {
+                addFlashMessage('error', 'Task title, department, and due date are required.');
+                break;
+            }
+
+            try {
+                $stmt = $pdo->prepare('INSERT INTO tasks (title, description, department_id, assignee, due_date, status, priority) VALUES (:title, :description, :department_id, :assignee, :due_date, :status, :priority)');
+                $stmt->execute([
+                    ':title' => $title,
+                    ':description' => $description,
+                    ':department_id' => $departmentId,
+                    ':assignee' => $assignee,
+                    ':due_date' => $dueDate,
+                    ':status' => $status,
+                    ':priority' => $priority,
+                ]);
+                addFlashMessage('success', 'Task created successfully.');
+            } catch (PDOException $exception) {
+                addFlashMessage('error', 'Unable to create task right now. Please try again.');
+            }
+            break;
+
+        case 'update_task_status':
+            $anchor = '#task-list';
+            if (!isAuthenticated()) {
+                addFlashMessage('error', 'Please sign in to manage tasks.');
+                break;
+            }
+
+            $taskId = (int)($_POST['task_id'] ?? 0);
+            $status = $_POST['status'] ?? 'Pending';
+            $allowedStatuses = ['Pending', 'In Progress', 'Completed'];
+
+            if ($taskId > 0 && in_array($status, $allowedStatuses, true)) {
+                $stmt = $pdo->prepare('UPDATE tasks SET status = :status WHERE id = :id');
+                $stmt->execute([
+                    ':status' => $status,
+                    ':id' => $taskId,
+                ]);
+                addFlashMessage('success', 'Task status updated.');
+            }
+            break;
+
+        case 'delete_task':
+            $anchor = '#task-list';
+            if (!isAuthenticated()) {
+                addFlashMessage('error', 'Please sign in to manage tasks.');
+                break;
+            }
+
+            $taskId = (int)($_POST['task_id'] ?? 0);
+            if ($taskId > 0) {
+                $stmt = $pdo->prepare('DELETE FROM tasks WHERE id = :id');
+                $stmt->execute([':id' => $taskId]);
+                addFlashMessage('success', 'Task deleted.');
+            }
+            break;
+
+        default:
+            break;
+    }
+
+    redirectToSelf($anchor);
+}
+
+function addFlashMessage(string $type, string $message): void
+{
+    $_SESSION['flash_messages'] ??= [];
+    $_SESSION['flash_messages'][] = [
+        'type' => $type,
+        'message' => $message,
+    ];
+}
+
+function consumeFlashMessages(): array
+{
+    $messages = $_SESSION['flash_messages'] ?? [];
+    unset($_SESSION['flash_messages']);
+
+    return $messages;
+}
+
+function redirectToSelf(string $anchor = ''): void
+{
+    $uri = $_SERVER['REQUEST_URI'] ?? ($_SERVER['PHP_SELF'] ?? '/');
+    $uri = strtok($uri, '#');
+    $location = $uri . $anchor;
+    header('Location: ' . $location);
+    exit;
+}
+
+function isAuthenticated(): bool
+{
+    return isset($_SESSION['user_id']) && (int)$_SESSION['user_id'] > 0;
+}
+
+function getAuthenticatedUser(PDO $pdo): ?array
+{
+    if (!isAuthenticated()) {
+        return null;
+    }
+
+    $userId = (int)$_SESSION['user_id'];
+    $stmt = $pdo->prepare('SELECT id, name, email FROM users WHERE id = :id');
+    $stmt->execute([':id' => $userId]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($user === false) {
+        unset($_SESSION['user_id']);
+        return null;
+    }
+
+    return $user;
+}
+
+function fetchDepartments(PDO $pdo): array
+{
+    $stmt = $pdo->query('SELECT id, name FROM departments ORDER BY name');
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function fetchTasks(PDO $pdo): array
+{
+    $sql = 'SELECT t.*, d.name AS department_name FROM tasks t JOIN departments d ON d.id = t.department_id ORDER BY due_date ASC, priority DESC';
+    $stmt = $pdo->query($sql);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function buildSummary(array $tasks, array $departments): array
+{
+    $summary = [
+        'total' => count($tasks),
+        'status' => [
+            'Pending' => 0,
+            'In Progress' => 0,
+            'Completed' => 0,
+        ],
+        'by_department' => [],
+    ];
+
+    foreach ($departments as $department) {
+        $summary['by_department'][$department['id']] = [
+            'name' => $department['name'],
+            'count' => 0,
+        ];
+    }
+
+    foreach ($tasks as $task) {
+        if (isset($summary['status'][$task['status']])) {
+            $summary['status'][$task['status']]++;
+        }
+        if (isset($summary['by_department'][$task['department_id']])) {
+            $summary['by_department'][$task['department_id']]['count']++;
+        }
+    }
+
+    uasort($summary['by_department'], static function (array $a, array $b): int {
+        $comparison = $b['count'] <=> $a['count'];
+        if ($comparison !== 0) {
+            return $comparison;
+        }
+
+        return strcmp($a['name'], $b['name']);
+    });
+
+    return $summary;
+}
+
+function findUpcomingAlerts(array $tasks): array
+{
+    $alerts = [
+        'overdue' => [],
+        'upcoming' => [],
+    ];
+
+    $today = new DateTimeImmutable('today');
+    $upcomingThreshold = $today->modify('+3 days');
+
+    foreach ($tasks as $task) {
+        if ($task['status'] === 'Completed') {
+            continue;
+        }
+
+        $dueDate = DateTimeImmutable::createFromFormat('Y-m-d', $task['due_date']);
+        if (!$dueDate) {
+            continue;
+        }
+
+        if ($dueDate < $today) {
+            $alerts['overdue'][] = $task;
+        } elseif ($dueDate <= $upcomingThreshold) {
+            $alerts['upcoming'][] = $task;
+        }
+    }
+
+    return $alerts;
+}
+
+function isValidDate(string $date): bool
+{
+    $dateTime = DateTimeImmutable::createFromFormat('Y-m-d', $date);
+    return $dateTime instanceof DateTimeImmutable && $dateTime->format('Y-m-d') === $date;
+}
+
+function getStatusLabel(string $status): string
+{
+    return [
+        'Pending' => 'Pending',
+        'In Progress' => 'In Progress',
+        'Completed' => 'Completed',
+    ][$status] ?? $status;
+}
+
+function getPriorityLabel(string $priority): string
+{
+    return [
+        'High' => 'High',
+        'Normal' => 'Normal',
+        'Low' => 'Low',
+    ][$priority] ?? $priority;
+}
+
+function escape(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Department Task Management</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+    <header class="app-header">
+        <div class="header-content">
+            <div class="header-bar">
+                <p class="eyebrow">Operations Control Center</p>
+                <div class="header-actions">
+                    <?php if ($currentUser !== null): ?>
+                        <span class="user-chip">Signed in as <?php echo escape($currentUser['name']); ?></span>
+                        <form method="post" class="logout-form">
+                            <input type="hidden" name="action" value="logout">
+                            <button type="submit" class="ghost-btn">Sign out</button>
+                        </form>
+                    <?php else: ?>
+                        <a href="#register" class="ghost-btn">Create account</a>
+                    <?php endif; ?>
+                </div>
+            </div>
+            <h1>Department Task Management</h1>
+            <p>Assign, track, and deliver tasks across divisions with clear ownership and deadlines.</p>
+        </div>
+    </header>
+
+    <?php if (!empty($flashMessages)): ?>
+        <div class="flash-container">
+            <?php foreach ($flashMessages as $flash): ?>
+                <div class="flash-message flash-<?php echo escape($flash['type']); ?>"><?php echo escape($flash['message']); ?></div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($currentUser === null): ?>
+        <main class="auth-layout">
+            <section class="card auth-card" id="login">
+                <h2>Sign In</h2>
+                <p class="card-subtitle auth-subtitle">Access the task command center with your credentials.</p>
+                <form method="post" class="auth-form">
+                    <input type="hidden" name="action" value="login">
+                    <label>
+                        Email Address
+                        <input type="email" name="email" required placeholder="you@example.com" autocomplete="email">
+                    </label>
+                    <label>
+                        Password
+                        <input type="password" name="password" required placeholder="Enter your password" autocomplete="current-password">
+                    </label>
+                    <button type="submit" class="primary-btn">Sign In</button>
+                </form>
+            </section>
+            <section class="card auth-card" id="register">
+                <h2>Create Account</h2>
+                <p class="card-subtitle auth-subtitle">Invite team members to coordinate cross-departmental tasks.</p>
+                <form method="post" class="auth-form">
+                    <input type="hidden" name="action" value="register">
+                    <label>
+                        Full Name
+                        <input type="text" name="name" required placeholder="e.g., Sara Alotaibi" autocomplete="name">
+                    </label>
+                    <label>
+                        Work Email
+                        <input type="email" name="email" required placeholder="name@municipality.gov" autocomplete="email">
+                    </label>
+                    <label>
+                        Password
+                        <input type="password" name="password" required placeholder="Minimum 8 characters" autocomplete="new-password">
+                    </label>
+                    <label>
+                        Confirm Password
+                        <input type="password" name="confirm_password" required placeholder="Re-enter your password" autocomplete="new-password">
+                    </label>
+                    <button type="submit" class="primary-btn">Register</button>
+                </form>
+            </section>
+        </main>
+    <?php else: ?>
+        <main class="layout">
+            <section class="panel">
+                <h2>Quick Stats</h2>
+                <div class="stats-grid">
+                    <article class="stat-card">
+                        <h3>Total Tasks</h3>
+                        <p class="stat-number"><?php echo $summary['total']; ?></p>
+                    </article>
+                    <?php foreach ($summary['status'] as $status => $count): ?>
+                        <article class="stat-card">
+                            <h3><?php echo escape(getStatusLabel($status)); ?></h3>
+                            <p class="stat-number"><?php echo $count; ?></p>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+
+                <h2>Deadline Alerts</h2>
+                <p class="card-subtitle">Stay ahead of key deliveries.</p>
+                <div class="alerts">
+                    <div class="alert-group overdue">
+                        <h3>Overdue</h3>
+                        <?php if (empty($upcomingAlerts['overdue'])): ?>
+                            <p>No overdue tasks.</p>
+                        <?php else: ?>
+                            <ul>
+                                <?php foreach ($upcomingAlerts['overdue'] as $task): ?>
+                                    <li>
+                                        <strong><?php echo escape($task['title']); ?></strong>
+                                        <span> · <?php echo escape($task['department_name']); ?></span>
+                                        <time>Due: <?php echo escape($task['due_date']); ?></time>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </div>
+                    <div class="alert-group upcoming">
+                        <h3>Upcoming</h3>
+                        <?php if (empty($upcomingAlerts['upcoming'])): ?>
+                            <p>No upcoming deadlines within three days.</p>
+                        <?php else: ?>
+                            <ul>
+                                <?php foreach ($upcomingAlerts['upcoming'] as $task): ?>
+                                    <li>
+                                        <strong><?php echo escape($task['title']); ?></strong>
+                                        <span> · <?php echo escape($task['department_name']); ?></span>
+                                        <time>Due: <?php echo escape($task['due_date']); ?></time>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </section>
+
+            <section class="content">
+                <section class="card" id="create-task">
+                    <h2>Create New Task</h2>
+                    <form method="post" class="task-form">
+                        <input type="hidden" name="action" value="create_task">
+                        <div class="form-grid">
+                            <label>
+                                Task Title
+                                <input type="text" name="title" required placeholder="e.g., Finalize budget proposal">
+                            </label>
+                            <label>
+                                Assignee
+                                <input type="text" name="assignee" placeholder="Person responsible">
+                            </label>
+                            <label>
+                                Department
+                                <select name="department_id" required>
+                                    <option value="" disabled selected>Select department</option>
+                                    <?php foreach ($departments as $department): ?>
+                                        <option value="<?php echo $department['id']; ?>"><?php echo escape($department['name']); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </label>
+                            <label>
+                                Priority
+                                <select name="priority">
+                                    <option value="High">High</option>
+                                    <option value="Normal" selected>Normal</option>
+                                    <option value="Low">Low</option>
+                                </select>
+                            </label>
+                            <label>
+                                Due Date
+                                <input type="date" name="due_date" required>
+                            </label>
+                            <label>
+                                Status
+                                <select name="status">
+                                    <option value="Pending">Pending</option>
+                                    <option value="In Progress">In Progress</option>
+                                    <option value="Completed">Completed</option>
+                                </select>
+                            </label>
+                        </div>
+                        <label>
+                            Task Details
+                            <textarea name="description" rows="4" placeholder="Add a short task summary"></textarea>
+                        </label>
+                        <button type="submit" class="primary-btn">Save Task</button>
+                    </form>
+                </section>
+
+                <section class="card" id="task-list">
+                    <header class="card-header">
+                        <div>
+                            <h2>Task List</h2>
+                            <p>Use the filters to segment assignments by department, status, or priority.</p>
+                        </div>
+                        <div class="filters">
+                            <label>
+                                Search
+                                <input type="search" id="search" placeholder="Search by task or owner">
+                            </label>
+                            <label>
+                                Department
+                                <select id="filter-department">
+                                    <option value="all">All</option>
+                                    <?php foreach ($departments as $department): ?>
+                                        <option value="<?php echo $department['id']; ?>"><?php echo escape($department['name']); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </label>
+                            <label>
+                                Status
+                                <select id="filter-status">
+                                    <option value="all">All</option>
+                                    <option value="Pending">Pending</option>
+                                    <option value="In Progress">In Progress</option>
+                                    <option value="Completed">Completed</option>
+                                </select>
+                            </label>
+                            <label>
+                                Priority
+                                <select id="filter-priority">
+                                    <option value="all">All</option>
+                                    <option value="High">High</option>
+                                    <option value="Normal">Normal</option>
+                                    <option value="Low">Low</option>
+                                </select>
+                            </label>
+                        </div>
+                    </header>
+
+                    <div class="table-wrapper">
+                        <table id="tasks-table">
+                            <thead>
+                                <tr>
+                                    <th>Task</th>
+                                    <th>Department</th>
+                                    <th>Assignee</th>
+                                    <th>Priority</th>
+                                    <th>Status</th>
+                                    <th>Due Date</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php if (empty($tasks)): ?>
+                                    <tr><td colspan="7">No tasks available yet.</td></tr>
+                                <?php endif; ?>
+                                <?php foreach ($tasks as $task): ?>
+                                    <tr data-department="<?php echo $task['department_id']; ?>" data-status="<?php echo escape($task['status']); ?>" data-priority="<?php echo escape($task['priority']); ?>">
+                                        <td>
+                                            <strong><?php echo escape($task['title']); ?></strong>
+                                            <?php if (!empty($task['description'])): ?>
+                                                <p class="description"><?php echo nl2br(escape($task['description'])); ?></p>
+                                            <?php endif; ?>
+                                        </td>
+                                        <td><?php echo escape($task['department_name']); ?></td>
+                                        <td><?php echo escape($task['assignee'] ?: '—'); ?></td>
+                                        <td><span class="tag priority-<?php echo strtolower($task['priority']); ?>"><?php echo escape(getPriorityLabel($task['priority'])); ?></span></td>
+                                        <td><span class="tag status-<?php echo strtolower(str_replace(' ', '-', $task['status'])); ?>"><?php echo escape(getStatusLabel($task['status'])); ?></span></td>
+                                        <td>
+                                            <time datetime="<?php echo escape($task['due_date']); ?>" class="due-date"><?php echo escape($task['due_date']); ?></time>
+                                            <span class="badge due-indicator"></span>
+                                        </td>
+                                        <td class="actions">
+                                            <form method="post" class="inline-form">
+                                                <input type="hidden" name="action" value="update_task_status">
+                                                <input type="hidden" name="task_id" value="<?php echo $task['id']; ?>">
+                                                <select name="status" onchange="this.form.submit()">
+                                                    <option value="Pending" <?php echo $task['status'] === 'Pending' ? 'selected' : ''; ?>>Pending</option>
+                                                    <option value="In Progress" <?php echo $task['status'] === 'In Progress' ? 'selected' : ''; ?>>In Progress</option>
+                                                    <option value="Completed" <?php echo $task['status'] === 'Completed' ? 'selected' : ''; ?>>Completed</option>
+                                                </select>
+                                            </form>
+                                            <form method="post" class="inline-form" onsubmit="return confirm('Are you sure you want to delete this task?');">
+                                                <input type="hidden" name="action" value="delete_task">
+                                                <input type="hidden" name="task_id" value="<?php echo $task['id']; ?>">
+                                                <button type="submit" class="danger-btn">Delete</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+            </section>
+
+            <aside class="side-column">
+                <section class="card department-card" id="department-overview">
+                    <h2>Departments</h2>
+                    <p class="card-subtitle">Task load across teams.</p>
+                    <ul class="department-list">
+                        <?php foreach ($summary['by_department'] as $info): ?>
+                            <li>
+                                <span class="department-name"><?php echo escape($info['name']); ?></span>
+                                <span class="badge"><?php echo $info['count']; ?></span>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </section>
+            </aside>
+        </main>
+    <?php endif; ?>
+
+    <script src="assets/scripts.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add session-backed registration, login, logout, and flash messaging so only authenticated users manage tasks
- redesign the dashboard to show a right-aligned department workload panel and a dedicated authentication landing view
- extend styling and database schema for the new user accounts and refreshed layout components

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ea48b72014832c93530883d016947f