### PR TITLE
Translate portal interface to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# Department Task Management System
+
+A lightweight web portal for coordinating departmental work. The interface is built with HTML, CSS, and JavaScript, while PHP powers the backend and connects the application to a MySQL database (compatible with MAMP on macOS).
+
+## Key features
+- Dashboard with quick metrics, upcoming deadlines, and reminder history.
+- Full CRUD workflow for departmental tasks (create, update status, delete).
+- Department directory with optional contact email and automatic seeding of the provided fourteen departments.
+- Reminder logging endpoint to record when a follow-up notification is sent.
+
+## Requirements
+- PHP 8 or newer.
+- MySQL server (the default MAMP database works well).
+- Web server such as Apache bundled with MAMP.
+
+## Getting started with MAMP
+1. Copy the project into your MAMP web directory (typically `/Applications/MAMP/htdocs`).
+2. Open phpMyAdmin through `http://localhost/phpMyAdmin`.
+3. Import the database schema located at `database/schema.sql` to create tables and default department rows.
+4. Update the connection values in `db.php` if your credentials differ. The defaults are:
+   - Username: `root`
+   - Password: `root`
+   - Database: `task_manager`
+5. Start MAMP servers and visit `http://localhost/tatarwar/index.php` (or the folder name you chose) to access the portal.
+
+## Database structure
+- `departments`: stores department names and optional email contacts.
+- `tasks`: tracks task details, responsible department, priority, status, and due date.
+- `notifications`: records reminder messages tied to tasks.
+
+## Project structure
+```
+.
+├── assets
+│   ├── css
+│   │   └── style.css
+│   └── js
+│       └── app.js
+├── database
+│   └── schema.sql
+├── includes
+│   ├── footer.php
+│   ├── functions.php
+│   └── header.php
+├── db.php
+├── index.php
+├── tasks.php
+├── departments.php
+└── README.md
+```
+
+## Customising the platform
+- Update the colour palette or typography in `assets/css/style.css`.
+- Extend the reminder logic in `send_reminder.php` to trigger actual emails or integrations.
+- Modify the `departments.php` form to capture additional metadata as required.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,370 @@
+:root {
+    --primary: #1f7a8c;
+    --primary-dark: #0f5257;
+    --accent: #f18f01;
+    --background: #f8f9fb;
+    --text-main: #1c1c1c;
+    --text-muted: #6c757d;
+    --border: #e1e5eb;
+    --success: #2eb872;
+    --danger: #e63946;
+    --warning: #ffb703;
+    --shadow: 0 12px 30px rgba(15, 82, 87, 0.12);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Inter', 'Segoe UI', Tahoma, sans-serif;
+    background-color: var(--background);
+    color: var(--text-main);
+    line-height: 1.6;
+}
+
+.main-header {
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary));
+    color: #fff;
+    padding: 1.5rem 3rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    box-shadow: var(--shadow);
+}
+
+.branding {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.logo-circle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.15);
+    font-weight: 700;
+    font-size: 1.2rem;
+}
+
+.main-header h1 {
+    margin: 0;
+    font-size: 1.6rem;
+}
+
+.main-header p {
+    margin: 0.2rem 0 0;
+    color: rgba(255,255,255,0.75);
+}
+
+nav a {
+    color: rgba(255,255,255,0.9);
+    margin: 0 0.7rem;
+    text-decoration: none;
+    font-weight: 500;
+    padding-bottom: 0.3rem;
+    border-bottom: 2px solid transparent;
+}
+
+nav a.active,
+nav a:hover {
+    color: #fff;
+    border-color: var(--accent);
+}
+
+.container {
+    max-width: 1200px;
+    margin: 2rem auto;
+    padding: 0 1.5rem;
+}
+
+.grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.grid-3 {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+    background: #fff;
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: var(--shadow);
+    position: relative;
+}
+
+.card h2,
+.card h3 {
+    margin-top: 0;
+}
+
+.metrics {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+
+.metrics span.value {
+    font-size: 2.2rem;
+    font-weight: 700;
+    color: var(--primary-dark);
+}
+
+.metrics span.label {
+    color: var(--text-muted);
+}
+
+.table-wrapper {
+    overflow-x: auto;
+    border-radius: 16px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th, td {
+    padding: 0.9rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+}
+
+th {
+    background: #f1f4f8;
+    font-weight: 600;
+}
+
+tr:hover {
+    background: #f9fbfd;
+}
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.status-overdue {
+    background: rgba(230, 57, 70, 0.1);
+    color: var(--danger);
+}
+
+.status-warning {
+    background: rgba(255, 183, 3, 0.15);
+    color: var(--warning);
+}
+
+.status-open {
+    background: rgba(31, 122, 140, 0.12);
+    color: var(--primary-dark);
+}
+
+.status-complete {
+    background: rgba(46, 184, 114, 0.15);
+    color: var(--success);
+}
+
+.form-card form {
+    display: grid;
+    gap: 1rem;
+}
+
+.form-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+label {
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+    display: inline-block;
+}
+
+input[type="text"],
+input[type="date"],
+input[type="email"],
+select,
+textarea {
+    width: 100%;
+    padding: 0.8rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    font-family: inherit;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    background: #fdfdff;
+}
+
+textarea {
+    min-height: 120px;
+    resize: vertical;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(31, 122, 140, 0.15);
+}
+
+button,
+.button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.75rem 1.8rem;
+    font-family: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    background: var(--primary);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: center;
+}
+
+button:hover,
+.button:hover {
+    transform: translateY(-1px);
+    box-shadow: var(--shadow);
+}
+
+button.secondary {
+    background: #fff;
+    color: var(--primary);
+    border: 1px solid rgba(31, 122, 140, 0.4);
+}
+
+.badge {
+    display: inline-block;
+    padding: 0.3rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(31, 122, 140, 0.1);
+    color: var(--primary-dark);
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.alert {
+    padding: 0.8rem 1rem;
+    border-radius: 12px;
+    margin-bottom: 1rem;
+    font-weight: 600;
+}
+
+.alert.success {
+    background: rgba(46, 184, 114, 0.15);
+    color: var(--success);
+}
+
+.alert.error {
+    background: rgba(230, 57, 70, 0.15);
+    color: var(--danger);
+}
+
+.timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.timeline li {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.8rem 0;
+    border-bottom: 1px dashed var(--border);
+}
+
+.timeline li:last-child {
+    border-bottom: none;
+}
+
+.empty-state {
+    text-align: center;
+    color: var(--text-muted);
+    padding: 2rem 1rem;
+}
+
+@media (max-width: 768px) {
+    .main-header {
+        padding: 1.5rem;
+    }
+
+    nav a {
+        margin: 0 0.4rem;
+    }
+}
+
+.main-footer {
+    text-align: center;
+    padding: 2rem 1rem;
+    color: var(--text-muted);
+}
+
+.table-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.table-actions form {
+    margin: 0;
+}
+
+.table-actions button {
+    padding: 0.5rem 1rem;
+    font-size: 0.85rem;
+}
+
+.tag {
+    display: inline-block;
+    padding: 0.2rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(15, 82, 87, 0.1);
+    color: var(--primary-dark);
+    font-size: 0.75rem;
+}
+
+.reminder-button {
+    background: var(--accent);
+}
+
+.toast {
+    position: fixed;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #fff;
+    color: var(--text-main);
+    padding: 1rem 1.5rem;
+    border-radius: 16px;
+    box-shadow: var(--shadow);
+    display: none;
+    min-width: 280px;
+    text-align: center;
+}
+
+.toast.show {
+    display: block;
+}
+
+.text-muted {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,41 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const toast = document.createElement('div');
+    toast.className = 'toast';
+    document.body.appendChild(toast);
+
+    function showToast(message, type = 'success') {
+        toast.textContent = message;
+        toast.classList.remove('error', 'success');
+        toast.classList.add('show', type);
+        setTimeout(() => toast.classList.remove('show'), 3000);
+    }
+
+    document.querySelectorAll('.reminder-button').forEach(button => {
+        button.addEventListener('click', async () => {
+            const taskId = button.dataset.taskId;
+            button.disabled = true;
+            try {
+                const response = await fetch('send_reminder.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ taskId })
+                });
+
+                const result = await response.json();
+                if (response.ok) {
+                    showToast(result.message, 'success');
+                    const stamp = button.closest('tr').querySelector('.reminder-stamp');
+                    if (stamp) {
+                        stamp.textContent = result.lastReminder;
+                    }
+                } else {
+                    throw new Error(result.message || 'Unable to send reminder');
+                }
+            } catch (error) {
+                showToast(error.message, 'error');
+            } finally {
+                button.disabled = false;
+            }
+        });
+    });
+});

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,47 @@
+CREATE DATABASE IF NOT EXISTS task_manager CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE task_manager;
+
+CREATE TABLE IF NOT EXISTS departments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    email VARCHAR(190) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(180) NOT NULL,
+    description TEXT NULL,
+    department_id INT NOT NULL,
+    priority VARCHAR(20) DEFAULT 'Medium',
+    status VARCHAR(30) DEFAULT 'Pending',
+    due_date DATE NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_tasks_departments FOREIGN KEY (department_id) REFERENCES departments(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    task_id INT NOT NULL,
+    message TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_notifications_tasks FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO departments (name) VALUES
+    ('Office of the Secretary General'),
+    ('General Department of Information Technology'),
+    ('Cybersecurity Department'),
+    ('Investment Agency'),
+    ('General Department of Gardens and Landscaping'),
+    ('General Department of Internal Audits'),
+    ('General Department of Operations and Emergencies'),
+    ('Department of Safety and Security'),
+    ('Central Unit for Plan Approval'),
+    ('Department of Land Affairs'),
+    ('Environmental Health Department'),
+    ('General Department of Cleaning'),
+    ('Central City Municipality'),
+    ('Northern Municipality')
+ON DUPLICATE KEY UPDATE name = VALUES(name);

--- a/db.php
+++ b/db.php
@@ -1,0 +1,22 @@
+<?php
+$host = getenv('DB_HOST') ?: 'localhost';
+$port = getenv('DB_PORT') ?: '3306';
+$name = getenv('DB_NAME') ?: 'task_manager';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASSWORD') !== false ? getenv('DB_PASSWORD') : 'root';
+$charset = 'utf8mb4';
+$dsn = "mysql:host={$host};port={$port};dbname={$name};charset={$charset}";
+$options = [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $exception) {
+    http_response_code(500);
+    echo '<h1>Unable to connect to the database</h1>';
+    echo '<p>' . htmlspecialchars($exception->getMessage(), ENT_QUOTES, 'UTF-8') . '</p>';
+    exit;
+}

--- a/departments.php
+++ b/departments.php
@@ -1,0 +1,112 @@
+<?php
+$pageTitle = 'Departments';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$errors = [];
+$success = '';
+
+$defaultDepartments = [
+    'Office of the Secretary General',
+    'General Department of Information Technology',
+    'Cybersecurity Department',
+    'Investment Agency',
+    'General Department of Gardens and Landscaping',
+    'General Department of Internal Audits',
+    'General Department of Operations and Emergencies',
+    'Department of Safety and Security',
+    'Central Unit for Plan Approval',
+    'Department of Land Affairs',
+    'Environmental Health Department',
+    'General Department of Cleaning',
+    'Central City Municipality',
+    'Northern Municipality',
+];
+
+$count = (int)$pdo->query('SELECT COUNT(*) FROM departments')->fetchColumn();
+if ($count === 0) {
+    $insert = $pdo->prepare('INSERT INTO departments (name) VALUES (:name)');
+    foreach ($defaultDepartments as $departmentName) {
+        $insert->execute(['name' => $departmentName]);
+    }
+    $success = 'Default departments were added automatically.';
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+
+    if ($name === '') {
+        $errors[] = 'Department name is required.';
+    }
+
+    if (empty($errors)) {
+        $stmt = $pdo->prepare('INSERT INTO departments (name, email) VALUES (:name, :email)');
+        $stmt->execute([
+            'name' => $name,
+            'email' => $email ?: null,
+        ]);
+        $success = 'Department created successfully.';
+    }
+}
+
+$departments = $pdo->query('SELECT d.*, COUNT(t.id) AS tasks_count,
+    SUM(CASE WHEN t.status = "Completed" THEN 1 ELSE 0 END) AS completed_count
+    FROM departments d
+    LEFT JOIN tasks t ON t.department_id = d.id
+    GROUP BY d.id
+    ORDER BY d.name ASC')->fetchAll();
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="grid" style="grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">
+    <article class="card form-card">
+        <h2>Add Department</h2>
+        <p class="text-muted">Create a new department to assign work</p>
+        <?php if ($errors): ?>
+            <div class="alert error">
+                <?= implode('<br>', array_map('sanitize', $errors)); ?>
+            </div>
+        <?php endif; ?>
+        <?php if ($success && !$errors): ?>
+            <div class="alert success"><?= sanitize($success); ?></div>
+        <?php endif; ?>
+        <form method="post">
+            <div>
+                <label for="name">Department name</label>
+                <input type="text" id="name" name="name" required>
+            </div>
+            <div>
+                <label for="email">Email (optional)</label>
+                <input type="email" id="email" name="email" placeholder="team@example.com">
+            </div>
+            <button type="submit">Add department</button>
+        </form>
+    </article>
+    <article class="card">
+        <h2>Departments list</h2>
+        <div class="table-wrapper">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Department</th>
+                        <th>Email</th>
+                        <th>Total tasks</th>
+                        <th>Completed</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($departments as $department): ?>
+                        <tr>
+                            <td><?= sanitize($department['name']); ?></td>
+                            <td><?= $department['email'] ? sanitize($department['email']) : '-'; ?></td>
+                            <td><?= (int)$department['tasks_count']; ?></td>
+                            <td><?= (int)$department['completed_count']; ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </article>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,0 +1,7 @@
+    </main>
+    <footer class="main-footer">
+        <p>© <?= date('Y'); ?> Department Task Management Platform</p>
+    </footer>
+    <script src="assets/js/app.js"></script>
+</body>
+</html>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,70 @@
+<?php
+if (!ini_get('date.timezone')) {
+    date_default_timezone_set('Asia/Riyadh');
+}
+
+function sanitize(string $value = null): string
+{
+    return htmlspecialchars($value ?? '', ENT_QUOTES, 'UTF-8');
+}
+
+function analyze_due_status(?string $dueDate, string $status = 'In Progress'): array
+{
+    $today = new DateTimeImmutable('today');
+    if (strtolower($status) === 'completed') {
+        return [
+            'label' => 'Completed',
+            'class' => 'status-complete',
+        ];
+    }
+
+    if (!$dueDate) {
+        return [
+            'label' => 'No due date',
+            'class' => 'status-open',
+        ];
+    }
+
+    try {
+        $due = new DateTimeImmutable($dueDate);
+    } catch (Exception $e) {
+        return [
+            'label' => 'Invalid due date',
+            'class' => 'status-open',
+        ];
+    }
+
+    if ($due < $today) {
+        return [
+            'label' => 'Overdue',
+            'class' => 'status-overdue',
+        ];
+    }
+
+    $diff = $today->diff($due)->days;
+
+    if ($diff <= 3) {
+        return [
+            'label' => 'Due soon',
+            'class' => 'status-warning',
+        ];
+    }
+
+    return [
+        'label' => 'On track',
+        'class' => 'status-open',
+    ];
+}
+
+function format_date(?string $date): string
+{
+    if (!$date) {
+        return '-';
+    }
+
+    try {
+        return (new DateTimeImmutable($date))->format('Y-m-d');
+    } catch (Exception $e) {
+        return $date;
+    }
+}

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,31 @@
+<?php
+require_once __DIR__ . '/../includes/functions.php';
+$pageTitle = $pageTitle ?? 'Task Management Hub';
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= sanitize($pageTitle); ?></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+    <header class="main-header">
+        <div class="branding">
+            <span class="logo-circle">TM</span>
+            <div>
+                <h1>Enterprise Task Management</h1>
+                <p>Coordinate work across departments</p>
+            </div>
+        </div>
+        <nav>
+            <a href="index.php" class="<?= basename($_SERVER['PHP_SELF']) === 'index.php' ? 'active' : ''; ?>">Dashboard</a>
+            <a href="tasks.php" class="<?= basename($_SERVER['PHP_SELF']) === 'tasks.php' ? 'active' : ''; ?>">Tasks</a>
+            <a href="departments.php" class="<?= basename($_SERVER['PHP_SELF']) === 'departments.php' ? 'active' : ''; ?>">Departments</a>
+        </nav>
+    </header>
+    <main class="container">

--- a/index.php
+++ b/index.php
@@ -1,0 +1,95 @@
+<?php
+$pageTitle = 'Dashboard';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$totalTasks = (int)$pdo->query('SELECT COUNT(*) FROM tasks')->fetchColumn();
+$openTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status IN ('Pending', 'In Progress')")->fetchColumn();
+$completedTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status = 'Completed'")->fetchColumn();
+$overdueTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status != 'Completed' AND due_date IS NOT NULL AND due_date < CURDATE()")
+    ->fetchColumn();
+
+$upcomingTasks = $pdo->query("SELECT t.id, t.title, t.due_date, d.name AS department_name
+    FROM tasks t
+    JOIN departments d ON d.id = t.department_id
+    WHERE t.status != 'Completed' AND t.due_date IS NOT NULL AND t.due_date >= CURDATE()
+    ORDER BY t.due_date ASC
+    LIMIT 6")->fetchAll();
+
+$latestNotifications = $pdo->query("SELECT n.message, DATE_FORMAT(n.created_at, '%Y-%m-%d %H:%i') AS created_at,
+    t.title AS task_title
+    FROM notifications n
+    JOIN tasks t ON t.id = n.task_id
+    ORDER BY n.created_at DESC
+    LIMIT 5")->fetchAll();
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="grid grid-3">
+    <article class="card">
+        <div class="metrics">
+            <span class="label">Total Tasks</span>
+            <span class="value"><?= $totalTasks; ?></span>
+        </div>
+        <p>All tasks currently registered across departments.</p>
+    </article>
+    <article class="card">
+        <div class="metrics">
+            <span class="label">Open Tasks</span>
+            <span class="value"><?= $openTasks; ?></span>
+        </div>
+        <p>Tasks pending follow-up or in progress.</p>
+    </article>
+    <article class="card">
+        <div class="metrics">
+            <span class="label">Completed Tasks</span>
+            <span class="value"><?= $completedTasks; ?></span>
+        </div>
+        <p>Tasks finished and confirmed by departments.</p>
+    </article>
+</section>
+
+<section class="grid" style="margin-top: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">
+    <article class="card">
+        <h2>Upcoming Deadlines</h2>
+        <?php if (!$upcomingTasks): ?>
+            <div class="empty-state">No upcoming due dates found.</div>
+        <?php else: ?>
+            <ul class="timeline">
+                <?php foreach ($upcomingTasks as $task): ?>
+                    <li>
+                        <div>
+                            <strong><?= sanitize($task['title']); ?></strong>
+                            <div class="text-muted">Department: <?= sanitize($task['department_name']); ?></div>
+                        </div>
+                        <span class="badge">Due: <?= sanitize(format_date($task['due_date'])); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </article>
+    <article class="card">
+        <h2>Delivery Alerts</h2>
+        <?php if (!$latestNotifications): ?>
+            <div class="empty-state">No reminders sent yet.</div>
+        <?php else: ?>
+            <ul class="timeline">
+                <?php foreach ($latestNotifications as $notification): ?>
+                    <li>
+                        <div>
+                            <strong><?= sanitize($notification['task_title']); ?></strong>
+                            <div class="text-muted"><?= sanitize($notification['message']); ?></div>
+                        </div>
+                        <span class="badge"><?= sanitize($notification['created_at']); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </article>
+    <article class="card">
+        <h2>Overdue Tasks</h2>
+        <p><strong><?= $overdueTasks; ?></strong> tasks are past their due date.</p>
+        <a href="tasks.php" class="button">Review tasks and resolve delays</a>
+    </article>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/send_reminder.php
+++ b/send_reminder.php
@@ -1,0 +1,46 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['message' => 'Request method not allowed']);
+    exit;
+}
+
+$payload = json_decode(file_get_contents('php://input'), true) ?? [];
+$taskId = isset($payload['taskId']) ? (int) $payload['taskId'] : 0;
+
+if (!$taskId) {
+    http_response_code(400);
+    echo json_encode(['message' => 'Unknown task']);
+    exit;
+}
+
+require_once __DIR__ . '/db.php';
+
+$taskStmt = $pdo->prepare('SELECT id, title, due_date FROM tasks WHERE id = :id');
+$taskStmt->execute(['id' => $taskId]);
+$task = $taskStmt->fetch();
+
+if (!$task) {
+    http_response_code(404);
+    echo json_encode(['message' => 'Task not found']);
+    exit;
+}
+
+$message = sprintf('Reminder for task "%s". Due date: %s', $task['title'], $task['due_date'] ?: 'No due date');
+
+$insert = $pdo->prepare('INSERT INTO notifications (task_id, message, created_at) VALUES (:task_id, :message, NOW())');
+$insert->execute([
+    'task_id' => $taskId,
+    'message' => $message,
+]);
+
+$lastReminder = $pdo->prepare('SELECT DATE_FORMAT(created_at, "%Y-%m-%d %H:%i") as created_at FROM notifications WHERE task_id = :task_id ORDER BY created_at DESC LIMIT 1');
+$lastReminder->execute(['task_id' => $taskId]);
+$stamp = $lastReminder->fetchColumn();
+
+echo json_encode([
+    'message' => 'Reminder sent successfully',
+    'lastReminder' => $stamp,
+]);

--- a/tasks.php
+++ b/tasks.php
@@ -1,0 +1,192 @@
+<?php
+$pageTitle = 'Task Management';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$errors = [];
+$success = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'create') {
+        $title = trim($_POST['title'] ?? '');
+        $departmentId = (int)($_POST['department_id'] ?? 0);
+        $priority = $_POST['priority'] ?? 'Medium';
+        $dueDate = $_POST['due_date'] ?? null;
+        $description = trim($_POST['description'] ?? '');
+
+        if ($title === '') {
+            $errors[] = 'Task title is required.';
+        }
+
+        if ($departmentId <= 0) {
+            $errors[] = 'Select a responsible department.';
+        }
+
+        if (empty($errors)) {
+            $stmt = $pdo->prepare('INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+                VALUES (:title, :description, :department_id, :priority, :status, :due_date, NOW(), NOW())');
+            $stmt->execute([
+                'title' => $title,
+                'description' => $description,
+                'department_id' => $departmentId,
+                'priority' => $priority,
+                'status' => 'Pending',
+                'due_date' => $dueDate ?: null,
+            ]);
+
+            $success = 'Task created successfully.';
+        }
+    } elseif ($action === 'update_status') {
+        $taskId = (int)($_POST['task_id'] ?? 0);
+        $status = $_POST['status'] ?? 'Pending';
+
+        if ($taskId > 0) {
+            $update = $pdo->prepare('UPDATE tasks SET status = :status, updated_at = NOW() WHERE id = :id');
+            $update->execute([
+                'status' => $status,
+                'id' => $taskId,
+            ]);
+            $success = 'Task status updated.';
+        }
+    } elseif ($action === 'delete') {
+        $taskId = (int)($_POST['task_id'] ?? 0);
+        if ($taskId > 0) {
+            $pdo->prepare('DELETE FROM notifications WHERE task_id = :id')->execute(['id' => $taskId]);
+            $pdo->prepare('DELETE FROM tasks WHERE id = :id')->execute(['id' => $taskId]);
+            $success = 'Task deleted.';
+        }
+    }
+}
+
+$departments = $pdo->query('SELECT id, name FROM departments ORDER BY name ASC')->fetchAll();
+
+$tasksStmt = $pdo->query('SELECT t.*, d.name AS department_name,
+    (SELECT DATE_FORMAT(n.created_at, "%Y-%m-%d %H:%i") FROM notifications n WHERE n.task_id = t.id ORDER BY n.created_at DESC LIMIT 1) AS last_reminder
+    FROM tasks t
+    JOIN departments d ON t.department_id = d.id
+    ORDER BY t.due_date IS NULL, t.due_date ASC, t.created_at DESC');
+$tasks = $tasksStmt->fetchAll();
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="grid grid-3">
+    <article class="card form-card">
+        <h2>Create Task</h2>
+        <p class="text-muted">Assign work to departments and set due dates</p>
+        <?php if ($errors): ?>
+            <div class="alert error">
+                <?= implode('<br>', array_map('sanitize', $errors)); ?>
+            </div>
+        <?php endif; ?>
+        <?php if ($success && !$errors): ?>
+            <div class="alert success"><?= sanitize($success); ?></div>
+        <?php endif; ?>
+        <form method="post">
+            <input type="hidden" name="action" value="create">
+            <div>
+                <label for="title">Task title</label>
+                <input type="text" id="title" name="title" required>
+            </div>
+            <div class="form-grid">
+                <div>
+                    <label for="department_id">Department</label>
+                    <select id="department_id" name="department_id" required>
+                        <option value="">Select department</option>
+                        <?php foreach ($departments as $department): ?>
+                            <option value="<?= (int)$department['id']; ?>"><?= sanitize($department['name']); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div>
+                    <label for="priority">Priority</label>
+                    <select id="priority" name="priority">
+                        <option value="High">High</option>
+                        <option value="Medium" selected>Medium</option>
+                        <option value="Low">Low</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="due_date">Due date</label>
+                    <input type="date" id="due_date" name="due_date">
+                </div>
+            </div>
+            <div>
+                <label for="description">Task description</label>
+                <textarea id="description" name="description" placeholder="Add details and instructions"></textarea>
+            </div>
+            <button type="submit">Save task</button>
+        </form>
+    </article>
+</section>
+
+<section class="card">
+    <div class="metrics">
+        <h2>Task log</h2>
+        <span class="badge">Total <?= count($tasks); ?> tasks</span>
+    </div>
+    <div class="table-wrapper">
+        <table>
+            <thead>
+                <tr>
+                    <th>Task</th>
+                    <th>Department</th>
+                    <th>Priority</th>
+                    <th>Due date</th>
+                    <th>Status</th>
+                    <th>Last reminder</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+            <?php if (!$tasks): ?>
+                <tr>
+                    <td colspan="7" class="empty-state">No tasks yet. Start by adding assignments for departments.</td>
+                </tr>
+            <?php else: ?>
+                <?php foreach ($tasks as $task): ?>
+                    <?php $statusData = analyze_due_status($task['due_date'], $task['status']); ?>
+                    <tr>
+                        <td>
+                            <strong><?= sanitize($task['title']); ?></strong>
+                            <?php if ($task['description']): ?>
+                                <div class="text-muted"><?= nl2br(sanitize($task['description'])); ?></div>
+                            <?php endif; ?>
+                        </td>
+                        <td><?= sanitize($task['department_name']); ?></td>
+                        <td><span class="tag"><?= sanitize($task['priority']); ?></span></td>
+                        <td><?= sanitize(format_date($task['due_date'])); ?></td>
+                        <td>
+                            <span class="status-badge <?= $statusData['class']; ?>"><?= sanitize($statusData['label']); ?></span>
+                        </td>
+                        <td class="reminder-stamp">
+                            <?= $task['last_reminder'] ? sanitize($task['last_reminder']) : 'Not sent yet'; ?>
+                        </td>
+                        <td>
+                            <div class="table-actions">
+                                <form method="post">
+                                    <input type="hidden" name="action" value="update_status">
+                                    <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
+                                    <select name="status" onchange="this.form.submit()">
+                                        <option value="Pending" <?= $task['status'] === 'Pending' ? 'selected' : ''; ?>>Pending</option>
+                                        <option value="In Progress" <?= $task['status'] === 'In Progress' ? 'selected' : ''; ?>>In progress</option>
+                                        <option value="Completed" <?= $task['status'] === 'Completed' ? 'selected' : ''; ?>>Completed</option>
+                                    </select>
+                                </form>
+                                <button type="button" class="reminder-button" data-task-id="<?= (int)$task['id']; ?>">Send reminder</button>
+                                <form method="post" onsubmit="return confirm('Are you sure you want to delete this task?');">
+                                    <input type="hidden" name="action" value="delete">
+                                    <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
+                                    <button type="submit" class="secondary">Delete</button>
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endif; ?>
+            </tbody>
+        </table>
+    </div>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- translate the dashboard, navigation, and shared layout to English while updating typography and table alignment for LTR use
- update task, department, reminder, and helper logic strings plus schema defaults to English wording
- rewrite the README in English with setup, database, and customization guidance

## Testing
- php -l index.php
- php -l tasks.php
- php -l departments.php
- php -l send_reminder.php

------
https://chatgpt.com/codex/tasks/task_e_68ed33eeec68832cba2eeea9e2c18e2b