### PR TITLE
Remove financial metrics from PMO dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+database/app.sqlite

--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# Municipal Project Command Center
+
+This PHP application delivers a professional, widescreen command environment for municipal tasking, project portfolio control, and risk monitoring. It now ships as a multi-page experience so each workflow lives on its own screen—perfect for MacBook presentations or MAMP-based demos.
+
+## Application map
+
+| Page | Purpose |
+| --- | --- |
+| `login.php` / `register.php` | Authentication portal for coordinators and department leads. |
+| `dashboard.php` | Executive overview with portfolio metrics, due-date alerts, and recent progress notes. |
+| `projects.php` | Register and review programmes with sponsors, timelines, and completion tracking. |
+| `tasks.php` | Create, filter, update, and retire assignments per department and project. |
+| `departments.php` | Monitor workload distribution, risk exposure, and upcoming deadlines for every directorate. |
+| `updates.php` | Log structured progress reports with risk/blocker commentary and review the latest activity feed. |
+
+Each screen reads and writes to the same SQLite database so data stays in sync as you move between services.
+
+## Key capabilities
+
+- **Authentication:** Built-in registration, login, and logout flows so only authorized coordinators can manage assignments.
+- **Portfolio management:** Register strategic projects/programs with sponsors, timelines, and auto-calculated completion metrics.
+- **Task engine:** Assign work to departments, tag it to projects, track risk, impact, effort, status, priority, and due dates with rich filtering.
+- **Progress logging:** Capture structured progress updates, risks, and blockers while automatically nudging task status as work advances.
+- **Executive insights:** Portfolio snapshot, risk distribution, departmental workload heatmap, and deadline alerts surface the most important signals at a glance.
+
+## Running locally with MAMP (macOS)
+
+1. Clone or copy this repository into your MAMP `htdocs` folder (for example `~/Applications/MAMP/htdocs/tatarwar`).
+2. Launch MAMP and start the Apache and MySQL servers (SQLite is used, so MySQL is optional).
+3. Visit [http://localhost:8888/tatarwar](http://localhost:8888/tatarwar) in your browser. The login screen will appear immediately.
+4. Register your first account, sign in, and navigate between the dedicated pages using the top navigation bar.
+
+> The bundled SQLite database file (`database/app.sqlite`) is created automatically the first time you load any page.
+
+### Alternative: PHP built-in web server
+
+If you prefer the PHP development server:
+
+```bash
+php -S localhost:8000
+```
+
+Then browse to [http://localhost:8000](http://localhost:8000) (the router will send you to the login page or dashboard depending on your session).
+
+## Database layout
+
+The system uses an embedded **SQLite** database. No external server is required—the application creates and migrates the schema for you.
+
+- **Database file:** `database/app.sqlite`
+- **Schema source:** `database/schema.sql`
+- **Core tables:** `departments`, `projects`, `tasks`, `task_updates`, `users`
+
+When you run the dashboard for the first time the file is created automatically inside `database/`. Delete the file at any time to reset the demo data and the app will rebuild it on the next load.
+
+## Inspecting the database on macOS with VS Code
+
+If you are working on a MacBook, the easiest way to browse or edit the bundled SQLite database is directly from Visual Studio Code:
+
+1. Open the project folder in VS Code.
+2. Install the extension **"SQLite" by alexcvzz** (search for "SQLite" in the Extensions sidebar) and reload VS Code if prompted.
+3. After installation, open the command palette (`⇧⌘P`) and run **"SQLite: Open Database"**.
+4. Choose the file `database/app.sqlite`. The extension will add the file to the **SQLite Explorer** view in the Activity Bar (usually a cylinder icon).
+5. Expand the database entry from the SQLite Explorer to browse tables, view rows, or run custom SQL queries.
+
+> 💡 Double-clicking `app.sqlite` in the normal VS Code file explorer will only show a "binary file" warning because SQLite databases are not plain text. Always open the file through the SQLite extension (or the CLI below) to inspect its contents.
+
+### Using the built-in sqlite3 CLI (optional)
+
+macOS ships with the `sqlite3` command-line tool. You can inspect the same file from the terminal:
+
+```bash
+cd /path/to/your/project
+sqlite3 database/app.sqlite
+```
+
+Once inside the prompt you can list the tables with `.tables` or quit with `.exit`. This is handy if you prefer working from the terminal instead of a VS Code extension.

--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -1,0 +1,88 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const searchInput = document.getElementById('search');
+    const departmentFilter = document.getElementById('filter-department');
+    const statusFilter = document.getElementById('filter-status');
+    const priorityFilter = document.getElementById('filter-priority');
+    const projectFilter = document.getElementById('filter-project');
+    const riskFilter = document.getElementById('filter-risk');
+    const rows = Array.from(document.querySelectorAll('#tasks-table tbody tr'));
+
+    const applyFilters = () => {
+        const searchTerm = (searchInput?.value || '').toLowerCase();
+        const department = departmentFilter?.value || 'all';
+        const status = statusFilter?.value || 'all';
+        const priority = priorityFilter?.value || 'all';
+        const project = projectFilter?.value || 'all';
+        const risk = riskFilter?.value || 'all';
+
+        rows.forEach(row => {
+            const title = row.querySelector('td strong')?.textContent.toLowerCase() || '';
+            const assignee = row.querySelector('td:nth-child(4)')?.textContent.toLowerCase() || '';
+            const description = row.querySelector('.description')?.textContent.toLowerCase() || '';
+            const projectName = row.querySelector('td:nth-child(3)')?.textContent.toLowerCase() || '';
+
+            const matchesSearch = !searchTerm || title.includes(searchTerm) || assignee.includes(searchTerm) || description.includes(searchTerm) || projectName.includes(searchTerm);
+            const matchesDepartment = department === 'all' || row.dataset.department === department;
+            const matchesStatus = status === 'all' || row.dataset.status === status;
+            const matchesPriority = priority === 'all' || row.dataset.priority === priority;
+            const matchesProject = project === 'all' || row.dataset.project === project;
+            const matchesRisk = risk === 'all' || row.dataset.risk === risk;
+
+            row.style.display = (matchesSearch && matchesDepartment && matchesStatus && matchesPriority && matchesProject && matchesRisk) ? '' : 'none';
+        });
+    };
+
+    [searchInput, departmentFilter, statusFilter, priorityFilter, projectFilter, riskFilter].forEach(element => {
+        element?.addEventListener('input', applyFilters);
+        element?.addEventListener('change', applyFilters);
+    });
+
+    const dueDates = document.querySelectorAll('.due-date');
+    const today = new Date();
+
+    const formatDays = (value) => {
+        const absolute = Math.abs(value);
+        return `${absolute} day${absolute === 1 ? '' : 's'}`;
+    };
+
+    dueDates.forEach(dueDateElement => {
+        const dueText = dueDateElement.getAttribute('datetime');
+        if (!dueText) {
+            return;
+        }
+
+        const dueDate = new Date(`${dueText}T00:00:00`);
+        const indicator = dueDateElement.nextElementSibling;
+        if (!(indicator instanceof HTMLElement)) {
+            return;
+        }
+
+        const todayMidnight = new Date(today);
+        todayMidnight.setHours(0, 0, 0, 0);
+        const diffTime = dueDate.getTime() - todayMidnight.getTime();
+        const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24));
+
+        indicator.textContent = '';
+        indicator.classList.remove('overdue', 'soon', 'safe');
+
+        if (Number.isNaN(diffDays)) {
+            return;
+        }
+
+        if (diffDays < 0) {
+            indicator.textContent = `Overdue by ${formatDays(diffDays)}`;
+            indicator.classList.add('overdue');
+        } else if (diffDays === 0) {
+            indicator.textContent = 'Due today';
+            indicator.classList.add('soon');
+        } else if (diffDays <= 5) {
+            indicator.textContent = `Due in ${formatDays(diffDays)}`;
+            indicator.classList.add('soon');
+        } else {
+            indicator.textContent = `Due in ${formatDays(diffDays)}`;
+            indicator.classList.add('safe');
+        }
+    });
+
+    applyFilters();
+});

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,985 @@
+:root {
+    --background: #f5f7fb;
+    --surface: #ffffff;
+    --surface-alt: #f0f4ff;
+    --primary: #1b4be3;
+    --primary-dark: #1234c2;
+    --text: #111827;
+    --muted: #6b7280;
+    --border: #e2e8f0;
+    --success: #16a34a;
+    --danger: #dc2626;
+    --warning: #d97706;
+    --shadow: 0 24px 60px -35px rgba(15, 23, 42, 0.35);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.08), transparent 45%),
+                linear-gradient(180deg, #f8fafc 0%, #eef2ff 60%, #e2e8f0 100%);
+    color: var(--text);
+    min-height: 100vh;
+    line-height: 1.6;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.app-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+.site-header {
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(29, 78, 216, 0.9));
+    color: #fff;
+    padding: 1.5rem 0;
+    box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.7);
+}
+
+.header-inner {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 0 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+    flex-wrap: wrap;
+}
+
+.brand-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.brand {
+    font-weight: 700;
+    font-size: 1.25rem;
+    color: #fff;
+}
+
+.brand-subtitle {
+    margin: 0;
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.primary-nav {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.nav-link {
+    color: rgba(255, 255, 255, 0.8);
+    font-weight: 500;
+    padding: 0.4rem 0.8rem;
+    border-radius: 999px;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-link:hover {
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
+}
+
+.nav-link.active {
+    background: #fff;
+    color: var(--primary);
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.user-chip {
+    background: rgba(255, 255, 255, 0.18);
+    padding: 0.4rem 1rem;
+    border-radius: 999px;
+    font-weight: 600;
+}
+
+.primary-btn,
+.ghost-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.65rem 1.4rem;
+    border-radius: 999px;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    text-decoration: none;
+}
+
+.primary-btn {
+    background: var(--primary);
+    color: #fff;
+    box-shadow: 0 14px 30px -20px rgba(29, 78, 216, 0.9);
+}
+
+.primary-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 20px 35px -18px rgba(29, 78, 216, 0.45);
+}
+
+.ghost-btn {
+    background: rgba(255, 255, 255, 0.08);
+    color: inherit;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.ghost-btn:hover {
+    transform: translateY(-1px);
+}
+
+.logout-form {
+    margin: 0;
+}
+
+.page-content {
+    flex: 1;
+    padding-bottom: 3rem;
+}
+
+.page-main {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 2.5rem 2.5rem 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.card {
+    background: var(--surface);
+    border-radius: 20px;
+    padding: 1.75rem;
+    box-shadow: var(--shadow);
+    border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.card-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.card-header h2 {
+    margin: 0;
+    font-size: 1.5rem;
+}
+
+.card-subtitle {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.flash-container {
+    max-width: 1280px;
+    margin: 1.5rem auto 0;
+    padding: 0 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.flash-message {
+    padding: 0.9rem 1.2rem;
+    border-radius: 12px;
+    font-weight: 500;
+}
+
+.flash-success {
+    background: rgba(22, 163, 74, 0.1);
+    color: var(--success);
+    border: 1px solid rgba(22, 163, 74, 0.2);
+}
+
+.flash-error {
+    background: rgba(220, 38, 38, 0.1);
+    color: var(--danger);
+    border: 1px solid rgba(220, 38, 38, 0.2);
+}
+
+.analytics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.metric-card h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--muted);
+}
+
+.metric-value {
+    font-size: 2.4rem;
+    font-weight: 700;
+    margin: 0.4rem 0;
+}
+
+.metric-hint {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.status-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.status-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+}
+
+.status-tile {
+    background: var(--surface-alt);
+    border-radius: 14px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.status-label {
+    font-size: 0.9rem;
+    color: var(--muted);
+}
+
+.status-count {
+    font-size: 1.7rem;
+    font-weight: 700;
+}
+
+.risk-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.risk-row {
+    display: grid;
+    grid-template-columns: 120px 1fr 60px;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.risk-name {
+    font-weight: 600;
+}
+
+.risk-bar {
+    background: var(--surface-alt);
+    border-radius: 999px;
+    overflow: hidden;
+    height: 10px;
+}
+
+.risk-fill {
+    height: 100%;
+    border-radius: 999px;
+}
+
+.risk-low { background: #22c55e; }
+.risk-moderate { background: #f97316; }
+.risk-high { background: #f43f5e; }
+.risk-critical { background: #991b1b; }
+
+.department-load h3 {
+    margin-top: 0;
+}
+
+.department-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.department-item {
+    display: grid;
+    grid-template-columns: minmax(200px, 1fr) 1fr 48px;
+    gap: 1rem;
+    align-items: center;
+}
+
+.department-progress {
+    background: var(--surface-alt);
+    border-radius: 999px;
+    height: 12px;
+    overflow: hidden;
+}
+
+.department-fill {
+    height: 100%;
+    background: var(--primary);
+}
+
+.department-count {
+    font-weight: 600;
+    text-align: right;
+}
+
+.dual-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.5rem;
+}
+
+.alert-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.alert-item {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    background: var(--surface-alt);
+}
+
+.alert-title {
+    margin: 0;
+    font-weight: 600;
+}
+
+.alert-meta {
+    margin: 0.2rem 0 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.alert-chip {
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.alert-chip.overdue { background: rgba(220, 38, 38, 0.15); color: var(--danger); }
+.alert-chip.soon { background: rgba(217, 119, 6, 0.15); color: var(--warning); }
+
+.empty-state {
+    margin: 0;
+    color: var(--muted);
+    font-style: italic;
+}
+
+.updates-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.update-item {
+    padding: 1.25rem;
+    background: var(--surface-alt);
+    border-radius: 16px;
+}
+
+.update-headline {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.update-headline h3 {
+    margin: 0;
+    font-size: 1.15rem;
+}
+
+.update-progress {
+    font-weight: 700;
+    color: var(--primary);
+}
+
+.update-summary {
+    margin: 0.75rem 0 0.5rem;
+}
+
+.update-meta {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.stacked-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem 1.5rem;
+}
+
+label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-weight: 600;
+    color: var(--text);
+    font-size: 0.95rem;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="date"],
+input[type="number"],
+select,
+textarea {
+    font: inherit;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+textarea {
+    resize: vertical;
+}
+
+.filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.filters select,
+.filters input[type="search"] {
+    min-width: 160px;
+}
+
+.table-wrapper {
+    overflow-x: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 960px;
+}
+
+th, td {
+    text-align: left;
+    padding: 0.75rem 0.9rem;
+    border-bottom: 1px solid var(--border);
+}
+
+th {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+}
+
+tr:hover {
+    background: rgba(59, 130, 246, 0.05);
+}
+
+.description {
+    margin: 0.35rem 0 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.due-date {
+    display: block;
+    font-weight: 600;
+}
+
+.due-indicator {
+    display: block;
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.inline-form {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.inline-form select {
+    padding: 0.4rem 0.5rem;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.3rem 0.6rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.8rem;
+}
+
+.priority-critical { background: rgba(220, 38, 38, 0.15); color: var(--danger); }
+.priority-high { background: rgba(249, 115, 22, 0.18); color: var(--warning); }
+.priority-normal { background: rgba(59, 130, 246, 0.18); color: var(--primary); }
+.priority-low { background: rgba(16, 185, 129, 0.18); color: #047857; }
+
+.risk-low { color: #047857; background: rgba(16, 185, 129, 0.15); }
+.risk-moderate { color: #d97706; background: rgba(217, 119, 6, 0.18); }
+.risk-high { color: #dc2626; background: rgba(220, 38, 38, 0.18); }
+.risk-critical { color: #7f1d1d; background: rgba(127, 29, 29, 0.2); }
+
+.project-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.5rem;
+}
+
+.project-card {
+    background: linear-gradient(180deg, #ffffff 0%, #f8faff 100%);
+    border-radius: 18px;
+    padding: 1.5rem;
+    border: 1px solid rgba(15, 23, 42, 0.06);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.project-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.project-meta h3 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.status-pill {
+    padding: 0.35rem 0.8rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+}
+
+.status-active { background: rgba(59, 130, 246, 0.15); color: var(--primary); }
+.status-on-hold { background: rgba(217, 119, 6, 0.15); color: var(--warning); }
+.status-completed { background: rgba(16, 185, 129, 0.18); color: #047857; }
+.status-archived { background: rgba(148, 163, 184, 0.18); color: #475569; }
+
+.project-theme {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.project-description {
+    margin: 0;
+    color: var(--text);
+}
+
+.project-facts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+    margin: 0;
+}
+
+.project-facts div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.project-facts dt {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    color: var(--muted);
+    letter-spacing: 0.08em;
+}
+
+.project-facts dd {
+    margin: 0;
+    font-weight: 600;
+}
+
+.project-progress {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.progress-track {
+    height: 12px;
+    border-radius: 999px;
+    background: var(--surface-alt);
+    overflow: hidden;
+}
+
+.progress-fill {
+    height: 100%;
+    background: var(--primary);
+}
+
+.project-footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    font-size: 0.9rem;
+    color: var(--muted);
+}
+
+.department-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.department-card {
+    background: linear-gradient(180deg, #ffffff 0%, #f1f5ff 100%);
+    border-radius: 18px;
+    padding: 1.4rem;
+    border: 1px solid rgba(15, 23, 42, 0.06);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.department-card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.department-total {
+    font-weight: 700;
+    color: var(--primary);
+}
+
+.department-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem 1rem;
+    margin: 0;
+}
+
+.department-stats div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.department-stats dt {
+    margin: 0;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    color: var(--muted);
+    letter-spacing: 0.06em;
+}
+
+.department-stats dd {
+    margin: 0;
+    font-weight: 600;
+}
+
+.department-risk,
+.department-next {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+}
+
+.summary-tile {
+    background: var(--surface-alt);
+    border-radius: 14px;
+    padding: 1rem 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.summary-label {
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.summary-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+}
+
+.timeline {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.timeline-entry {
+    border-left: 4px solid var(--primary);
+    padding-left: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.timeline-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.timeline-header h3 {
+    margin: 0;
+}
+
+.timeline-progress {
+    font-weight: 700;
+    color: var(--primary);
+}
+
+.timeline-meta {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.timeline-summary {
+    margin: 0;
+}
+
+.timeline-note {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.site-footer {
+    text-align: center;
+    padding: 2rem 1rem;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+code {
+    background: rgba(15, 23, 42, 0.05);
+    padding: 0.2rem 0.4rem;
+    border-radius: 6px;
+    font-family: 'Source Code Pro', monospace;
+}
+
+.auth-shell {
+    min-height: 100vh;
+    display: flex;
+    align-items: stretch;
+    justify-content: center;
+    background: linear-gradient(160deg, #1b4be3 0%, #0f172a 60%);
+    color: #fff;
+    padding: 3rem 1.5rem;
+}
+
+.auth-wrapper {
+    max-width: 1100px;
+    width: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 520px) minmax(0, 440px);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+.auth-panel {
+    background: #fff;
+    color: var(--text);
+    border-radius: 24px;
+    padding: 2.5rem;
+    box-shadow: 0 30px 60px -35px rgba(15, 23, 42, 0.6);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.auth-header h1 {
+    margin: 0.2rem 0 0.6rem;
+    font-size: 2rem;
+}
+
+.auth-lede {
+    margin: 0;
+    color: var(--muted);
+}
+
+.auth-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.auth-switch {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.auth-switch a {
+    color: var(--primary);
+    font-weight: 600;
+}
+
+.auth-aside {
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 24px;
+    padding: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+    color: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(18px);
+}
+
+.auth-aside h2 {
+    margin: 0;
+}
+
+.auth-aside p {
+    margin: 0;
+}
+
+.auth-highlights {
+    list-style: disc;
+    margin: 0;
+    padding-left: 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.eyebrow {
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-weight: 600;
+    font-size: 0.75rem;
+    color: var(--primary);
+    margin: 0;
+}
+
+.auth-panel .eyebrow {
+    color: var(--primary);
+}
+
+@media (max-width: 1024px) {
+    .auth-wrapper {
+        grid-template-columns: 1fr;
+    }
+
+    .auth-aside {
+        order: -1;
+    }
+
+    .header-inner {
+        padding: 0 1.5rem;
+    }
+
+    .page-main {
+        padding: 2rem 1.5rem 0;
+    }
+}
+
+@media (max-width: 768px) {
+    .primary-nav {
+        width: 100%;
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+
+    .header-actions {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .department-item {
+        grid-template-columns: 1fr;
+    }
+
+    table {
+        min-width: 720px;
+    }
+}
+
+@media (max-width: 600px) {
+    .analytics-grid,
+    .dual-grid,
+    .project-grid,
+    .department-grid,
+    .summary-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .auth-shell {
+        padding: 2rem 1rem;
+    }
+
+    .card {
+        padding: 1.25rem;
+    }
+}

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,171 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+if ($currentUser === null) {
+    header('Location: login.php');
+    exit;
+}
+
+$pageTitle = 'Executive Dashboard | Municipal PMO Suite';
+$activeNav = 'dashboard';
+
+$departments = fetchDepartments($pdo);
+$projects = fetchProjects($pdo);
+$tasks = fetchTasks($pdo);
+$summary = buildSummary($tasks, $departments);
+$portfolioSnapshot = buildPortfolioSnapshot($projects, $tasks, $summary);
+$upcomingAlerts = findUpcomingAlerts($tasks);
+$recentUpdates = fetchRecentUpdates($pdo);
+
+require __DIR__ . '/includes/header.php';
+require __DIR__ . '/includes/flash.php';
+?>
+<main class="page-main dashboard-main">
+    <section class="analytics-grid">
+        <article class="card metric-card">
+            <h2>Active programs</h2>
+            <p class="metric-value"><?php echo $portfolioSnapshot['active_projects']; ?></p>
+            <p class="metric-hint">Projects currently running or paused across all agencies.</p>
+        </article>
+        <article class="card metric-card">
+            <h2>Departments engaged</h2>
+            <p class="metric-value"><?php echo $portfolioSnapshot['engaged_departments']; ?></p>
+            <p class="metric-hint">Directorates currently active across all assignments.</p>
+        </article>
+        <article class="card metric-card">
+            <h2>Completion rate</h2>
+            <p class="metric-value"><?php echo $portfolioSnapshot['completion_rate']; ?>%</p>
+            <p class="metric-hint">Share of tasks marked complete vs. overall assignments.</p>
+        </article>
+        <article class="card metric-card">
+            <h2>At-risk tasks</h2>
+            <p class="metric-value"><?php echo $portfolioSnapshot['at_risk_tasks']; ?></p>
+            <p class="metric-hint">Items tagged High or Critical risk needing intervention.</p>
+        </article>
+    </section>
+
+    <section class="card status-card">
+        <header class="card-header">
+            <h2>Status &amp; risk distribution</h2>
+            <p class="card-subtitle">Track execution load across departments.</p>
+        </header>
+        <div class="status-grid">
+            <?php foreach ($summary['status'] as $status => $count): ?>
+                <div class="status-tile">
+                    <span class="status-label"><?php echo escape($status); ?></span>
+                    <span class="status-count"><?php echo $count; ?></span>
+                </div>
+            <?php endforeach; ?>
+        </div>
+        <div class="risk-summary">
+            <?php foreach ($summary['risk'] as $riskLevel => $count): ?>
+                <div class="risk-row">
+                    <span class="risk-name"><?php echo escape($riskLevel); ?></span>
+                    <div class="risk-bar">
+                        <div class="risk-fill <?php echo getRiskClass($riskLevel); ?>" style="width: <?php echo $summary['total'] > 0 ? round(($count / $summary['total']) * 100) : 0; ?>%"></div>
+                    </div>
+                    <span class="risk-count"><?php echo $count; ?></span>
+                </div>
+            <?php endforeach; ?>
+        </div>
+        <div class="department-load">
+            <h3>Department load</h3>
+            <ul class="department-list">
+                <?php foreach ($summary['by_department'] as $departmentSummary): ?>
+                    <li class="department-item">
+                        <span class="department-name"><?php echo escape($departmentSummary['name']); ?></span>
+                        <div class="department-progress">
+                            <?php
+                                $percent = $summary['peak_department_tasks'] > 0
+                                    ? (int) round(($departmentSummary['count'] / $summary['peak_department_tasks']) * 100)
+                                    : 0;
+                            ?>
+                            <div class="department-fill" style="width: <?php echo $percent; ?>%"></div>
+                        </div>
+                        <span class="department-count"><?php echo $departmentSummary['count']; ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    </section>
+
+    <section class="dual-grid">
+        <article class="card alerts-card">
+            <header class="card-header">
+                <h2>Overdue alerts</h2>
+                <p class="card-subtitle">Assignments past deadline</p>
+            </header>
+            <?php if (empty($upcomingAlerts['overdue'])): ?>
+                <p class="empty-state">No overdue tasks. Great job keeping everything on track.</p>
+            <?php else: ?>
+                <ul class="alert-list">
+                    <?php foreach ($upcomingAlerts['overdue'] as $task): ?>
+                        <li class="alert-item">
+                            <div>
+                                <p class="alert-title"><?php echo escape($task['title']); ?></p>
+                                <p class="alert-meta">Department: <?php echo escape($task['department_name']); ?> &middot; <?php echo escape($task['priority']); ?> priority</p>
+                            </div>
+                            <span class="alert-chip overdue"><?php echo escape(describeDueDifference($task['days_diff'])); ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+        </article>
+        <article class="card alerts-card">
+            <header class="card-header">
+                <h2>Due soon</h2>
+                <p class="card-subtitle">Monitor upcoming deadlines</p>
+            </header>
+            <?php if (empty($upcomingAlerts['upcoming'])): ?>
+                <p class="empty-state">No tasks due in the next five days.</p>
+            <?php else: ?>
+                <ul class="alert-list">
+                    <?php foreach ($upcomingAlerts['upcoming'] as $task): ?>
+                        <li class="alert-item">
+                            <div>
+                                <p class="alert-title"><?php echo escape($task['title']); ?></p>
+                                <p class="alert-meta"><?php echo escape($task['department_name']); ?> &middot; Due <?php echo escape(formatDate($task['due_date'])); ?></p>
+                            </div>
+                            <span class="alert-chip soon"><?php echo escape(describeDueDifference($task['days_diff'])); ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+        </article>
+    </section>
+
+    <section class="card updates-card">
+        <header class="card-header">
+            <h2>Latest progress updates</h2>
+            <p class="card-subtitle">Recent field reports from directorates.</p>
+        </header>
+        <?php if (empty($recentUpdates)): ?>
+            <p class="empty-state">No updates logged yet. Visit the Updates workspace to submit a status report.</p>
+        <?php else: ?>
+            <ul class="updates-list">
+                <?php foreach ($recentUpdates as $update): ?>
+                    <li class="update-item">
+                        <div class="update-headline">
+                            <h3><?php echo escape($update['task_title']); ?></h3>
+                            <span class="update-progress"><?php echo (int) $update['progress_percent']; ?>%</span>
+                        </div>
+                        <p class="update-summary"><?php echo escape($update['update_summary']); ?></p>
+                        <p class="update-meta">
+                            <?php echo escape($update['department_name']); ?>
+                            <?php if ($update['project_name']): ?>
+                                &middot; Project: <?php echo escape($update['project_name']); ?>
+                            <?php endif; ?>
+                            <?php if ($update['created_by']): ?>
+                                &middot; Reporter: <?php echo escape($update['created_by']); ?>
+                            <?php endif; ?>
+                            &middot; <?php echo escape(formatDate(substr($update['created_at'], 0, 10))); ?>
+                        </p>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </section>
+</main>
+<?php require __DIR__ . '/includes/footer.php'; ?>

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,66 @@
+CREATE TABLE IF NOT EXISTS departments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS projects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    sponsor TEXT,
+    description TEXT,
+    strategic_theme TEXT,
+    start_date DATE,
+    target_date DATE,
+    status TEXT NOT NULL DEFAULT 'Active',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    description TEXT,
+    department_id INTEGER NOT NULL,
+    project_id INTEGER,
+    assignee TEXT,
+    due_date DATE NOT NULL,
+    status TEXT NOT NULL DEFAULT 'Pending',
+    priority TEXT NOT NULL DEFAULT 'Normal',
+    risk_level TEXT NOT NULL DEFAULT 'Moderate',
+    impact_level TEXT NOT NULL DEFAULT 'Medium',
+    effort_level TEXT NOT NULL DEFAULT 'Medium',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (department_id) REFERENCES departments(id),
+    FOREIGN KEY (project_id) REFERENCES projects(id)
+);
+
+CREATE TRIGGER IF NOT EXISTS update_tasks_timestamp
+AFTER UPDATE ON tasks
+FOR EACH ROW
+BEGIN
+    UPDATE tasks SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+END;
+
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS task_updates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id INTEGER NOT NULL,
+    update_summary TEXT NOT NULL,
+    progress_percent INTEGER NOT NULL DEFAULT 0 CHECK (progress_percent BETWEEN 0 AND 100),
+    risk_note TEXT,
+    blocker_note TEXT,
+    created_by TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_project ON tasks(project_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_due_date ON tasks(due_date);
+CREATE INDEX IF NOT EXISTS idx_task_updates_task ON task_updates(task_id);

--- a/departments.php
+++ b/departments.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+if ($currentUser === null) {
+    header('Location: login.php');
+    exit;
+}
+
+$pageTitle = 'Departments Directory | Municipal PMO Suite';
+$activeNav = 'departments';
+
+$departments = fetchDepartments($pdo);
+$tasks = fetchTasks($pdo);
+$summary = buildSummary($tasks, $departments);
+
+$departmentStats = [];
+foreach ($departments as $department) {
+    $departmentStats[$department['id']] = [
+        'name' => $department['name'],
+        'total' => 0,
+        'status' => array_fill_keys(allowedTaskStatuses(), 0),
+        'high_risk' => 0,
+        'next_due' => null,
+    ];
+}
+
+foreach ($tasks as $task) {
+    $deptId = (int) $task['department_id'];
+    if (!isset($departmentStats[$deptId])) {
+        continue;
+    }
+    $departmentStats[$deptId]['total']++;
+    if (isset($departmentStats[$deptId]['status'][$task['status']])) {
+        $departmentStats[$deptId]['status'][$task['status']]++;
+    }
+    if (in_array($task['risk_level'], ['High', 'Critical'], true)) {
+        $departmentStats[$deptId]['high_risk']++;
+    }
+    $dueDate = DateTimeImmutable::createFromFormat('Y-m-d', $task['due_date']);
+    if ($dueDate instanceof DateTimeImmutable) {
+        if ($departmentStats[$deptId]['next_due'] === null || $dueDate < $departmentStats[$deptId]['next_due']) {
+            $departmentStats[$deptId]['next_due'] = $dueDate;
+        }
+    }
+}
+
+require __DIR__ . '/includes/header.php';
+require __DIR__ . '/includes/flash.php';
+?>
+<main class="page-main departments-main">
+    <section class="card">
+        <header class="card-header">
+            <h2>Directorate overview</h2>
+            <p class="card-subtitle">Monitor task distribution and risk across every municipal office.</p>
+        </header>
+        <div class="department-grid">
+            <?php foreach ($departmentStats as $department): ?>
+                <article class="department-card">
+                    <header>
+                        <h3><?php echo escape($department['name']); ?></h3>
+                        <span class="department-total"><?php echo $department['total']; ?> tasks</span>
+                    </header>
+                    <dl class="department-stats">
+                        <?php foreach ($department['status'] as $status => $count): ?>
+                            <div>
+                                <dt><?php echo escape($status); ?></dt>
+                                <dd><?php echo $count; ?></dd>
+                            </div>
+                        <?php endforeach; ?>
+                    </dl>
+                    <p class="department-risk">
+                        High risk tasks: <strong><?php echo $department['high_risk']; ?></strong>
+                    </p>
+                    <p class="department-next">
+                        Next due: <strong><?php echo $department['next_due'] ? escape($department['next_due']->format('d M Y')) : 'No upcoming due dates'; ?></strong>
+                    </p>
+                </article>
+            <?php endforeach; ?>
+        </div>
+    </section>
+
+    <section class="card">
+        <header class="card-header">
+            <h2>Summary snapshot</h2>
+            <p class="card-subtitle">Aggregate counts from all departments.</p>
+        </header>
+        <div class="summary-grid">
+            <div class="summary-tile">
+                <span class="summary-label">Total tasks</span>
+                <span class="summary-value"><?php echo $summary['total']; ?></span>
+            </div>
+            <?php foreach ($summary['status'] as $status => $count): ?>
+                <div class="summary-tile">
+                    <span class="summary-label"><?php echo escape($status); ?></span>
+                    <span class="summary-value"><?php echo $count; ?></span>
+                </div>
+            <?php endforeach; ?>
+            <?php foreach ($summary['risk'] as $risk => $count): ?>
+                <div class="summary-tile">
+                    <span class="summary-label"><?php echo escape($risk); ?> risk</span>
+                    <span class="summary-value"><?php echo $count; ?></span>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    </section>
+</main>
+<?php require __DIR__ . '/includes/footer.php'; ?>

--- a/includes/app.php
+++ b/includes/app.php
@@ -1,0 +1,837 @@
+<?php
+declare(strict_types=1);
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+function getDatabaseConnection(): PDO
+{
+    static $pdo = null;
+
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+
+    $dbPath = __DIR__ . '/../database/app.sqlite';
+    $initialize = !file_exists($dbPath);
+
+    $pdo = new PDO('sqlite:' . $dbPath);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    if ($initialize) {
+        initializeDatabase($pdo);
+    } else {
+        ensureSchema($pdo);
+    }
+
+    return $pdo;
+}
+
+function initializeDatabase(PDO $pdo): void
+{
+    $pdo->exec('PRAGMA foreign_keys = ON');
+    $schema = file_get_contents(__DIR__ . '/../database/schema.sql');
+    if ($schema === false) {
+        throw new RuntimeException('Unable to read schema.sql file.');
+    }
+    $pdo->exec($schema);
+
+    $departments = [
+        'Office of the Secretary',
+        'General Directorate of Information Technology',
+        'Cybersecurity Department',
+        'Investment Agency',
+        'General Directorate of Gardens and Beautification',
+        'General Directorate of Internal Auditing',
+        'General Directorate of Operations and Emergencies',
+        'Security and Safety Department',
+        'Central Unit for Plan Approval',
+        'Land Department',
+        'Environmental Health Department',
+        'General Directorate of Cleanliness',
+        'Downtown Municipality',
+        'North Municipality',
+    ];
+
+    $stmt = $pdo->prepare('INSERT OR IGNORE INTO departments (name) VALUES (:name)');
+    foreach ($departments as $name) {
+        $stmt->execute([':name' => $name]);
+    }
+
+    $projects = [
+        [
+            'name' => 'Smart City Command Platform',
+            'sponsor' => 'Office of the Secretary',
+            'description' => 'Unifies cross-department reporting and situational awareness across the municipality.',
+            'strategic_theme' => 'Digital Transformation',
+            'start_date' => '2024-01-15',
+            'target_date' => '2024-12-20',
+            'status' => 'Active',
+        ],
+        [
+            'name' => 'Clean & Green 2030',
+            'sponsor' => 'General Directorate of Cleanliness',
+            'description' => 'City-wide waste reduction and beautification program with measurable impact goals.',
+            'strategic_theme' => 'Sustainability',
+            'start_date' => '2023-11-01',
+            'target_date' => '2025-03-30',
+            'status' => 'Active',
+        ],
+        [
+            'name' => 'Emergency Response Modernization',
+            'sponsor' => 'General Directorate of Operations and Emergencies',
+            'description' => 'Upgrade dispatch technology and joint response playbooks for critical incidents.',
+            'strategic_theme' => 'Public Safety',
+            'start_date' => '2024-02-05',
+            'target_date' => '2024-10-15',
+            'status' => 'On Hold',
+        ],
+    ];
+
+    $projectStmt = $pdo->prepare('INSERT OR IGNORE INTO projects (name, sponsor, description, strategic_theme, start_date, target_date, status) VALUES (:name, :sponsor, :description, :strategic_theme, :start_date, :target_date, :status)');
+    foreach ($projects as $project) {
+        $projectStmt->execute([
+            ':name' => $project['name'],
+            ':sponsor' => $project['sponsor'],
+            ':description' => $project['description'],
+            ':strategic_theme' => $project['strategic_theme'],
+            ':start_date' => $project['start_date'],
+            ':target_date' => $project['target_date'],
+            ':status' => $project['status'],
+        ]);
+    }
+}
+
+function ensureSchema(PDO $pdo): void
+{
+    $pdo->exec('PRAGMA foreign_keys = ON');
+    $schema = file_get_contents(__DIR__ . '/../database/schema.sql');
+    if ($schema === false) {
+        throw new RuntimeException('Unable to read schema.sql file.');
+    }
+    $pdo->exec($schema);
+
+    ensureColumn($pdo, 'tasks', 'project_id', 'INTEGER');
+    ensureColumn($pdo, 'tasks', 'risk_level', "TEXT NOT NULL DEFAULT 'Moderate'");
+    ensureColumn($pdo, 'tasks', 'impact_level', "TEXT NOT NULL DEFAULT 'Medium'");
+    ensureColumn($pdo, 'tasks', 'effort_level', "TEXT NOT NULL DEFAULT 'Medium'");
+}
+
+function ensureColumn(PDO $pdo, string $table, string $column, string $definition): void
+{
+    $stmt = $pdo->query('PRAGMA table_info(' . $table . ')');
+    $columns = $stmt->fetchAll(PDO::FETCH_COLUMN, 1);
+    if (!in_array($column, $columns, true)) {
+        $pdo->exec('ALTER TABLE ' . $table . ' ADD COLUMN ' . $column . ' ' . $definition);
+    }
+}
+
+function handlePostRequests(PDO $pdo): void
+{
+    if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+        return;
+    }
+
+    $action = $_POST['action'] ?? '';
+    $anchor = '';
+    $redirectTarget = trim((string) ($_POST['redirect'] ?? ''));
+
+    switch ($action) {
+        case 'register':
+            if ($redirectTarget === '') {
+                $redirectTarget = 'register.php';
+            }
+            $anchor = '';
+            
+            $name = trim($_POST['name'] ?? '');
+            $emailInput = trim($_POST['email'] ?? '');
+            $email = filter_var($emailInput, FILTER_VALIDATE_EMAIL);
+            $password = $_POST['password'] ?? '';
+            $confirmPassword = $_POST['confirm_password'] ?? '';
+
+            if ($name === '' || $email === false) {
+                addFlashMessage('error', 'Please provide your name and a valid email address.');
+                break;
+            }
+
+            if (strlen($password) < 8) {
+                addFlashMessage('error', 'Password must be at least 8 characters long.');
+                break;
+            }
+
+            if ($password !== $confirmPassword) {
+                addFlashMessage('error', 'Passwords do not match.');
+                break;
+            }
+
+            $normalizedEmail = strtolower((string) $email);
+
+            try {
+                $stmt = $pdo->prepare('INSERT INTO users (name, email, password_hash) VALUES (:name, :email, :password_hash)');
+                $stmt->execute([
+                    ':name' => $name,
+                    ':email' => $normalizedEmail,
+                    ':password_hash' => password_hash($password, PASSWORD_DEFAULT),
+                ]);
+                addFlashMessage('success', 'Account created successfully. You can now sign in.');
+                $redirectTarget = 'login.php';
+                $anchor = '';
+            } catch (PDOException $exception) {
+                if ($exception->getCode() === '23000') {
+                    addFlashMessage('error', 'An account with this email already exists.');
+                } else {
+                    addFlashMessage('error', 'Unable to create account at the moment. Please try again.');
+                }
+            }
+            break;
+
+        case 'login':
+            if ($redirectTarget === '') {
+                $redirectTarget = 'login.php';
+            }
+            $anchor = '';
+            $emailInput = trim($_POST['email'] ?? '');
+            $email = filter_var($emailInput, FILTER_VALIDATE_EMAIL);
+            $password = $_POST['password'] ?? '';
+
+            if ($email === false || $password === '') {
+                addFlashMessage('error', 'Enter both email and password to sign in.');
+                break;
+            }
+
+            $normalizedEmail = strtolower((string) $email);
+            $stmt = $pdo->prepare('SELECT id, name, password_hash FROM users WHERE email = :email');
+            $stmt->execute([':email' => $normalizedEmail]);
+            $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+            if ($user && password_verify($password, $user['password_hash'])) {
+                session_regenerate_id(true);
+                $_SESSION['user_id'] = (int) $user['id'];
+                addFlashMessage('success', 'Welcome back, ' . $user['name'] . '!');
+                $redirectTarget = 'dashboard.php';
+                $anchor = '';
+            } else {
+                addFlashMessage('error', 'Incorrect email or password.');
+            }
+            break;
+
+        case 'logout':
+            $_SESSION = [];
+            session_regenerate_id(true);
+            addFlashMessage('success', 'You have been signed out.');
+            $redirectTarget = 'login.php';
+            break;
+
+        case 'create_task':
+            if ($redirectTarget === '') {
+                $redirectTarget = 'tasks.php';
+            }
+            $anchor = '#task-form';
+            if (!isAuthenticated()) {
+                addFlashMessage('error', 'Please sign in to manage tasks.');
+                break;
+            }
+
+            $title = trim($_POST['title'] ?? '');
+            $description = trim($_POST['description'] ?? '');
+            $departmentId = (int) ($_POST['department_id'] ?? 0);
+            $projectId = (int) ($_POST['project_id'] ?? 0);
+            $assignee = trim($_POST['assignee'] ?? '');
+            $dueDate = $_POST['due_date'] ?? '';
+            $status = $_POST['status'] ?? 'Pending';
+            $priority = $_POST['priority'] ?? 'Normal';
+            $riskLevel = $_POST['risk_level'] ?? 'Moderate';
+            $impactLevel = $_POST['impact_level'] ?? 'Medium';
+            $effortLevel = $_POST['effort_level'] ?? 'Medium';
+
+            if ($title === '' || $departmentId <= 0 || !isValidDate($dueDate)) {
+                addFlashMessage('error', 'Task title, department, and due date are required.');
+                break;
+            }
+
+            if (!in_array($status, allowedTaskStatuses(), true)) {
+                addFlashMessage('error', 'Invalid task status provided.');
+                break;
+            }
+
+            if (!in_array($priority, allowedPriorities(), true)) {
+                addFlashMessage('error', 'Invalid priority selection.');
+                break;
+            }
+
+            if (!in_array($riskLevel, allowedRiskLevels(), true) || !in_array($impactLevel, allowedImpactLevels(), true) || !in_array($effortLevel, allowedEffortLevels(), true)) {
+                addFlashMessage('error', 'Invalid risk, impact, or effort level.');
+                break;
+            }
+
+            $projectValue = $projectId > 0 ? $projectId : null;
+
+            try {
+                $stmt = $pdo->prepare('INSERT INTO tasks (title, description, department_id, project_id, assignee, due_date, status, priority, risk_level, impact_level, effort_level) VALUES (:title, :description, :department_id, :project_id, :assignee, :due_date, :status, :priority, :risk_level, :impact_level, :effort_level)');
+                $stmt->execute([
+                    ':title' => $title,
+                    ':description' => $description,
+                    ':department_id' => $departmentId,
+                    ':project_id' => $projectValue,
+                    ':assignee' => $assignee,
+                    ':due_date' => $dueDate,
+                    ':status' => $status,
+                    ':priority' => $priority,
+                    ':risk_level' => $riskLevel,
+                    ':impact_level' => $impactLevel,
+                    ':effort_level' => $effortLevel,
+                ]);
+                addFlashMessage('success', 'Task created successfully.');
+            } catch (PDOException $exception) {
+                addFlashMessage('error', 'Unable to create task right now. Please try again.');
+            }
+            break;
+
+        case 'update_task_status':
+            if ($redirectTarget === '') {
+                $redirectTarget = 'tasks.php';
+            }
+            $anchor = '#task-list';
+            if (!isAuthenticated()) {
+                addFlashMessage('error', 'Please sign in to manage tasks.');
+                break;
+            }
+
+            $taskId = (int) ($_POST['task_id'] ?? 0);
+            $status = $_POST['status'] ?? 'Pending';
+            if ($taskId > 0 && in_array($status, allowedTaskStatuses(), true)) {
+                $stmt = $pdo->prepare('UPDATE tasks SET status = :status WHERE id = :id');
+                $stmt->execute([
+                    ':status' => $status,
+                    ':id' => $taskId,
+                ]);
+                addFlashMessage('success', 'Task status updated.');
+            }
+            break;
+
+        case 'delete_task':
+            if ($redirectTarget === '') {
+                $redirectTarget = 'tasks.php';
+            }
+            $anchor = '#task-list';
+            if (!isAuthenticated()) {
+                addFlashMessage('error', 'Please sign in to manage tasks.');
+                break;
+            }
+
+            $taskId = (int) ($_POST['task_id'] ?? 0);
+            if ($taskId > 0) {
+                $stmt = $pdo->prepare('DELETE FROM tasks WHERE id = :id');
+                $stmt->execute([':id' => $taskId]);
+                addFlashMessage('success', 'Task deleted.');
+            }
+            break;
+
+        case 'create_project':
+            if ($redirectTarget === '') {
+                $redirectTarget = 'projects.php';
+            }
+            $anchor = '#project-form';
+            if (!isAuthenticated()) {
+                addFlashMessage('error', 'Please sign in to manage projects.');
+                break;
+            }
+
+            $name = trim($_POST['name'] ?? '');
+            $strategicTheme = trim($_POST['strategic_theme'] ?? '');
+            $sponsor = trim($_POST['sponsor'] ?? '');
+            $description = trim($_POST['description'] ?? '');
+            $startDate = $_POST['start_date'] ?? '';
+            $targetDate = $_POST['target_date'] ?? '';
+            $status = $_POST['status'] ?? 'Active';
+
+            if ($name === '') {
+                addFlashMessage('error', 'Project name is required.');
+                break;
+            }
+
+            if (!in_array($status, ['Active', 'On Hold', 'Completed', 'Archived'], true)) {
+                addFlashMessage('error', 'Invalid project status.');
+                break;
+            }
+
+            if ($startDate !== '' && !isValidDate($startDate)) {
+                addFlashMessage('error', 'Invalid start date format.');
+                break;
+            }
+
+            if ($targetDate !== '' && !isValidDate($targetDate)) {
+                addFlashMessage('error', 'Invalid target date format.');
+                break;
+            }
+
+            try {
+                $stmt = $pdo->prepare('INSERT INTO projects (name, sponsor, description, strategic_theme, start_date, target_date, status) VALUES (:name, :sponsor, :description, :strategic_theme, :start_date, :target_date, :status)');
+                $stmt->execute([
+                    ':name' => $name,
+                    ':sponsor' => $sponsor,
+                    ':description' => $description,
+                    ':strategic_theme' => $strategicTheme,
+                    ':start_date' => $startDate !== '' ? $startDate : null,
+                    ':target_date' => $targetDate !== '' ? $targetDate : null,
+                    ':status' => $status,
+                ]);
+                addFlashMessage('success', 'Project created successfully.');
+            } catch (PDOException $exception) {
+                if ($exception->getCode() === '23000') {
+                    addFlashMessage('error', 'A project with this name already exists.');
+                } else {
+                    addFlashMessage('error', 'Unable to create project right now. Please try again.');
+                }
+            }
+            break;
+
+        case 'log_task_update':
+            if ($redirectTarget === '') {
+                $redirectTarget = 'updates.php';
+            }
+            $anchor = '#update-form';
+            if (!isAuthenticated()) {
+                addFlashMessage('error', 'Please sign in to log progress.');
+                break;
+            }
+
+            $taskId = (int) ($_POST['task_id'] ?? 0);
+            $summary = trim($_POST['update_summary'] ?? '');
+            $progress = (int) ($_POST['progress_percent'] ?? 0);
+            $riskNote = trim($_POST['risk_note'] ?? '');
+            $blockerNote = trim($_POST['blocker_note'] ?? '');
+            $riskLevel = $_POST['risk_level'] ?? '';
+            $reporter = trim($_POST['created_by'] ?? '');
+
+            if ($taskId <= 0 || $summary === '') {
+                addFlashMessage('error', 'Select a task and provide an update summary.');
+                break;
+            }
+
+            if ($progress < 0 || $progress > 100) {
+                addFlashMessage('error', 'Progress must be between 0 and 100%.');
+                break;
+            }
+
+            if ($riskLevel !== '' && !in_array($riskLevel, allowedRiskLevels(), true)) {
+                addFlashMessage('error', 'Invalid risk level selection.');
+                break;
+            }
+
+            $riskValue = $riskLevel !== '' ? $riskLevel : null;
+            $reporterValue = $reporter !== '' ? $reporter : null;
+
+            try {
+                $stmt = $pdo->prepare('INSERT INTO task_updates (task_id, update_summary, progress_percent, risk_note, blocker_note, risk_level, created_by) VALUES (:task_id, :update_summary, :progress_percent, :risk_note, :blocker_note, :risk_level, :created_by)');
+                $stmt->execute([
+                    ':task_id' => $taskId,
+                    ':update_summary' => $summary,
+                    ':progress_percent' => $progress,
+                    ':risk_note' => $riskNote !== '' ? $riskNote : null,
+                    ':blocker_note' => $blockerNote !== '' ? $blockerNote : null,
+                    ':risk_level' => $riskValue,
+                    ':created_by' => $reporterValue,
+                ]);
+                addFlashMessage('success', 'Progress update recorded.');
+            } catch (PDOException $exception) {
+                addFlashMessage('error', 'Unable to save the update right now. Please try again.');
+            }
+            break;
+
+        default:
+            break;
+    }
+
+    redirectAfterAction($redirectTarget, $anchor);
+}
+
+function redirectAfterAction(?string $target, string $anchor = ''): void
+{
+    $target = trim((string) $target);
+    if ($target === '') {
+        redirectToSelf($anchor);
+    }
+
+    if ($anchor !== '') {
+        $target = preg_replace('/#.*/', '', $target) . $anchor;
+    }
+
+    header('Location: ' . $target);
+    exit;
+}
+function allowedTaskStatuses(): array
+{
+    return ['Pending', 'In Progress', 'Completed', 'On Hold'];
+}
+
+function allowedPriorities(): array
+{
+    return ['Critical', 'High', 'Normal', 'Low'];
+}
+
+function allowedRiskLevels(): array
+{
+    return ['Low', 'Moderate', 'High', 'Critical'];
+}
+
+function allowedImpactLevels(): array
+{
+    return ['Low', 'Medium', 'High', 'Extreme'];
+}
+
+function allowedEffortLevels(): array
+{
+    return ['Light', 'Medium', 'Heavy'];
+}
+
+function addFlashMessage(string $type, string $message): void
+{
+    $_SESSION['flash_messages'] ??= [];
+    $_SESSION['flash_messages'][] = [
+        'type' => $type,
+        'message' => $message,
+    ];
+}
+
+function consumeFlashMessages(): array
+{
+    $messages = $_SESSION['flash_messages'] ?? [];
+    unset($_SESSION['flash_messages']);
+
+    return $messages;
+}
+
+function redirectToSelf(string $anchor = ''): void
+{
+    $uri = $_SERVER['REQUEST_URI'] ?? ($_SERVER['PHP_SELF'] ?? '/');
+    $uri = strtok($uri, '#');
+    $location = $uri . $anchor;
+    header('Location: ' . $location);
+    exit;
+}
+
+function isAuthenticated(): bool
+{
+    return isset($_SESSION['user_id']) && (int) $_SESSION['user_id'] > 0;
+}
+
+function getAuthenticatedUser(PDO $pdo): ?array
+{
+    if (!isAuthenticated()) {
+        return null;
+    }
+
+    $userId = (int) $_SESSION['user_id'];
+    $stmt = $pdo->prepare('SELECT id, name, email FROM users WHERE id = :id');
+    $stmt->execute([':id' => $userId]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($user === false) {
+        unset($_SESSION['user_id']);
+        return null;
+    }
+
+    return $user;
+}
+
+function fetchDepartments(PDO $pdo): array
+{
+    $stmt = $pdo->query('SELECT id, name FROM departments ORDER BY name');
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function fetchProjects(PDO $pdo): array
+{
+    $sql = <<<SQL
+        SELECT
+            p.id,
+            p.name,
+            p.sponsor,
+            p.description,
+            p.strategic_theme,
+            p.start_date,
+            p.target_date,
+            p.status,
+            COUNT(t.id) AS total_tasks,
+            SUM(CASE WHEN t.status = 'Completed' THEN 1 ELSE 0 END) AS completed_tasks,
+            SUM(CASE WHEN t.status != 'Completed' AND t.risk_level IN ('High', 'Critical') THEN 1 ELSE 0 END) AS at_risk_tasks,
+            MAX(u.created_at) AS last_update_at
+        FROM projects p
+        LEFT JOIN tasks t ON t.project_id = p.id
+        LEFT JOIN task_updates u ON u.task_id = t.id
+        GROUP BY p.id
+        ORDER BY CASE p.status WHEN 'Active' THEN 0 WHEN 'On Hold' THEN 1 WHEN 'Completed' THEN 2 ELSE 3 END,
+                 CASE WHEN p.target_date IS NULL THEN 1 ELSE 0 END,
+                 p.target_date
+    SQL;
+
+    $stmt = $pdo->query($sql);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function fetchTasks(PDO $pdo): array
+{
+    $sql = <<<SQL
+        SELECT
+            t.*,
+            d.name AS department_name,
+            p.name AS project_name,
+            (
+                SELECT progress_percent
+                FROM task_updates
+                WHERE task_id = t.id
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) AS latest_progress,
+            (
+                SELECT update_summary
+                FROM task_updates
+                WHERE task_id = t.id
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) AS latest_summary,
+            (
+                SELECT created_at
+                FROM task_updates
+                WHERE task_id = t.id
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) AS latest_update_at
+        FROM tasks t
+        JOIN departments d ON d.id = t.department_id
+        LEFT JOIN projects p ON p.id = t.project_id
+        ORDER BY t.due_date ASC,
+                 CASE t.priority WHEN 'Critical' THEN 3 WHEN 'High' THEN 2 WHEN 'Normal' THEN 1 ELSE 0 END DESC,
+                 t.created_at DESC
+    SQL;
+
+    $stmt = $pdo->query($sql);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function fetchRecentUpdates(PDO $pdo): array
+{
+    $sql = <<<SQL
+        SELECT
+            u.id,
+            u.task_id,
+            u.update_summary,
+            u.progress_percent,
+            u.risk_note,
+            u.blocker_note,
+            u.created_at,
+            u.created_by,
+            t.title AS task_title,
+            t.risk_level,
+            d.name AS department_name,
+            p.name AS project_name
+        FROM task_updates u
+        JOIN tasks t ON t.id = u.task_id
+        JOIN departments d ON d.id = t.department_id
+        LEFT JOIN projects p ON p.id = t.project_id
+        ORDER BY u.created_at DESC
+        LIMIT 8
+    SQL;
+
+    $stmt = $pdo->query($sql);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function buildSummary(array $tasks, array $departments): array
+{
+    $summary = [
+        'total' => count($tasks),
+        'status' => [
+            'Pending' => 0,
+            'In Progress' => 0,
+            'Completed' => 0,
+            'On Hold' => 0,
+        ],
+        'risk' => [
+            'Low' => 0,
+            'Moderate' => 0,
+            'High' => 0,
+            'Critical' => 0,
+        ],
+        'by_department' => [],
+        'peak_department_tasks' => 0,
+    ];
+
+    foreach ($departments as $department) {
+        $summary['by_department'][$department['id']] = [
+            'name' => $department['name'],
+            'count' => 0,
+        ];
+    }
+
+    foreach ($tasks as $task) {
+        if (isset($summary['status'][$task['status']])) {
+            $summary['status'][$task['status']]++;
+        }
+        if (isset($summary['risk'][$task['risk_level']])) {
+            $summary['risk'][$task['risk_level']]++;
+        }
+        if (isset($summary['by_department'][$task['department_id']])) {
+            $summary['by_department'][$task['department_id']]['count']++;
+            $summary['peak_department_tasks'] = max($summary['peak_department_tasks'], $summary['by_department'][$task['department_id']]['count']);
+        }
+    }
+
+    uasort($summary['by_department'], static function (array $a, array $b): int {
+        $comparison = $b['count'] <=> $a['count'];
+        if ($comparison !== 0) {
+            return $comparison;
+        }
+
+        return strcmp($a['name'], $b['name']);
+    });
+
+    return $summary;
+}
+
+function buildPortfolioSnapshot(array $projects, array $tasks, array $summary): array
+{
+    $activeProjects = 0;
+    $engagedDepartments = [];
+    $completedTasks = $summary['status']['Completed'] ?? 0;
+    $totalTasks = max(1, $summary['total']);
+    $atRiskTasks = ($summary['risk']['High'] ?? 0) + ($summary['risk']['Critical'] ?? 0);
+
+    foreach ($projects as $project) {
+        if ($project['status'] === 'Active' || $project['status'] === 'On Hold') {
+            $activeProjects++;
+        }
+    }
+
+    foreach ($tasks as $task) {
+        $engagedDepartments[$task['department_id']] = true;
+    }
+
+    $completionRate = (int) round(($completedTasks / $totalTasks) * 100);
+
+    return [
+        'active_projects' => $activeProjects,
+        'engaged_departments' => count($engagedDepartments),
+        'completion_rate' => $completionRate,
+        'at_risk_tasks' => $atRiskTasks,
+    ];
+}
+
+function findUpcomingAlerts(array $tasks): array
+{
+    $alerts = [
+        'overdue' => [],
+        'upcoming' => [],
+    ];
+
+    $today = new DateTimeImmutable('today');
+    $upcomingThreshold = $today->modify('+5 days');
+
+    foreach ($tasks as $task) {
+        if ($task['status'] === 'Completed') {
+            continue;
+        }
+
+        $dueDate = DateTimeImmutable::createFromFormat('Y-m-d', $task['due_date']);
+        if (!$dueDate) {
+            continue;
+        }
+
+        $diff = (int) $today->diff($dueDate)->format('%r%a');
+        $taskWithDiff = $task;
+        $taskWithDiff['days_diff'] = $diff;
+
+        if ($dueDate < $today) {
+            $alerts['overdue'][] = $taskWithDiff;
+        } elseif ($dueDate <= $upcomingThreshold) {
+            $alerts['upcoming'][] = $taskWithDiff;
+        }
+    }
+
+    return $alerts;
+}
+
+function isValidDate(string $date): bool
+{
+    $dateTime = DateTimeImmutable::createFromFormat('Y-m-d', $date);
+    return $dateTime instanceof DateTimeImmutable && $dateTime->format('Y-m-d') === $date;
+}
+
+function getStatusLabel(string $status): string
+{
+    return [
+        'Pending' => 'Pending',
+        'In Progress' => 'In Progress',
+        'Completed' => 'Completed',
+        'On Hold' => 'On Hold',
+    ][$status] ?? $status;
+}
+
+function getPriorityLabel(string $priority): string
+{
+    return [
+        'Critical' => 'Critical',
+        'High' => 'High',
+        'Normal' => 'Normal',
+        'Low' => 'Low',
+    ][$priority] ?? $priority;
+}
+
+function getRiskClass(string $riskLevel): string
+{
+    return 'risk-' . strtolower(str_replace(' ', '-', $riskLevel));
+}
+
+function formatDate(?string $value): string
+{
+    if ($value === null || $value === '') {
+        return 'TBD';
+    }
+
+    $date = DateTimeImmutable::createFromFormat('Y-m-d', $value);
+    if (!$date) {
+        return $value;
+    }
+
+    return $date->format('d M Y');
+}
+
+function describeDueDifference(int $daysDiff): string
+{
+    if ($daysDiff === 0) {
+        return 'Due today';
+    }
+
+    if ($daysDiff > 0) {
+        $plural = $daysDiff === 1 ? '' : 's';
+        return 'Due in ' . $daysDiff . ' day' . $plural;
+    }
+
+    $daysOverdue = abs($daysDiff);
+    $plural = $daysOverdue === 1 ? '' : 's';
+    return $daysOverdue . ' day' . $plural . ' overdue';
+}
+
+function excerpt(string $value, int $length = 120): string
+{
+    if (function_exists('mb_strlen') && function_exists('mb_substr')) {
+        if (mb_strlen($value, 'UTF-8') <= $length) {
+            return $value;
+        }
+
+        return rtrim(mb_substr($value, 0, $length, 'UTF-8')) . '…';
+    }
+
+    if (strlen($value) <= $length) {
+        return $value;
+    }
+
+    return rtrim(substr($value, 0, $length)) . '…';
+}
+
+function escape(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+}

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/app.php';
+
+$pdo = getDatabaseConnection();
+handlePostRequests($pdo);
+$currentUser = getAuthenticatedUser($pdo);
+$flashMessages = consumeFlashMessages();

--- a/includes/flash.php
+++ b/includes/flash.php
@@ -1,0 +1,7 @@
+<?php if (!empty($flashMessages)): ?>
+    <div class="flash-container">
+        <?php foreach ($flashMessages as $flash): ?>
+            <div class="flash-message flash-<?php echo escape($flash['type']); ?>"><?php echo escape($flash['message']); ?></div>
+        <?php endforeach; ?>
+    </div>
+<?php endif; ?>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,0 +1,7 @@
+    </div>
+    <footer class="site-footer">
+        <p>Municipal Transformation Program Office &middot; Riyadh Municipality</p>
+    </footer>
+    <script src="assets/scripts.js" defer></script>
+</body>
+</html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+/** @var string $pageTitle */
+/** @var string $activeNav */
+/** @var array|null $currentUser */
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo escape($pageTitle); ?></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body class="app-shell">
+    <header class="site-header">
+        <div class="header-inner">
+            <div class="brand-block">
+                <a href="dashboard.php" class="brand">Municipal PMO Suite</a>
+                <p class="brand-subtitle">Citywide project and operations control</p>
+            </div>
+            <nav class="primary-nav" aria-label="Primary">
+                <a class="nav-link<?php echo $activeNav === 'dashboard' ? ' active' : ''; ?>" href="dashboard.php">Dashboard</a>
+                <a class="nav-link<?php echo $activeNav === 'projects' ? ' active' : ''; ?>" href="projects.php">Projects</a>
+                <a class="nav-link<?php echo $activeNav === 'tasks' ? ' active' : ''; ?>" href="tasks.php">Tasks</a>
+                <a class="nav-link<?php echo $activeNav === 'departments' ? ' active' : ''; ?>" href="departments.php">Departments</a>
+                <a class="nav-link<?php echo $activeNav === 'updates' ? ' active' : ''; ?>" href="updates.php">Updates</a>
+            </nav>
+            <div class="header-actions">
+                <?php if ($currentUser !== null): ?>
+                    <span class="user-chip">Signed in as <?php echo escape($currentUser['name']); ?></span>
+                    <form method="post" class="logout-form">
+                        <input type="hidden" name="action" value="logout">
+                        <input type="hidden" name="redirect" value="login.php">
+                        <button type="submit" class="ghost-btn">Sign out</button>
+                    </form>
+                <?php else: ?>
+                    <a class="ghost-btn" href="login.php">Sign in</a>
+                    <a class="primary-btn" href="register.php">Create account</a>
+                <?php endif; ?>
+            </div>
+        </div>
+    </header>
+    <div class="page-content">

--- a/index.php
+++ b/index.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/app.php';
+
+$pdo = getDatabaseConnection();
+$currentUser = getAuthenticatedUser($pdo);
+
+$destination = $currentUser === null ? 'login.php' : 'dashboard.php';
+header('Location: ' . $destination);
+exit;

--- a/login.php
+++ b/login.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+if ($currentUser !== null) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+$pageTitle = 'Sign in to the Municipal PMO Suite';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo escape($pageTitle); ?></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body class="auth-shell">
+    <main class="auth-wrapper">
+        <section class="auth-panel">
+            <header class="auth-header">
+                <p class="eyebrow">Municipal PMO Suite</p>
+                <h1>Sign in</h1>
+                <p class="auth-lede">Access the command environment to coordinate projects, assignments, and cross-department execution.</p>
+            </header>
+            <?php require __DIR__ . '/includes/flash.php'; ?>
+            <form method="post" class="auth-form" novalidate>
+                <input type="hidden" name="action" value="login">
+                <input type="hidden" name="redirect" value="login.php">
+                <label>
+                    Work Email
+                    <input type="email" name="email" required placeholder="you@municipality.gov.sa" autocomplete="email">
+                </label>
+                <label>
+                    Password
+                    <input type="password" name="password" required placeholder="Enter your password" autocomplete="current-password">
+                </label>
+                <button type="submit" class="primary-btn">Sign in</button>
+            </form>
+            <p class="auth-switch">Need access? <a href="register.php">Create an account</a>.</p>
+        </section>
+        <aside class="auth-aside">
+            <h2>Made for MAMP &amp; MacBook setups</h2>
+            <p>Drop the project inside your <code>htdocs</code> folder, start the MAMP servers, and open <strong>http://localhost:8888/tatarwar</strong> to reach this login portal.</p>
+            <ul class="auth-highlights">
+                <li>Role-based dashboards for every directorate</li>
+                <li>Portfolio analytics tailored to municipal KPIs</li>
+                <li>Task, project, and risk tracking in one workspace</li>
+            </ul>
+        </aside>
+    </main>
+</body>
+</html>

--- a/projects.php
+++ b/projects.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+if ($currentUser === null) {
+    header('Location: login.php');
+    exit;
+}
+
+$pageTitle = 'Projects Portfolio | Municipal PMO Suite';
+$activeNav = 'projects';
+
+$departments = fetchDepartments($pdo);
+$projects = fetchProjects($pdo);
+
+require __DIR__ . '/includes/header.php';
+require __DIR__ . '/includes/flash.php';
+?>
+<main class="page-main projects-main">
+    <section class="card" id="project-form">
+        <header class="card-header">
+            <h2>Register a project</h2>
+            <p class="card-subtitle">Capture sponsor, strategic alignment, and timeline details.</p>
+        </header>
+        <form method="post" class="stacked-form" novalidate>
+            <input type="hidden" name="action" value="create_project">
+            <input type="hidden" name="redirect" value="projects.php">
+            <div class="form-grid">
+                <label>
+                    Project name
+                    <input type="text" name="name" required placeholder="e.g., Digital Permitting Platform">
+                </label>
+                <label>
+                    Sponsor
+                    <input type="text" name="sponsor" placeholder="Which directorate is sponsoring?">
+                </label>
+                <label>
+                    Strategic theme
+                    <input type="text" name="strategic_theme" placeholder="e.g., Smart City">
+                </label>
+                <label>
+                    Start date
+                    <input type="date" name="start_date">
+                </label>
+                <label>
+                    Target date
+                    <input type="date" name="target_date">
+                </label>
+                <label>
+                    Status
+                    <select name="status">
+                        <option value="Active">Active</option>
+                        <option value="On Hold">On Hold</option>
+                        <option value="Completed">Completed</option>
+                        <option value="Archived">Archived</option>
+                    </select>
+                </label>
+            </div>
+            <label>
+                Description
+                <textarea name="description" rows="4" placeholder="Describe objectives, scope, and expected outcomes."></textarea>
+            </label>
+            <button type="submit" class="primary-btn">Add project</button>
+        </form>
+    </section>
+
+    <section class="card" id="project-catalog">
+        <header class="card-header">
+            <h2>Portfolio catalog</h2>
+            <p class="card-subtitle">All projects tracked across departments.</p>
+        </header>
+        <?php if (empty($projects)): ?>
+            <p class="empty-state">No initiatives registered yet. Add your first project using the form above.</p>
+        <?php else: ?>
+            <div class="project-grid">
+                <?php foreach ($projects as $project): ?>
+                    <?php
+                        $totalTasks = (int) $project['total_tasks'];
+                        $completed = (int) $project['completed_tasks'];
+                        $progress = $totalTasks > 0 ? (int) round(($completed / $totalTasks) * 100) : 0;
+                    ?>
+                    <article class="project-card">
+                        <header>
+                            <div class="project-meta">
+                                <h3><?php echo escape($project['name']); ?></h3>
+                                <span class="status-pill status-<?php echo strtolower(str_replace(' ', '-', $project['status'])); ?>"><?php echo escape($project['status']); ?></span>
+                            </div>
+                            <?php if ($project['strategic_theme']): ?>
+                                <p class="project-theme">Theme: <?php echo escape($project['strategic_theme']); ?></p>
+                            <?php endif; ?>
+                        </header>
+                        <p class="project-description"><?php echo escape($project['description'] ?: 'No description provided yet.'); ?></p>
+                        <dl class="project-facts">
+                            <div>
+                                <dt>Sponsor</dt>
+                                <dd><?php echo escape($project['sponsor'] ?: '—'); ?></dd>
+                            </div>
+                            <div>
+                                <dt>Timeline</dt>
+                                <dd><?php echo escape(formatDate($project['start_date'])); ?> → <?php echo escape(formatDate($project['target_date'])); ?></dd>
+                            </div>
+                        </dl>
+                        <div class="project-progress">
+                            <div class="progress-track">
+                                <div class="progress-fill" style="width: <?php echo $progress; ?>%"></div>
+                            </div>
+                            <span class="progress-label"><?php echo $progress; ?>% complete (<?php echo $completed; ?> of <?php echo $totalTasks; ?> tasks)</span>
+                        </div>
+                        <footer class="project-footer">
+                            <span class="project-stat">Tasks: <?php echo $totalTasks; ?></span>
+                            <span class="project-stat">At-risk: <?php echo (int) $project['at_risk_tasks']; ?></span>
+                            <span class="project-stat">Last update: <?php echo $project['last_update_at'] ? escape(formatDate(substr($project['last_update_at'], 0, 10))) : '—'; ?></span>
+                        </footer>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+    </section>
+</main>
+<?php require __DIR__ . '/includes/footer.php'; ?>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+if ($currentUser !== null) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+$pageTitle = 'Create an account for the Municipal PMO Suite';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo escape($pageTitle); ?></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body class="auth-shell">
+    <main class="auth-wrapper">
+        <section class="auth-panel">
+            <header class="auth-header">
+                <p class="eyebrow">Municipal PMO Suite</p>
+                <h1>Create an account</h1>
+                <p class="auth-lede">Invite members of your transformation office to collaborate on shared execution plans.</p>
+            </header>
+            <?php require __DIR__ . '/includes/flash.php'; ?>
+            <form method="post" class="auth-form" novalidate>
+                <input type="hidden" name="action" value="register">
+                <input type="hidden" name="redirect" value="register.php">
+                <label>
+                    Full Name
+                    <input type="text" name="name" required placeholder="e.g., Sara Alotaibi" autocomplete="name">
+                </label>
+                <label>
+                    Work Email
+                    <input type="email" name="email" required placeholder="name@municipality.gov.sa" autocomplete="email">
+                </label>
+                <div class="form-grid">
+                    <label>
+                        Password
+                        <input type="password" name="password" required minlength="8" placeholder="Minimum 8 characters" autocomplete="new-password">
+                    </label>
+                    <label>
+                        Confirm Password
+                        <input type="password" name="confirm_password" required minlength="8" placeholder="Re-enter password" autocomplete="new-password">
+                    </label>
+                </div>
+                <button type="submit" class="primary-btn">Create account</button>
+            </form>
+            <p class="auth-switch">Already have credentials? <a href="login.php">Sign in instead</a>.</p>
+        </section>
+        <aside class="auth-aside">
+            <h2>Ready for a full municipal rollout</h2>
+            <p>All departments share one SQLite database (<code>database/app.sqlite</code>) bundled with the project. MAMP automatically serves the PHP application so your MacBook can run demos without extra setup.</p>
+            <ul class="auth-highlights">
+                <li>Pre-loaded department directory with 14 entities</li>
+                <li>Project registry with sponsor and timeline data</li>
+                <li>Task risk, impact, and effort scoring for prioritization</li>
+            </ul>
+        </aside>
+    </main>
+</body>
+</html>

--- a/tasks.php
+++ b/tasks.php
@@ -1,0 +1,214 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+if ($currentUser === null) {
+    header('Location: login.php');
+    exit;
+}
+
+$pageTitle = 'Tasks & Assignments | Municipal PMO Suite';
+$activeNav = 'tasks';
+
+$departments = fetchDepartments($pdo);
+$projects = fetchProjects($pdo);
+$tasks = fetchTasks($pdo);
+
+require __DIR__ . '/includes/header.php';
+require __DIR__ . '/includes/flash.php';
+?>
+<main class="page-main tasks-main">
+    <section class="card" id="task-form">
+        <header class="card-header">
+            <h2>Create a task</h2>
+            <p class="card-subtitle">Assign work to a department with timeline, risk, and impact context.</p>
+        </header>
+        <form method="post" class="stacked-form" novalidate>
+            <input type="hidden" name="action" value="create_task">
+            <input type="hidden" name="redirect" value="tasks.php">
+            <div class="form-grid">
+                <label>
+                    Task title
+                    <input type="text" name="title" required placeholder="e.g., Launch emergency response drill">
+                </label>
+                <label>
+                    Department
+                    <select name="department_id" required>
+                        <option value="">Select department</option>
+                        <?php foreach ($departments as $department): ?>
+                            <option value="<?php echo (int) $department['id']; ?>"><?php echo escape($department['name']); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>
+                    Project (optional)
+                    <select name="project_id">
+                        <option value="">No linked project</option>
+                        <?php foreach ($projects as $project): ?>
+                            <option value="<?php echo (int) $project['id']; ?>"><?php echo escape($project['name']); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>
+                    Assignee
+                    <input type="text" name="assignee" placeholder="Person responsible">
+                </label>
+                <label>
+                    Due date
+                    <input type="date" name="due_date" required>
+                </label>
+                <label>
+                    Status
+                    <select name="status">
+                        <?php foreach (allowedTaskStatuses() as $status): ?>
+                            <option value="<?php echo escape($status); ?>"><?php echo escape($status); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>
+                    Priority
+                    <select name="priority">
+                        <?php foreach (allowedPriorities() as $priority): ?>
+                            <option value="<?php echo escape($priority); ?>"><?php echo escape($priority); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>
+                    Risk level
+                    <select name="risk_level">
+                        <?php foreach (allowedRiskLevels() as $risk): ?>
+                            <option value="<?php echo escape($risk); ?>"><?php echo escape($risk); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>
+                    Impact level
+                    <select name="impact_level">
+                        <?php foreach (allowedImpactLevels() as $impact): ?>
+                            <option value="<?php echo escape($impact); ?>"><?php echo escape($impact); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>
+                    Effort level
+                    <select name="effort_level">
+                        <?php foreach (allowedEffortLevels() as $effort): ?>
+                            <option value="<?php echo escape($effort); ?>"><?php echo escape($effort); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+            </div>
+            <label>
+                Description
+                <textarea name="description" rows="4" placeholder="What is the desired outcome? Include context, collaborators, and dependencies."></textarea>
+            </label>
+            <button type="submit" class="primary-btn">Create task</button>
+        </form>
+    </section>
+
+    <section class="card" id="task-list">
+        <header class="card-header">
+            <div>
+                <h2>Task board</h2>
+                <p class="card-subtitle">Filter assignments by department, status, priority, or project.</p>
+            </div>
+            <div class="filters">
+                <input type="search" id="search" placeholder="Search tasks or assignees">
+                <select id="filter-department">
+                    <option value="all">All departments</option>
+                    <?php foreach ($departments as $department): ?>
+                        <option value="<?php echo (int) $department['id']; ?>"><?php echo escape($department['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <select id="filter-project">
+                    <option value="all">All projects</option>
+                    <?php foreach ($projects as $project): ?>
+                        <option value="<?php echo (int) $project['id']; ?>"><?php echo escape($project['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <select id="filter-status">
+                    <option value="all">All statuses</option>
+                    <?php foreach (allowedTaskStatuses() as $status): ?>
+                        <option value="<?php echo escape($status); ?>"><?php echo escape($status); ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <select id="filter-priority">
+                    <option value="all">All priorities</option>
+                    <?php foreach (allowedPriorities() as $priority): ?>
+                        <option value="<?php echo escape($priority); ?>"><?php echo escape($priority); ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <select id="filter-risk">
+                    <option value="all">All risk levels</option>
+                    <?php foreach (allowedRiskLevels() as $risk): ?>
+                        <option value="<?php echo escape($risk); ?>"><?php echo escape($risk); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+        </header>
+        <?php if (empty($tasks)): ?>
+            <p class="empty-state">No tasks yet. Use the form above to plan the next milestones.</p>
+        <?php else: ?>
+            <div class="table-wrapper">
+                <table id="tasks-table">
+                    <thead>
+                        <tr>
+                            <th>Task</th>
+                            <th>Department</th>
+                            <th>Project</th>
+                            <th>Assignee</th>
+                            <th>Due</th>
+                            <th>Status</th>
+                            <th>Priority</th>
+                            <th>Risk</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($tasks as $task): ?>
+                            <tr data-department="<?php echo (int) $task['department_id']; ?>" data-status="<?php echo escape($task['status']); ?>" data-priority="<?php echo escape($task['priority']); ?>" data-project="<?php echo $task['project_id'] ?? 'none'; ?>" data-risk="<?php echo escape($task['risk_level']); ?>">
+                                <td>
+                                    <strong><?php echo escape($task['title']); ?></strong>
+                                    <?php if ($task['description']): ?>
+                                        <p class="description"><?php echo escape($task['description']); ?></p>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?php echo escape($task['department_name']); ?></td>
+                                <td><?php echo $task['project_name'] ? escape($task['project_name']) : '—'; ?></td>
+                                <td><?php echo $task['assignee'] ? escape($task['assignee']) : '—'; ?></td>
+                                <td>
+                                    <time class="due-date" datetime="<?php echo escape($task['due_date']); ?>"><?php echo escape(formatDate($task['due_date'])); ?></time>
+                                    <span class="due-indicator"></span>
+                                </td>
+                                <td>
+                                    <form method="post" class="inline-form">
+                                        <input type="hidden" name="action" value="update_task_status">
+                                        <input type="hidden" name="redirect" value="tasks.php">
+                                        <input type="hidden" name="task_id" value="<?php echo (int) $task['id']; ?>">
+                                        <select name="status" onchange="this.form.submit()">
+                                            <?php foreach (allowedTaskStatuses() as $status): ?>
+                                                <option value="<?php echo escape($status); ?>"<?php echo $status === $task['status'] ? ' selected' : ''; ?>><?php echo escape($status); ?></option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                    </form>
+                                </td>
+                                <td><span class="badge priority-<?php echo strtolower($task['priority']); ?>"><?php echo escape($task['priority']); ?></span></td>
+                                <td><span class="badge risk-<?php echo strtolower(str_replace(' ', '-', $task['risk_level'])); ?>"><?php echo escape($task['risk_level']); ?></span></td>
+                                <td>
+                                    <form method="post" class="inline-form" onsubmit="return confirm('Delete this task?');">
+                                        <input type="hidden" name="action" value="delete_task">
+                                        <input type="hidden" name="redirect" value="tasks.php">
+                                        <input type="hidden" name="task_id" value="<?php echo (int) $task['id']; ?>">
+                                        <button type="submit" class="ghost-btn">Delete</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        <?php endif; ?>
+    </section>
+</main>
+<?php require __DIR__ . '/includes/footer.php'; ?>

--- a/updates.php
+++ b/updates.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+if ($currentUser === null) {
+    header('Location: login.php');
+    exit;
+}
+
+$pageTitle = 'Progress Updates | Municipal PMO Suite';
+$activeNav = 'updates';
+
+$tasks = fetchTasks($pdo);
+$recentUpdates = fetchRecentUpdates($pdo);
+
+require __DIR__ . '/includes/header.php';
+require __DIR__ . '/includes/flash.php';
+?>
+<main class="page-main updates-main">
+    <section class="card" id="update-form">
+        <header class="card-header">
+            <h2>Log a progress update</h2>
+            <p class="card-subtitle">Document percentage completion, risks, and blockers.</p>
+        </header>
+        <form method="post" class="stacked-form" novalidate>
+            <input type="hidden" name="action" value="log_task_update">
+            <input type="hidden" name="redirect" value="updates.php">
+            <label>
+                Task
+                <select name="task_id" required>
+                    <option value="">Select task</option>
+                    <?php foreach ($tasks as $task): ?>
+                        <option value="<?php echo (int) $task['id']; ?>"><?php echo escape($task['title']); ?> (<?php echo escape($task['department_name']); ?>)</option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <div class="form-grid">
+                <label>
+                    Progress (%)
+                    <input type="number" name="progress_percent" min="0" max="100" step="1" value="0" required>
+                </label>
+                <label>
+                    Risk level
+                    <select name="risk_level">
+                        <option value="">No change</option>
+                        <?php foreach (allowedRiskLevels() as $risk): ?>
+                            <option value="<?php echo escape($risk); ?>"><?php echo escape($risk); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>
+                    Reporter
+                    <input type="text" name="created_by" placeholder="Name of person logging the update">
+                </label>
+            </div>
+            <label>
+                Update summary
+                <textarea name="update_summary" rows="3" required placeholder="Summarize key progress since the last report."></textarea>
+            </label>
+            <label>
+                Risk note (optional)
+                <textarea name="risk_note" rows="3" placeholder="Flag emerging risks or mitigation plans."></textarea>
+            </label>
+            <label>
+                Blocker note (optional)
+                <textarea name="blocker_note" rows="3" placeholder="Document blockers requiring escalation."></textarea>
+            </label>
+            <button type="submit" class="primary-btn">Submit update</button>
+        </form>
+    </section>
+
+    <section class="card updates-timeline">
+        <header class="card-header">
+            <h2>Recent updates</h2>
+            <p class="card-subtitle">Latest signals from the field.</p>
+        </header>
+        <?php if (empty($recentUpdates)): ?>
+            <p class="empty-state">No updates recorded yet. Fill out the form above to start the history.</p>
+        <?php else: ?>
+            <ul class="timeline">
+                <?php foreach ($recentUpdates as $update): ?>
+                    <li class="timeline-entry">
+                        <header class="timeline-header">
+                            <h3><?php echo escape($update['task_title']); ?></h3>
+                            <span class="timeline-progress"><?php echo (int) $update['progress_percent']; ?>%</span>
+                        </header>
+                        <p class="timeline-meta">
+                            <?php echo escape($update['department_name']); ?>
+                            <?php if ($update['project_name']): ?>
+                                &middot; Project: <?php echo escape($update['project_name']); ?>
+                            <?php endif; ?>
+                            &middot; Logged on <?php echo escape(formatDate(substr($update['created_at'], 0, 10))); ?>
+                            <?php if ($update['created_by']): ?>
+                                &middot; By <?php echo escape($update['created_by']); ?>
+                            <?php endif; ?>
+                        </p>
+                        <p class="timeline-summary"><?php echo escape($update['update_summary']); ?></p>
+                        <?php if ($update['risk_note']): ?>
+                            <p class="timeline-note"><strong>Risk:</strong> <?php echo escape($update['risk_note']); ?></p>
+                        <?php endif; ?>
+                        <?php if ($update['blocker_note']): ?>
+                            <p class="timeline-note"><strong>Blocker:</strong> <?php echo escape($update['blocker_note']); ?></p>
+                        <?php endif; ?>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </section>
+</main>
+<?php require __DIR__ . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- drop the project budget column from the schema, seed data, and request handling so no financial figures are persisted
- replace the dashboard budget card with an engaged departments metric and update project UI/documentation to remove budget mentions

## Testing
- for file in index.php login.php register.php dashboard.php tasks.php projects.php departments.php updates.php includes/app.php includes/bootstrap.php includes/header.php includes/footer.php includes/flash.php; do php -l $file || exit 1; done

------
https://chatgpt.com/codex/tasks/task_e_68ea48b72014832c93530883d016947f