### PR TITLE
Polish UI styling and seed sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# Department Task Management System
+
+A lightweight web portal for coordinating departmental work. The interface is built with HTML, CSS, and JavaScript, while PHP powers the backend and connects the application to a MySQL database (compatible with MAMP on macOS).
+
+## Key features
+- Dashboard with quick metrics, upcoming deadlines, and reminder history.
+- Full CRUD workflow for departmental tasks (create, update status, delete).
+- Department directory with optional contact email and automatic seeding of the provided fourteen departments.
+- Reminder logging endpoint to record when a follow-up notification is sent.
+
+## Requirements
+- PHP 8 or newer.
+- MySQL server (the default MAMP database works well).
+- Web server such as Apache bundled with MAMP.
+
+## Getting started with MAMP
+1. Copy the project into your MAMP web directory (typically `/Applications/MAMP/htdocs`).
+2. Open phpMyAdmin through `http://localhost/phpMyAdmin`.
+3. Import the database schema located at `database/schema.sql` to create tables, default department rows, and sample task data tha
+t populates the dashboard immediately.
+4. Update the connection values in `db.php` if your credentials differ. The defaults are:
+   - Username: `root`
+   - Password: `root`
+   - Database: `task_manager`
+5. Start MAMP servers and visit `http://localhost/tatarwar/index.php` (or the folder name you chose) to access the portal.
+
+## Database structure
+- `departments`: stores department names and optional email contacts.
+- `tasks`: tracks task details, responsible department, priority, status, and due date.
+- `notifications`: records reminder messages tied to tasks.
+
+## Project structure
+```
+.
+├── assets
+│   ├── css
+│   │   └── style.css
+│   └── js
+│       └── app.js
+├── database
+│   └── schema.sql
+├── includes
+│   ├── footer.php
+│   ├── functions.php
+│   └── header.php
+├── db.php
+├── index.php
+├── tasks.php
+├── departments.php
+└── README.md
+```
+
+## Customising the platform
+- Update the colour palette or typography in `assets/css/style.css`.
+- Extend the reminder logic in `send_reminder.php` to trigger actual emails or integrations.
+- Modify the `departments.php` form to capture additional metadata as required.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,517 @@
+:root {
+    --primary: #2563eb;
+    --primary-dark: #1d4ed8;
+    --accent: #f97316;
+    --background: #f4f6fb;
+    --surface: #ffffff;
+    --text-main: #0f172a;
+    --text-muted: #64748b;
+    --border: #e2e8f0;
+    --success: #10b981;
+    --danger: #ef4444;
+    --warning: #f59e0b;
+    --shadow: 0 18px 40px rgba(37, 99, 235, 0.12);
+    --shadow-soft: 0 10px 24px rgba(15, 23, 42, 0.08);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Plus Jakarta Sans', 'Inter', 'Segoe UI', Tahoma, sans-serif;
+    background: linear-gradient(180deg, #eef2ff 0%, #f8fafc 60%, #f4f6fb 100%);
+    color: var(--text-main);
+    line-height: 1.65;
+}
+
+.main-header {
+    background: radial-gradient(120% 120% at 100% 0%, rgba(37, 99, 235, 0.95) 0%, rgba(29, 78, 216, 0.9) 45%, rgba(15, 23, 42, 0.95) 100%);
+    color: #fff;
+    padding: 1.8rem 3.2rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+    box-shadow: var(--shadow);
+    border-bottom-left-radius: 28px;
+    border-bottom-right-radius: 28px;
+}
+
+.branding {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.logo-circle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 60px;
+    height: 60px;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.18);
+    font-weight: 700;
+    font-size: 1.25rem;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
+    backdrop-filter: blur(6px);
+}
+
+.main-header h1 {
+    margin: 0;
+    font-size: 1.9rem;
+    letter-spacing: -0.5px;
+}
+
+.main-header p {
+    margin: 0.35rem 0 0;
+    color: rgba(255, 255, 255, 0.78);
+    font-weight: 500;
+    letter-spacing: 0.3px;
+}
+
+nav {
+    display: flex;
+    gap: 0.8rem;
+    flex-wrap: wrap;
+}
+
+nav a {
+    color: rgba(255, 255, 255, 0.88);
+    text-decoration: none;
+    font-weight: 600;
+    padding: 0.55rem 1.2rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    letter-spacing: 0.25px;
+}
+
+nav a.active,
+nav a:hover {
+    color: #0f172a;
+    background: #fff;
+    border-color: rgba(255, 255, 255, 0.45);
+    transform: translateY(-1px);
+}
+
+.container {
+    max-width: 1240px;
+    margin: 2.5rem auto 3.5rem;
+    padding: 0 1.8rem;
+}
+
+.grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.grid-3 {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+    background: var(--surface);
+    border-radius: 22px;
+    padding: 1.8rem;
+    box-shadow: var(--shadow-soft);
+    position: relative;
+    border: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.card h2,
+.card h3 {
+    margin-top: 0;
+}
+
+.stat-grid {
+    margin-bottom: 1.8rem;
+}
+
+.stat-card {
+    display: flex;
+    align-items: center;
+    gap: 1.4rem;
+    overflow: hidden;
+    position: relative;
+    padding: 1.8rem 1.9rem;
+    background: linear-gradient(130deg, rgba(255, 255, 255, 0.92) 0%, rgba(241, 245, 255, 0.95) 55%, rgba(226, 232, 240, 0.8) 100%);
+}
+
+.stat-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 22px;
+    pointer-events: none;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.stat-icon {
+    width: 62px;
+    height: 62px;
+    border-radius: 20px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: #fff;
+    flex-shrink: 0;
+    box-shadow: 0 15px 30px rgba(15, 23, 42, 0.16);
+}
+
+.icon-total {
+    background: linear-gradient(135deg, #2563eb, #60a5fa);
+}
+
+.icon-open {
+    background: linear-gradient(135deg, #f97316, #fb923c);
+}
+
+.icon-complete {
+    background: linear-gradient(135deg, #10b981, #34d399);
+}
+
+.stat-content span.label {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 1.6px;
+    color: var(--text-muted);
+    font-weight: 700;
+}
+
+.stat-value {
+    font-size: 2.8rem;
+    font-weight: 800;
+    letter-spacing: -1px;
+    margin: 0.2rem 0 0.4rem;
+    color: var(--text-main);
+}
+
+.stat-description {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.table-wrapper {
+    overflow-x: auto;
+    border-radius: 16px;
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    background: rgba(248, 250, 252, 0.6);
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th, td {
+    padding: 1rem 1.1rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+}
+
+th {
+    background: linear-gradient(90deg, rgba(226, 232, 240, 0.8) 0%, rgba(241, 245, 249, 0.95) 100%);
+    font-weight: 700;
+    color: var(--text-main);
+    font-size: 0.9rem;
+}
+
+tr:hover {
+    background: rgba(226, 232, 240, 0.25);
+}
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.status-overdue {
+    background: rgba(230, 57, 70, 0.1);
+    color: var(--danger);
+}
+
+.status-warning {
+    background: rgba(255, 183, 3, 0.15);
+    color: var(--warning);
+}
+
+.status-open {
+    background: rgba(31, 122, 140, 0.12);
+    color: var(--primary-dark);
+}
+
+.status-complete {
+    background: rgba(46, 184, 114, 0.15);
+    color: var(--success);
+}
+
+.form-card form {
+    display: grid;
+    gap: 1rem;
+}
+
+.form-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+label {
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+    display: inline-block;
+}
+
+input[type="text"],
+input[type="date"],
+input[type="email"],
+select,
+textarea {
+    width: 100%;
+    padding: 0.85rem 1.1rem;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 14px;
+    font-family: inherit;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    background: rgba(255, 255, 255, 0.92);
+}
+
+textarea {
+    min-height: 120px;
+    resize: vertical;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+button,
+.button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.8rem 2.1rem;
+    font-family: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    background: linear-gradient(135deg, #2563eb, #4f46e5);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: center;
+    letter-spacing: 0.3px;
+    box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+}
+
+button:hover,
+.button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 32px rgba(79, 70, 229, 0.28);
+}
+
+button.secondary {
+    background: rgba(37, 99, 235, 0.1);
+    color: var(--primary-dark);
+    border: 1px solid rgba(37, 99, 235, 0.28);
+    box-shadow: none;
+}
+
+.button.ghost,
+button.ghost {
+    background: rgba(15, 23, 42, 0.04);
+    color: var(--text-main);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    box-shadow: none;
+}
+
+.badge {
+    display: inline-block;
+    padding: 0.35rem 0.95rem;
+    border-radius: 999px;
+    background: rgba(37, 99, 235, 0.1);
+    color: var(--primary-dark);
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.4px;
+}
+
+.alert {
+    padding: 0.8rem 1rem;
+    border-radius: 12px;
+    margin-bottom: 1rem;
+    font-weight: 600;
+}
+
+.alert.success {
+    background: rgba(16, 185, 129, 0.16);
+    color: var(--success);
+    border: 1px solid rgba(16, 185, 129, 0.25);
+}
+
+.alert.error {
+    background: rgba(239, 68, 68, 0.12);
+    color: var(--danger);
+    border: 1px solid rgba(239, 68, 68, 0.25);
+}
+
+.timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.timeline li {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.8rem 0;
+    border-bottom: 1px dashed var(--border);
+}
+
+.timeline li:last-child {
+    border-bottom: none;
+}
+
+.empty-state {
+    text-align: center;
+    color: var(--text-muted);
+    padding: 2rem 1rem;
+}
+
+.metric-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+}
+
+.metric-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.8rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.05);
+    color: var(--text-main);
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.metric-pill .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--primary);
+}
+
+.table-number {
+    font-weight: 700;
+    color: var(--text-main);
+}
+
+.table-number.muted {
+    color: var(--text-muted);
+}
+
+@media (max-width: 768px) {
+    .main-header {
+        padding: 1.6rem;
+    }
+
+    nav a {
+        margin: 0;
+    }
+
+    .stat-card {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+.main-footer {
+    text-align: center;
+    padding: 2rem 1rem;
+    color: var(--text-muted);
+}
+
+.table-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.table-actions form {
+    margin: 0;
+}
+
+.table-actions .button,
+.table-actions button {
+    padding: 0.55rem 1.4rem;
+    font-size: 0.82rem;
+    box-shadow: 0 10px 22px rgba(15, 23, 42, 0.12);
+}
+
+.table-actions select {
+    border-radius: 999px;
+    padding: 0.55rem 1.1rem;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    background: rgba(248, 250, 252, 0.9);
+    font-weight: 600;
+}
+
+.table-actions select:focus {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.tag {
+    display: inline-block;
+    padding: 0.2rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(15, 82, 87, 0.1);
+    color: var(--primary-dark);
+    font-size: 0.75rem;
+}
+
+.reminder-button {
+    background: linear-gradient(135deg, var(--accent), #fb923c);
+    box-shadow: 0 12px 24px rgba(249, 115, 22, 0.28);
+}
+
+.toast {
+    position: fixed;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #fff;
+    color: var(--text-main);
+    padding: 1rem 1.5rem;
+    border-radius: 16px;
+    box-shadow: var(--shadow);
+    display: none;
+    min-width: 280px;
+    text-align: center;
+}
+
+.toast.show {
+    display: block;
+}
+
+.text-muted {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,41 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const toast = document.createElement('div');
+    toast.className = 'toast';
+    document.body.appendChild(toast);
+
+    function showToast(message, type = 'success') {
+        toast.textContent = message;
+        toast.classList.remove('error', 'success');
+        toast.classList.add('show', type);
+        setTimeout(() => toast.classList.remove('show'), 3000);
+    }
+
+    document.querySelectorAll('.reminder-button').forEach(button => {
+        button.addEventListener('click', async () => {
+            const taskId = button.dataset.taskId;
+            button.disabled = true;
+            try {
+                const response = await fetch('send_reminder.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ taskId })
+                });
+
+                const result = await response.json();
+                if (response.ok) {
+                    showToast(result.message, 'success');
+                    const stamp = button.closest('tr').querySelector('.reminder-stamp');
+                    if (stamp) {
+                        stamp.textContent = result.lastReminder;
+                    }
+                } else {
+                    throw new Error(result.message || 'Unable to send reminder');
+                }
+            } catch (error) {
+                showToast(error.message, 'error');
+            } finally {
+                button.disabled = false;
+            }
+        });
+    });
+});

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,107 @@
+CREATE DATABASE IF NOT EXISTS task_manager CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE task_manager;
+
+CREATE TABLE IF NOT EXISTS departments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    email VARCHAR(190) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(180) NOT NULL,
+    description TEXT NULL,
+    department_id INT NOT NULL,
+    priority VARCHAR(20) DEFAULT 'Medium',
+    status VARCHAR(30) DEFAULT 'Pending',
+    due_date DATE NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_tasks_departments FOREIGN KEY (department_id) REFERENCES departments(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    task_id INT NOT NULL,
+    message TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_notifications_tasks FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO departments (name) VALUES
+    ('Office of the Secretary General'),
+    ('General Department of Information Technology'),
+    ('Cybersecurity Department'),
+    ('Investment Agency'),
+    ('General Department of Gardens and Landscaping'),
+    ('General Department of Internal Audits'),
+    ('General Department of Operations and Emergencies'),
+    ('Department of Safety and Security'),
+    ('Central Unit for Plan Approval'),
+    ('Department of Land Affairs'),
+    ('Environmental Health Department'),
+    ('General Department of Cleaning'),
+    ('Central City Municipality'),
+    ('Northern Municipality')
+ON DUPLICATE KEY UPDATE name = VALUES(name);
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Digital Infrastructure Audit', 'Complete the resiliency assessment for core datacenter services and report findings to the steering committee.', d.id, 'High', 'In Progress', DATE_ADD(CURDATE(), INTERVAL 5 DAY), NOW(), NOW()
+FROM departments d
+WHERE d.name = 'General Department of Information Technology'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Digital Infrastructure Audit' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Emergency Drill Readiness', 'Confirm equipment checklists and submit the cross-department readiness memo ahead of the city-wide drill.', d.id, 'Medium', 'Pending', DATE_ADD(CURDATE(), INTERVAL 2 DAY), NOW(), NOW()
+FROM departments d
+WHERE d.name = 'General Department of Operations and Emergencies'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Emergency Drill Readiness' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Investment Portfolio Review', 'Prepare quarterly briefing with performance highlights and risk actions for executive approval.', d.id, 'Medium', 'Completed', DATE_SUB(CURDATE(), INTERVAL 1 DAY), DATE_SUB(NOW(), INTERVAL 6 DAY), DATE_SUB(NOW(), INTERVAL 1 DAY)
+FROM departments d
+WHERE d.name = 'Investment Agency'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Investment Portfolio Review' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Public Park Revitalization', 'Finalize vendor contracts for the Riverside Park renovation and submit landscaping schedules.', d.id, 'High', 'Pending', DATE_SUB(CURDATE(), INTERVAL 3 DAY), DATE_SUB(NOW(), INTERVAL 14 DAY), DATE_SUB(NOW(), INTERVAL 3 DAY)
+FROM departments d
+WHERE d.name = 'General Department of Gardens and Landscaping'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Public Park Revitalization' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'City Clean-Up Campaign', 'Launch the awareness campaign and coordinate resources with district offices.', d.id, 'Low', 'In Progress', DATE_ADD(CURDATE(), INTERVAL 9 DAY), DATE_SUB(NOW(), INTERVAL 2 DAY), NOW()
+FROM departments d
+WHERE d.name = 'General Department of Cleaning'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'City Clean-Up Campaign' AND t.department_id = d.id
+  );
+
+INSERT INTO notifications (task_id, message, created_at)
+SELECT t.id, 'Reminder sent to confirm infrastructure resiliency updates.', DATE_SUB(NOW(), INTERVAL 1 DAY)
+FROM tasks t
+JOIN departments d ON d.id = t.department_id
+WHERE t.title = 'Digital Infrastructure Audit'
+  AND d.name = 'General Department of Information Technology'
+  AND NOT EXISTS (
+      SELECT 1 FROM notifications n WHERE n.task_id = t.id
+  );
+
+INSERT INTO notifications (task_id, message, created_at)
+SELECT t.id, 'Follow-up issued for upcoming emergency readiness drill.', DATE_SUB(NOW(), INTERVAL 6 HOUR)
+FROM tasks t
+JOIN departments d ON d.id = t.department_id
+WHERE t.title = 'Emergency Drill Readiness'
+  AND d.name = 'General Department of Operations and Emergencies'
+  AND NOT EXISTS (
+      SELECT 1 FROM notifications n WHERE n.task_id = t.id
+  );

--- a/db.php
+++ b/db.php
@@ -1,0 +1,22 @@
+<?php
+$host = getenv('DB_HOST') ?: 'localhost';
+$port = getenv('DB_PORT') ?: '3306';
+$name = getenv('DB_NAME') ?: 'task_manager';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASSWORD') !== false ? getenv('DB_PASSWORD') : 'root';
+$charset = 'utf8mb4';
+$dsn = "mysql:host={$host};port={$port};dbname={$name};charset={$charset}";
+$options = [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $exception) {
+    http_response_code(500);
+    echo '<h1>Unable to connect to the database</h1>';
+    echo '<p>' . htmlspecialchars($exception->getMessage(), ENT_QUOTES, 'UTF-8') . '</p>';
+    exit;
+}

--- a/departments.php
+++ b/departments.php
@@ -1,0 +1,115 @@
+<?php
+$pageTitle = 'Departments';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$errors = [];
+$success = '';
+
+$defaultDepartments = [
+    'Office of the Secretary General',
+    'General Department of Information Technology',
+    'Cybersecurity Department',
+    'Investment Agency',
+    'General Department of Gardens and Landscaping',
+    'General Department of Internal Audits',
+    'General Department of Operations and Emergencies',
+    'Department of Safety and Security',
+    'Central Unit for Plan Approval',
+    'Department of Land Affairs',
+    'Environmental Health Department',
+    'General Department of Cleaning',
+    'Central City Municipality',
+    'Northern Municipality',
+];
+
+$count = (int)$pdo->query('SELECT COUNT(*) FROM departments')->fetchColumn();
+if ($count === 0) {
+    $insert = $pdo->prepare('INSERT INTO departments (name) VALUES (:name)');
+    foreach ($defaultDepartments as $departmentName) {
+        $insert->execute(['name' => $departmentName]);
+    }
+    $success = 'Default departments were added automatically.';
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+
+    if ($name === '') {
+        $errors[] = 'Department name is required.';
+    }
+
+    if (empty($errors)) {
+        $stmt = $pdo->prepare('INSERT INTO departments (name, email) VALUES (:name, :email)');
+        $stmt->execute([
+            'name' => $name,
+            'email' => $email ?: null,
+        ]);
+        $success = 'Department created successfully.';
+    }
+}
+
+$departments = $pdo->query('SELECT d.*, COUNT(t.id) AS tasks_count,
+    SUM(CASE WHEN t.status = "Completed" THEN 1 ELSE 0 END) AS completed_count
+    FROM departments d
+    LEFT JOIN tasks t ON t.department_id = d.id
+    GROUP BY d.id
+    ORDER BY d.name ASC')->fetchAll();
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="grid" style="grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">
+    <article class="card form-card">
+        <h2>Add Department</h2>
+        <p class="text-muted">Create a new department to assign work</p>
+        <?php if ($errors): ?>
+            <div class="alert error">
+                <?= implode('<br>', array_map('sanitize', $errors)); ?>
+            </div>
+        <?php endif; ?>
+        <?php if ($success && !$errors): ?>
+            <div class="alert success"><?= sanitize($success); ?></div>
+        <?php endif; ?>
+        <form method="post">
+            <div>
+                <label for="name">Department name</label>
+                <input type="text" id="name" name="name" required>
+            </div>
+            <div>
+                <label for="email">Email (optional)</label>
+                <input type="email" id="email" name="email" placeholder="team@example.com">
+            </div>
+            <button type="submit">Add department</button>
+        </form>
+    </article>
+    <article class="card">
+        <div class="metric-header">
+            <h2>Departments list</h2>
+            <span class="metric-pill"><span class="dot"></span><?= number_format(count($departments)); ?> units</span>
+        </div>
+        <div class="table-wrapper">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Department</th>
+                        <th>Email</th>
+                        <th>Total tasks</th>
+                        <th>Completed</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($departments as $department): ?>
+                        <tr>
+                            <td><?= sanitize($department['name']); ?></td>
+                            <td><?= $department['email'] ? sanitize($department['email']) : '-'; ?></td>
+                            <td><span class="table-number"><?= number_format((int)$department['tasks_count']); ?></span></td>
+                            <td><span class="table-number muted"><?= number_format((int)$department['completed_count']); ?></span></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </article>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,0 +1,7 @@
+    </main>
+    <footer class="main-footer">
+        <p>© <?= date('Y'); ?> Department Task Management Platform</p>
+    </footer>
+    <script src="assets/js/app.js"></script>
+</body>
+</html>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,70 @@
+<?php
+if (!ini_get('date.timezone')) {
+    date_default_timezone_set('Asia/Riyadh');
+}
+
+function sanitize(string $value = null): string
+{
+    return htmlspecialchars($value ?? '', ENT_QUOTES, 'UTF-8');
+}
+
+function analyze_due_status(?string $dueDate, string $status = 'In Progress'): array
+{
+    $today = new DateTimeImmutable('today');
+    if (strtolower($status) === 'completed') {
+        return [
+            'label' => 'Completed',
+            'class' => 'status-complete',
+        ];
+    }
+
+    if (!$dueDate) {
+        return [
+            'label' => 'No due date',
+            'class' => 'status-open',
+        ];
+    }
+
+    try {
+        $due = new DateTimeImmutable($dueDate);
+    } catch (Exception $e) {
+        return [
+            'label' => 'Invalid due date',
+            'class' => 'status-open',
+        ];
+    }
+
+    if ($due < $today) {
+        return [
+            'label' => 'Overdue',
+            'class' => 'status-overdue',
+        ];
+    }
+
+    $diff = $today->diff($due)->days;
+
+    if ($diff <= 3) {
+        return [
+            'label' => 'Due soon',
+            'class' => 'status-warning',
+        ];
+    }
+
+    return [
+        'label' => 'On track',
+        'class' => 'status-open',
+    ];
+}
+
+function format_date(?string $date): string
+{
+    if (!$date) {
+        return '-';
+    }
+
+    try {
+        return (new DateTimeImmutable($date))->format('Y-m-d');
+    } catch (Exception $e) {
+        return $date;
+    }
+}

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,31 @@
+<?php
+require_once __DIR__ . '/../includes/functions.php';
+$pageTitle = $pageTitle ?? 'Task Management Hub';
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= sanitize($pageTitle); ?></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+    <header class="main-header">
+        <div class="branding">
+            <span class="logo-circle">TM</span>
+            <div>
+                <h1>Enterprise Task Management</h1>
+                <p>Coordinate assignments across departments with confidence</p>
+            </div>
+        </div>
+        <nav>
+            <a href="index.php" class="<?= basename($_SERVER['PHP_SELF']) === 'index.php' ? 'active' : ''; ?>">Dashboard</a>
+            <a href="tasks.php" class="<?= basename($_SERVER['PHP_SELF']) === 'tasks.php' ? 'active' : ''; ?>">Tasks</a>
+            <a href="departments.php" class="<?= basename($_SERVER['PHP_SELF']) === 'departments.php' ? 'active' : ''; ?>">Departments</a>
+        </nav>
+    </header>
+    <main class="container">

--- a/index.php
+++ b/index.php
@@ -1,0 +1,101 @@
+<?php
+$pageTitle = 'Dashboard';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$totalTasks = (int)$pdo->query('SELECT COUNT(*) FROM tasks')->fetchColumn();
+$openTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status IN ('Pending', 'In Progress')")->fetchColumn();
+$completedTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status = 'Completed'")->fetchColumn();
+$overdueTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status != 'Completed' AND due_date IS NOT NULL AND due_date < CURDATE()")
+    ->fetchColumn();
+
+$upcomingTasks = $pdo->query("SELECT t.id, t.title, t.due_date, d.name AS department_name
+    FROM tasks t
+    JOIN departments d ON d.id = t.department_id
+    WHERE t.status != 'Completed' AND t.due_date IS NOT NULL AND t.due_date >= CURDATE()
+    ORDER BY t.due_date ASC
+    LIMIT 6")->fetchAll();
+
+$latestNotifications = $pdo->query("SELECT n.message, DATE_FORMAT(n.created_at, '%Y-%m-%d %H:%i') AS created_at,
+    t.title AS task_title
+    FROM notifications n
+    JOIN tasks t ON t.id = n.task_id
+    ORDER BY n.created_at DESC
+    LIMIT 5")->fetchAll();
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="grid grid-3 stat-grid">
+    <article class="card stat-card">
+        <span class="stat-icon icon-total" aria-hidden="true">Σ</span>
+        <div class="stat-content">
+            <span class="label">Total Tasks</span>
+            <div class="stat-value"><?= number_format($totalTasks); ?></div>
+            <p class="stat-description">All assignments currently tracked across departments.</p>
+        </div>
+    </article>
+    <article class="card stat-card">
+        <span class="stat-icon icon-open" aria-hidden="true">⏳</span>
+        <div class="stat-content">
+            <span class="label">Open Tasks</span>
+            <div class="stat-value"><?= number_format($openTasks); ?></div>
+            <p class="stat-description">In-progress or awaiting action before their deadlines.</p>
+        </div>
+    </article>
+    <article class="card stat-card">
+        <span class="stat-icon icon-complete" aria-hidden="true">✔</span>
+        <div class="stat-content">
+            <span class="label">Completed Tasks</span>
+            <div class="stat-value"><?= number_format($completedTasks); ?></div>
+            <p class="stat-description">Tasks signed off and closed by department owners.</p>
+        </div>
+    </article>
+</section>
+
+<section class="grid" style="margin-top: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">
+    <article class="card">
+        <h2>Upcoming Deadlines</h2>
+        <?php if (!$upcomingTasks): ?>
+            <div class="empty-state">No upcoming due dates found.</div>
+        <?php else: ?>
+            <ul class="timeline">
+                <?php foreach ($upcomingTasks as $task): ?>
+                    <li>
+                        <div>
+                            <strong><?= sanitize($task['title']); ?></strong>
+                            <div class="text-muted">Department: <?= sanitize($task['department_name']); ?></div>
+                        </div>
+                        <span class="badge">Due: <?= sanitize(format_date($task['due_date'])); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </article>
+    <article class="card">
+        <h2>Delivery Alerts</h2>
+        <?php if (!$latestNotifications): ?>
+            <div class="empty-state">No reminders sent yet.</div>
+        <?php else: ?>
+            <ul class="timeline">
+                <?php foreach ($latestNotifications as $notification): ?>
+                    <li>
+                        <div>
+                            <strong><?= sanitize($notification['task_title']); ?></strong>
+                            <div class="text-muted"><?= sanitize($notification['message']); ?></div>
+                        </div>
+                        <span class="badge"><?= sanitize($notification['created_at']); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </article>
+    <article class="card">
+        <div class="metric-header">
+            <h2>Overdue Tasks</h2>
+            <span class="metric-pill"><span class="dot"></span><?= number_format($overdueTasks); ?> overdue</span>
+        </div>
+        <p class="stat-description">Keep delivery on track by nudging owners and reviewing blockers.</p>
+        <a href="tasks.php" class="button ghost">Review tasks and resolve delays</a>
+    </article>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/send_reminder.php
+++ b/send_reminder.php
@@ -1,0 +1,46 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['message' => 'Request method not allowed']);
+    exit;
+}
+
+$payload = json_decode(file_get_contents('php://input'), true) ?? [];
+$taskId = isset($payload['taskId']) ? (int) $payload['taskId'] : 0;
+
+if (!$taskId) {
+    http_response_code(400);
+    echo json_encode(['message' => 'Unknown task']);
+    exit;
+}
+
+require_once __DIR__ . '/db.php';
+
+$taskStmt = $pdo->prepare('SELECT id, title, due_date FROM tasks WHERE id = :id');
+$taskStmt->execute(['id' => $taskId]);
+$task = $taskStmt->fetch();
+
+if (!$task) {
+    http_response_code(404);
+    echo json_encode(['message' => 'Task not found']);
+    exit;
+}
+
+$message = sprintf('Reminder for task "%s". Due date: %s', $task['title'], $task['due_date'] ?: 'No due date');
+
+$insert = $pdo->prepare('INSERT INTO notifications (task_id, message, created_at) VALUES (:task_id, :message, NOW())');
+$insert->execute([
+    'task_id' => $taskId,
+    'message' => $message,
+]);
+
+$lastReminder = $pdo->prepare('SELECT DATE_FORMAT(created_at, "%Y-%m-%d %H:%i") as created_at FROM notifications WHERE task_id = :task_id ORDER BY created_at DESC LIMIT 1');
+$lastReminder->execute(['task_id' => $taskId]);
+$stamp = $lastReminder->fetchColumn();
+
+echo json_encode([
+    'message' => 'Reminder sent successfully',
+    'lastReminder' => $stamp,
+]);

--- a/tasks.php
+++ b/tasks.php
@@ -1,0 +1,192 @@
+<?php
+$pageTitle = 'Task Management';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$errors = [];
+$success = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'create') {
+        $title = trim($_POST['title'] ?? '');
+        $departmentId = (int)($_POST['department_id'] ?? 0);
+        $priority = $_POST['priority'] ?? 'Medium';
+        $dueDate = $_POST['due_date'] ?? null;
+        $description = trim($_POST['description'] ?? '');
+
+        if ($title === '') {
+            $errors[] = 'Task title is required.';
+        }
+
+        if ($departmentId <= 0) {
+            $errors[] = 'Select a responsible department.';
+        }
+
+        if (empty($errors)) {
+            $stmt = $pdo->prepare('INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+                VALUES (:title, :description, :department_id, :priority, :status, :due_date, NOW(), NOW())');
+            $stmt->execute([
+                'title' => $title,
+                'description' => $description,
+                'department_id' => $departmentId,
+                'priority' => $priority,
+                'status' => 'Pending',
+                'due_date' => $dueDate ?: null,
+            ]);
+
+            $success = 'Task created successfully.';
+        }
+    } elseif ($action === 'update_status') {
+        $taskId = (int)($_POST['task_id'] ?? 0);
+        $status = $_POST['status'] ?? 'Pending';
+
+        if ($taskId > 0) {
+            $update = $pdo->prepare('UPDATE tasks SET status = :status, updated_at = NOW() WHERE id = :id');
+            $update->execute([
+                'status' => $status,
+                'id' => $taskId,
+            ]);
+            $success = 'Task status updated.';
+        }
+    } elseif ($action === 'delete') {
+        $taskId = (int)($_POST['task_id'] ?? 0);
+        if ($taskId > 0) {
+            $pdo->prepare('DELETE FROM notifications WHERE task_id = :id')->execute(['id' => $taskId]);
+            $pdo->prepare('DELETE FROM tasks WHERE id = :id')->execute(['id' => $taskId]);
+            $success = 'Task deleted.';
+        }
+    }
+}
+
+$departments = $pdo->query('SELECT id, name FROM departments ORDER BY name ASC')->fetchAll();
+
+$tasksStmt = $pdo->query('SELECT t.*, d.name AS department_name,
+    (SELECT DATE_FORMAT(n.created_at, "%Y-%m-%d %H:%i") FROM notifications n WHERE n.task_id = t.id ORDER BY n.created_at DESC LIMIT 1) AS last_reminder
+    FROM tasks t
+    JOIN departments d ON t.department_id = d.id
+    ORDER BY t.due_date IS NULL, t.due_date ASC, t.created_at DESC');
+$tasks = $tasksStmt->fetchAll();
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="grid grid-3">
+    <article class="card form-card">
+        <h2>Create Task</h2>
+        <p class="text-muted">Assign work to departments and set due dates</p>
+        <?php if ($errors): ?>
+            <div class="alert error">
+                <?= implode('<br>', array_map('sanitize', $errors)); ?>
+            </div>
+        <?php endif; ?>
+        <?php if ($success && !$errors): ?>
+            <div class="alert success"><?= sanitize($success); ?></div>
+        <?php endif; ?>
+        <form method="post">
+            <input type="hidden" name="action" value="create">
+            <div>
+                <label for="title">Task title</label>
+                <input type="text" id="title" name="title" required>
+            </div>
+            <div class="form-grid">
+                <div>
+                    <label for="department_id">Department</label>
+                    <select id="department_id" name="department_id" required>
+                        <option value="">Select department</option>
+                        <?php foreach ($departments as $department): ?>
+                            <option value="<?= (int)$department['id']; ?>"><?= sanitize($department['name']); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div>
+                    <label for="priority">Priority</label>
+                    <select id="priority" name="priority">
+                        <option value="High">High</option>
+                        <option value="Medium" selected>Medium</option>
+                        <option value="Low">Low</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="due_date">Due date</label>
+                    <input type="date" id="due_date" name="due_date">
+                </div>
+            </div>
+            <div>
+                <label for="description">Task description</label>
+                <textarea id="description" name="description" placeholder="Add details and instructions"></textarea>
+            </div>
+            <button type="submit">Save task</button>
+        </form>
+    </article>
+</section>
+
+<section class="card">
+    <div class="metric-header">
+        <h2>Task log</h2>
+        <span class="metric-pill"><span class="dot"></span><?= number_format(count($tasks)); ?> tasks</span>
+    </div>
+    <div class="table-wrapper">
+        <table>
+            <thead>
+                <tr>
+                    <th>Task</th>
+                    <th>Department</th>
+                    <th>Priority</th>
+                    <th>Due date</th>
+                    <th>Status</th>
+                    <th>Last reminder</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+            <?php if (!$tasks): ?>
+                <tr>
+                    <td colspan="7" class="empty-state">No tasks yet. Start by adding assignments for departments.</td>
+                </tr>
+            <?php else: ?>
+                <?php foreach ($tasks as $task): ?>
+                    <?php $statusData = analyze_due_status($task['due_date'], $task['status']); ?>
+                    <tr>
+                        <td>
+                            <strong><?= sanitize($task['title']); ?></strong>
+                            <?php if ($task['description']): ?>
+                                <div class="text-muted"><?= nl2br(sanitize($task['description'])); ?></div>
+                            <?php endif; ?>
+                        </td>
+                        <td><?= sanitize($task['department_name']); ?></td>
+                        <td><span class="tag"><?= sanitize($task['priority']); ?></span></td>
+                        <td><?= sanitize(format_date($task['due_date'])); ?></td>
+                        <td>
+                            <span class="status-badge <?= $statusData['class']; ?>"><?= sanitize($statusData['label']); ?></span>
+                        </td>
+                        <td class="reminder-stamp">
+                            <?= $task['last_reminder'] ? sanitize($task['last_reminder']) : 'Not sent yet'; ?>
+                        </td>
+                        <td>
+                            <div class="table-actions">
+                                <form method="post">
+                                    <input type="hidden" name="action" value="update_status">
+                                    <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
+                                    <select name="status" onchange="this.form.submit()">
+                                        <option value="Pending" <?= $task['status'] === 'Pending' ? 'selected' : ''; ?>>Pending</option>
+                                        <option value="In Progress" <?= $task['status'] === 'In Progress' ? 'selected' : ''; ?>>In progress</option>
+                                        <option value="Completed" <?= $task['status'] === 'Completed' ? 'selected' : ''; ?>>Completed</option>
+                                    </select>
+                                </form>
+                                <button type="button" class="button reminder-button" data-task-id="<?= (int)$task['id']; ?>">Send reminder</button>
+                                <form method="post" onsubmit="return confirm('Are you sure you want to delete this task?');">
+                                    <input type="hidden" name="action" value="delete">
+                                    <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
+                                    <button type="submit" class="button ghost">Delete</button>
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endif; ?>
+            </tbody>
+        </table>
+    </div>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- refresh the shared layout with a new Plus Jakarta Sans typeface, updated color palette, and elevated stat cards and buttons
- enhance task and department tables with formatted metrics, action styling, and number formatting
- seed the schema with illustrative tasks and reminders plus document the sample data in the setup guide

## Testing
- php -l index.php
- php -l tasks.php
- php -l departments.php
- php -l send_reminder.php

------
https://chatgpt.com/codex/tasks/task_e_68ed33eeec68832cba2eeea9e2c18e2b