### PR TITLE
Adopt TaskFlow-style workspace layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# Department Task Management System
+
+A lightweight web portal for coordinating departmental work. The interface is built with HTML, CSS, and JavaScript, while PHP powers the backend and connects the application to a MySQL database (compatible with MAMP on macOS).
+
+## Key features
+- Dashboard with quick metrics, upcoming deadlines, and reminder history.
+- Full CRUD workflow for departmental tasks (create, update status, delete).
+- Department directory with optional contact email and automatic seeding of the provided fourteen departments.
+- Reminder logging endpoint to record when a follow-up notification is sent.
+- Figma-inspired interface with gradient hero header, glassmorphism cards, and responsive insight chips for a polished presentation.
+
+## Requirements
+- PHP 8 or newer.
+- MySQL server (the default MAMP database works well).
+- Web server such as Apache bundled with MAMP.
+
+## Getting started with MAMP
+1. Copy the project into your MAMP web directory (typically `/Applications/MAMP/htdocs`).
+2. Open phpMyAdmin through `http://localhost/phpMyAdmin`.
+3. Import the database schema located at `database/schema.sql`. It creates tables, seeds the fourteen departments, and loads a curated sample data set so dashboards and reminders are populated immediately.
+4. Update the connection values in `db.php` if your credentials differ. The defaults are:
+   - Username: `root`
+   - Password: `root`
+   - Database: `task_manager`
+5. Start MAMP servers and visit `http://localhost/tatarwar/index.php` (or the folder name you chose) to access the portal.
+
+## Database structure
+- `departments`: stores department names and optional email contacts.
+- `tasks`: tracks task details, responsible department, priority, status, and due date.
+- `notifications`: records reminder messages tied to tasks.
+
+## Project structure
+```
+.
+├── assets
+│   ├── css
+│   │   └── style.css
+│   └── js
+│       └── app.js
+├── database
+│   └── schema.sql
+├── includes
+│   ├── footer.php
+│   ├── functions.php
+│   └── header.php
+├── db.php
+├── index.php
+├── tasks.php
+├── departments.php
+└── README.md
+```
+
+## Customising the platform
+- Update the colour palette or typography in `assets/css/style.css`.
+- Extend the reminder logic in `send_reminder.php` to trigger actual emails or integrations.
+- Modify the `departments.php` form to capture additional metadata as required.
+
+## Design highlights
+- **Hero workspace shell:** layered gradient header with live status chip and quick access to navigation plus a new task shortcut.
+- **Insight overview cards:** reusable components show task health, overdue counts, and department activity in a glanceable grid.
+- **Elevated data tables:** floating rows, pill badges, and accent chips make task priorities and statuses readable across devices.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,771 @@
+:root {
+    --background: #f5f6fb;
+    --sidebar-bg: #ffffff;
+    --surface: #ffffff;
+    --surface-muted: #f0f2ff;
+    --text-strong: #111827;
+    --text-muted: #6b7280;
+    --border-color: #e5e7eb;
+    --border-strong: #d1d5db;
+    --primary: #6366f1;
+    --primary-strong: #4f46e5;
+    --accent: #10b981;
+    --warning: #f97316;
+    --danger: #ef4444;
+    --radius-lg: 20px;
+    --radius-md: 16px;
+    --radius-sm: 12px;
+    --shadow-sm: 0 10px 30px rgba(15, 23, 42, 0.08);
+    --shadow-xs: 0 6px 18px rgba(15, 23, 42, 0.05);
+    --font-family: 'Plus Jakarta Sans', 'Inter', 'Segoe UI', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: var(--background);
+    color: var(--text-strong);
+    font-family: var(--font-family);
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+.app-shell {
+    display: flex;
+    min-height: 100vh;
+}
+
+.sidebar {
+    width: 260px;
+    background: var(--sidebar-bg);
+    border-right: 1px solid var(--border-color);
+    padding: 2rem 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+}
+
+.sidebar-brand {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.brand-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, #4f46e5, #6366f1);
+    color: #ffffff;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    box-shadow: var(--shadow-xs);
+}
+
+.brand-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.brand-title {
+    font-weight: 700;
+    font-size: 1.15rem;
+}
+
+.brand-subtitle {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.nav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius-sm);
+    color: var(--text-strong);
+    text-decoration: none;
+    font-weight: 500;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-link:hover {
+    background: var(--surface-muted);
+}
+
+.nav-link.active {
+    background: rgba(99, 102, 241, 0.15);
+    color: var(--primary-strong);
+}
+
+.nav-link.muted {
+    color: var(--text-muted);
+    cursor: not-allowed;
+}
+
+.main-area {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 2rem 2.5rem 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+    gap: 1.5rem;
+}
+
+.page-titles h1 {
+    margin: 0;
+    font-size: 1.75rem;
+    letter-spacing: -0.02em;
+}
+
+.page-titles p {
+    margin: 0.25rem 0 0;
+    color: var(--text-muted);
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    background: var(--surface-muted);
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #22c55e;
+}
+
+.primary-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.65rem 1.25rem;
+    border-radius: var(--radius-sm);
+    background: var(--primary);
+    color: #ffffff;
+    text-decoration: none;
+    font-weight: 600;
+    box-shadow: var(--shadow-xs);
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.primary-action:hover {
+    background: var(--primary-strong);
+    transform: translateY(-1px);
+}
+
+.page-content {
+    padding: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.panel {
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    padding: 1.75rem;
+    box-shadow: var(--shadow-sm);
+}
+
+.panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+}
+
+.panel-header h2 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.panel-subtitle {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+}
+
+.metric-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.metric-label {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.metric-value {
+    font-size: 1.9rem;
+    font-weight: 700;
+}
+
+.metric-footnote {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.alert-card {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+    border: 1px solid rgba(239, 68, 68, 0.2);
+    background: rgba(254, 242, 242, 0.9);
+}
+
+.alert-card h2 {
+    margin: 0 0 0.5rem;
+}
+
+.alert-card p {
+    margin: 0;
+    color: #b91c1c;
+}
+
+.link-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.6rem 1.05rem;
+    border-radius: var(--radius-sm);
+    background: #fff;
+    border: 1px solid var(--border-color);
+    color: var(--primary-strong);
+    text-decoration: none;
+    font-weight: 600;
+    transition: border-color 0.2s ease;
+}
+
+.link-button:hover {
+    border-color: var(--primary);
+}
+
+.split-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.25rem;
+}
+
+.deadline-list,
+.activity-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.deadline-item,
+.activity-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.deadline-item strong,
+.activity-item strong {
+    font-size: 0.95rem;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: rgba(99, 102, 241, 0.12);
+    color: var(--primary-strong);
+}
+
+.badge.warning {
+    background: rgba(249, 115, 22, 0.15);
+    color: var(--warning);
+}
+
+.badge.neutral {
+    background: rgba(107, 114, 128, 0.18);
+    color: var(--text-muted);
+}
+
+.performance-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.performance-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.performance-row header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.progress-track {
+    width: 100%;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--surface-muted);
+    overflow: hidden;
+}
+
+.progress-fill {
+    display: block;
+    height: 100%;
+    background: var(--primary);
+    border-radius: inherit;
+}
+
+.progress-meta {
+    display: flex;
+    justify-content: space-between;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+}
+
+.form-panel form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+label {
+    display: block;
+    font-weight: 600;
+    font-size: 0.9rem;
+    margin-bottom: 0.35rem;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="date"],
+select,
+textarea {
+    width: 100%;
+    padding: 0.75rem 0.9rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-color);
+    font-family: inherit;
+    font-size: 0.95rem;
+    transition: border 0.2s ease, box-shadow 0.2s ease;
+    background: #fff;
+}
+
+textarea {
+    min-height: 120px;
+    resize: vertical;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+    outline: none;
+}
+
+button,
+.button {
+    font-family: inherit;
+}
+
+button[type="submit"],
+button.primary {
+    padding: 0.7rem 1.1rem;
+    border-radius: var(--radius-sm);
+    border: none;
+    background: var(--primary);
+    color: #fff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+button[type="submit"]:hover,
+button.primary:hover {
+    background: var(--primary-strong);
+    transform: translateY(-1px);
+}
+
+button.ghost,
+.link-ghost {
+    padding: 0.6rem 1rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-color);
+    background: #fff;
+    color: var(--text-strong);
+    font-weight: 500;
+    cursor: pointer;
+}
+
+button.ghost:hover,
+.link-ghost:hover {
+    border-color: var(--primary);
+    color: var(--primary-strong);
+}
+
+.alert {
+    padding: 0.75rem 0.9rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.9rem;
+}
+
+.alert.error {
+    background: rgba(239, 68, 68, 0.12);
+    color: #b91c1c;
+}
+
+.alert.success {
+    background: rgba(16, 185, 129, 0.14);
+    color: #047857;
+}
+
+.department-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.25rem;
+}
+
+.department-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.department-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.department-identity {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+}
+
+.department-dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.department-dot.blue { background: #6366f1; }
+.department-dot.pink { background: #ec4899; }
+.department-dot.orange { background: #f97316; }
+.department-dot.green { background: #10b981; }
+.department-dot.yellow { background: #facc15; }
+
+.department-header h2 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.department-header p {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.department-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.department-stats span {
+    display: block;
+    font-weight: 600;
+    color: var(--text-strong);
+}
+
+.progress-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.progress-wrap .progress-track {
+    height: 10px;
+}
+
+.progress-label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.task-overview {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.task-board {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.25rem;
+}
+
+.board-column {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.board-column header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.board-column h2 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.column-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.task-card {
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 1.1rem;
+    background: #ffffff;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.task-card h3 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.task-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.priority-badge {
+    display: inline-flex;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.priority-badge.high { background: rgba(239, 68, 68, 0.12); color: #b91c1c; }
+.priority-badge.medium { background: rgba(245, 158, 11, 0.15); color: #b45309; }
+.priority-badge.low { background: rgba(16, 185, 129, 0.15); color: #047857; }
+
+.card-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.inline-form {
+    display: flex;
+    gap: 0.6rem;
+}
+
+.inline-form select {
+    flex: 1;
+    min-width: 0;
+}
+
+.inline-form button {
+    white-space: nowrap;
+}
+
+.action-row {
+    display: flex;
+    gap: 0.6rem;
+}
+
+.action-row button,
+.action-row form {
+    flex: 1;
+}
+
+button.secondary {
+    padding: 0.6rem 0.95rem;
+    border-radius: var(--radius-sm);
+    background: #ffffff;
+    border: 1px solid var(--border-color);
+    color: var(--text-strong);
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+button.secondary:hover {
+    border-color: var(--primary);
+    color: var(--primary-strong);
+}
+
+.reminder-stamp {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+}
+
+.task-description {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    line-height: 1.5;
+}
+
+.empty-note {
+    text-align: center;
+    padding: 1rem;
+    border-radius: var(--radius-md);
+    background: var(--surface-muted);
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.main-footer {
+    padding: 1.5rem 2.5rem 2.5rem;
+    border-top: 1px solid var(--border-color);
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    margin-top: auto;
+}
+
+.toast {
+    position: fixed;
+    bottom: 2rem;
+    right: 2rem;
+    padding: 0.85rem 1.2rem;
+    border-radius: var(--radius-sm);
+    background: var(--primary);
+    color: #fff;
+    font-weight: 600;
+    opacity: 0;
+    transform: translateY(10px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    pointer-events: none;
+    z-index: 1000;
+}
+
+.toast.show {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.toast.error {
+    background: var(--danger);
+}
+
+.toast.success {
+    background: var(--accent);
+}
+
+@media (max-width: 1080px) {
+    .sidebar {
+        display: none;
+    }
+
+    .page-header {
+        padding: 1.75rem 1.75rem 1.25rem;
+    }
+
+    .page-content {
+        padding: 1.75rem;
+    }
+
+    .main-footer {
+        padding: 1.5rem 1.75rem 2rem;
+    }
+}
+
+@media (max-width: 720px) {
+    .page-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .header-actions {
+        justify-content: space-between;
+    }
+
+    .metrics-grid,
+    .split-grid,
+    .task-board,
+    .department-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .inline-form {
+        flex-direction: column;
+    }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,45 @@
+document.addEventListener('DOMContentLoaded', () => {
+    let toast = document.querySelector('.toast');
+
+    if (!toast) {
+        toast = document.createElement('div');
+        toast.className = 'toast';
+        document.body.appendChild(toast);
+    }
+
+    function showToast(message, type = 'success') {
+        toast.textContent = message;
+        toast.classList.remove('error', 'success');
+        toast.classList.add('show', type);
+        setTimeout(() => toast.classList.remove('show'), 3000);
+    }
+
+    document.querySelectorAll('.reminder-button').forEach(button => {
+        button.addEventListener('click', async () => {
+            const taskId = button.dataset.taskId;
+            button.disabled = true;
+            try {
+                const response = await fetch('send_reminder.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ taskId })
+                });
+
+                const result = await response.json();
+                if (response.ok) {
+                    showToast(result.message, 'success');
+                    const stamp = button.closest('.task-card')?.querySelector('.reminder-stamp');
+                    if (stamp) {
+                        stamp.textContent = result.lastReminder;
+                    }
+                } else {
+                    throw new Error(result.message || 'Unable to send reminder');
+                }
+            } catch (error) {
+                showToast(error.message, 'error');
+            } finally {
+                button.disabled = false;
+            }
+        });
+    });
+});

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,159 @@
+CREATE DATABASE IF NOT EXISTS task_manager CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE task_manager;
+
+CREATE TABLE IF NOT EXISTS departments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    email VARCHAR(190) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(180) NOT NULL,
+    description TEXT NULL,
+    department_id INT NOT NULL,
+    priority VARCHAR(20) DEFAULT 'Medium',
+    status VARCHAR(30) DEFAULT 'Pending',
+    due_date DATE NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_tasks_departments FOREIGN KEY (department_id) REFERENCES departments(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    task_id INT NOT NULL,
+    message TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_notifications_tasks FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO departments (name) VALUES
+    ('Office of the Secretary General'),
+    ('General Department of Information Technology'),
+    ('Cybersecurity Department'),
+    ('Investment Agency'),
+    ('General Department of Gardens and Landscaping'),
+    ('General Department of Internal Audits'),
+    ('General Department of Operations and Emergencies'),
+    ('Department of Safety and Security'),
+    ('Central Unit for Plan Approval'),
+    ('Department of Land Affairs'),
+    ('Environmental Health Department'),
+    ('General Department of Cleaning'),
+    ('Central City Municipality'),
+    ('Northern Municipality')
+ON DUPLICATE KEY UPDATE name = VALUES(name);
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Digital Infrastructure Audit', 'Complete the resiliency assessment for core datacenter services and report findings to the steering committee.', d.id, 'High', 'In Progress', DATE_ADD(CURDATE(), INTERVAL 5 DAY), NOW(), NOW()
+FROM departments d
+WHERE d.name = 'General Department of Information Technology'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Digital Infrastructure Audit' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Emergency Drill Readiness', 'Confirm equipment checklists and submit the cross-department readiness memo ahead of the city-wide drill.', d.id, 'Medium', 'Pending', DATE_ADD(CURDATE(), INTERVAL 2 DAY), NOW(), NOW()
+FROM departments d
+WHERE d.name = 'General Department of Operations and Emergencies'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Emergency Drill Readiness' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Investment Portfolio Review', 'Prepare quarterly briefing with performance highlights and risk actions for executive approval.', d.id, 'Medium', 'Completed', DATE_SUB(CURDATE(), INTERVAL 1 DAY), DATE_SUB(NOW(), INTERVAL 6 DAY), DATE_SUB(NOW(), INTERVAL 1 DAY)
+FROM departments d
+WHERE d.name = 'Investment Agency'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Investment Portfolio Review' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Public Park Revitalization', 'Finalize vendor contracts for the Riverside Park renovation and submit landscaping schedules.', d.id, 'High', 'Pending', DATE_SUB(CURDATE(), INTERVAL 3 DAY), DATE_SUB(NOW(), INTERVAL 14 DAY), DATE_SUB(NOW(), INTERVAL 3 DAY)
+FROM departments d
+WHERE d.name = 'General Department of Gardens and Landscaping'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Public Park Revitalization' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'City Clean-Up Campaign', 'Launch the awareness campaign and coordinate resources with district offices.', d.id, 'Low', 'In Progress', DATE_ADD(CURDATE(), INTERVAL 9 DAY), DATE_SUB(NOW(), INTERVAL 2 DAY), NOW()
+FROM departments d
+WHERE d.name = 'General Department of Cleaning'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'City Clean-Up Campaign' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Cybersecurity Incident Simulation', 'Coordinate the tabletop exercise with remediation playbooks and report findings to leadership.', d.id, 'High', 'In Progress', DATE_ADD(CURDATE(), INTERVAL 7 DAY), NOW(), NOW()
+FROM departments d
+WHERE d.name = 'Cybersecurity Department'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Cybersecurity Incident Simulation' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Land Use Compliance Audit', 'Compile zoning approvals and flag parcels that require renewal before the quarterly review.', d.id, 'Medium', 'Pending', DATE_ADD(CURDATE(), INTERVAL 4 DAY), DATE_SUB(NOW(), INTERVAL 5 DAY), NOW()
+FROM departments d
+WHERE d.name = 'Department of Land Affairs'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Land Use Compliance Audit' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Environmental Inspection Sweep', 'Deliver inspection summaries for high-risk districts and escalate unresolved breaches.', d.id, 'High', 'In Progress', DATE_ADD(CURDATE(), INTERVAL 3 DAY), DATE_SUB(NOW(), INTERVAL 1 DAY), NOW()
+FROM departments d
+WHERE d.name = 'Environmental Health Department'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Environmental Inspection Sweep' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Safety Drill Certification', 'Gather drill sign-offs from facility leads and publish the compliance dashboard update.', d.id, 'Medium', 'Pending', DATE_ADD(CURDATE(), INTERVAL 6 DAY), DATE_SUB(NOW(), INTERVAL 3 DAY), NOW()
+FROM departments d
+WHERE d.name = 'Department of Safety and Security'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Safety Drill Certification' AND t.department_id = d.id
+  );
+
+INSERT INTO notifications (task_id, message, created_at)
+SELECT t.id, 'Reminder sent to confirm infrastructure resiliency updates.', DATE_SUB(NOW(), INTERVAL 1 DAY)
+FROM tasks t
+JOIN departments d ON d.id = t.department_id
+WHERE t.title = 'Digital Infrastructure Audit'
+  AND d.name = 'General Department of Information Technology'
+  AND NOT EXISTS (
+      SELECT 1 FROM notifications n WHERE n.task_id = t.id
+  );
+
+INSERT INTO notifications (task_id, message, created_at)
+SELECT t.id, 'Security exercise materials distributed to stakeholders.', DATE_SUB(NOW(), INTERVAL 3 HOUR)
+FROM tasks t
+JOIN departments d ON d.id = t.department_id
+WHERE t.title = 'Cybersecurity Incident Simulation'
+  AND d.name = 'Cybersecurity Department'
+  AND NOT EXISTS (
+      SELECT 1 FROM notifications n WHERE n.task_id = t.id
+  );
+
+INSERT INTO notifications (task_id, message, created_at)
+SELECT t.id, 'Follow-up issued for environmental inspection deliverables.', DATE_SUB(NOW(), INTERVAL 8 HOUR)
+FROM tasks t
+JOIN departments d ON d.id = t.department_id
+WHERE t.title = 'Environmental Inspection Sweep'
+  AND d.name = 'Environmental Health Department'
+  AND NOT EXISTS (
+      SELECT 1 FROM notifications n WHERE n.task_id = t.id
+  );
+
+INSERT INTO notifications (task_id, message, created_at)
+SELECT t.id, 'Follow-up issued for upcoming emergency readiness drill.', DATE_SUB(NOW(), INTERVAL 6 HOUR)
+FROM tasks t
+JOIN departments d ON d.id = t.department_id
+WHERE t.title = 'Emergency Drill Readiness'
+  AND d.name = 'General Department of Operations and Emergencies'
+  AND NOT EXISTS (
+      SELECT 1 FROM notifications n WHERE n.task_id = t.id
+  );

--- a/db.php
+++ b/db.php
@@ -1,0 +1,22 @@
+<?php
+$host = getenv('DB_HOST') ?: 'localhost';
+$port = getenv('DB_PORT') ?: '3306';
+$name = getenv('DB_NAME') ?: 'task_manager';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASSWORD') !== false ? getenv('DB_PASSWORD') : 'root';
+$charset = 'utf8mb4';
+$dsn = "mysql:host={$host};port={$port};dbname={$name};charset={$charset}";
+$options = [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $exception) {
+    http_response_code(500);
+    echo '<h1>Unable to connect to the database</h1>';
+    echo '<p>' . htmlspecialchars($exception->getMessage(), ENT_QUOTES, 'UTF-8') . '</p>';
+    exit;
+}

--- a/departments.php
+++ b/departments.php
@@ -1,0 +1,175 @@
+<?php
+$pageTitle = 'Departments';
+$pageDescription = 'Manage departments and view their task performance.';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$errors = [];
+$success = '';
+
+$defaultDepartments = [
+    'Office of the Secretary General',
+    'General Department of Information Technology',
+    'Cybersecurity Department',
+    'Investment Agency',
+    'General Department of Gardens and Landscaping',
+    'General Department of Internal Audits',
+    'General Department of Operations and Emergencies',
+    'Department of Safety and Security',
+    'Central Unit for Plan Approval',
+    'Department of Land Affairs',
+    'Environmental Health Department',
+    'General Department of Cleaning',
+    'Central City Municipality',
+    'Northern Municipality',
+];
+
+$count = (int)$pdo->query('SELECT COUNT(*) FROM departments')->fetchColumn();
+if ($count === 0) {
+    $insert = $pdo->prepare('INSERT INTO departments (name) VALUES (:name)');
+    foreach ($defaultDepartments as $departmentName) {
+        $insert->execute(['name' => $departmentName]);
+    }
+    $success = 'Default departments were added automatically.';
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+
+    if ($name === '') {
+        $errors[] = 'Department name is required.';
+    }
+
+    if (empty($errors)) {
+        $stmt = $pdo->prepare('INSERT INTO departments (name, email) VALUES (:name, :email)');
+        $stmt->execute([
+            'name' => $name,
+            'email' => $email ?: null,
+        ]);
+        $success = 'Department created successfully.';
+    }
+}
+
+$departments = $pdo->query('SELECT d.*, COUNT(t.id) AS tasks_count,
+    SUM(CASE WHEN t.status = "Completed" THEN 1 ELSE 0 END) AS completed_count,
+    SUM(CASE WHEN t.status = "In Progress" THEN 1 ELSE 0 END) AS in_progress_count,
+    SUM(CASE WHEN t.status = "Pending" THEN 1 ELSE 0 END) AS pending_count,
+    SUM(CASE WHEN t.due_date IS NOT NULL AND t.due_date < CURDATE() AND t.status != "Completed" THEN 1 ELSE 0 END) AS overdue_count
+    FROM departments d
+    LEFT JOIN tasks t ON t.department_id = d.id
+    GROUP BY d.id
+    ORDER BY d.name ASC')->fetchAll();
+
+$totalDepartments = count($departments);
+$withContacts = 0;
+$activeWorkloads = 0;
+
+foreach ($departments as $department) {
+    if (!empty($department['email'])) {
+        $withContacts++;
+    }
+    if ((int)$department['tasks_count'] > 0) {
+        $activeWorkloads++;
+    }
+}
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="metrics-grid">
+    <article class="panel metric-card">
+        <span class="metric-label">Active units</span>
+        <span class="metric-value"><?= number_format($totalDepartments); ?></span>
+        <span class="metric-footnote">Participating in the workspace</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">Contacts listed</span>
+        <span class="metric-value"><?= number_format($withContacts); ?></span>
+        <span class="metric-footnote">Teams with escalation emails</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">Active workloads</span>
+        <span class="metric-value"><?= number_format($activeWorkloads); ?></span>
+        <span class="metric-footnote">Departments with assigned tasks</span>
+    </article>
+</section>
+
+<section class="panel form-panel">
+    <h2>Add Department</h2>
+    <p class="panel-subtitle">Create a new department to assign work</p>
+    <?php if ($errors): ?>
+        <div class="alert error">
+            <?= implode('<br>', array_map('sanitize', $errors)); ?>
+        </div>
+    <?php endif; ?>
+    <?php if ($success && !$errors): ?>
+        <div class="alert success"><?= sanitize($success); ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <div>
+            <label for="name">Department name</label>
+            <input type="text" id="name" name="name" required>
+        </div>
+        <div>
+            <label for="email">Email (optional)</label>
+            <input type="email" id="email" name="email" placeholder="team@example.com">
+        </div>
+        <button type="submit">Add department</button>
+    </form>
+</section>
+
+<section class="department-grid">
+    <?php if (!$departments): ?>
+        <div class="panel empty-note">No departments available. Add one to get started.</div>
+    <?php else: ?>
+        <?php $colors = ['blue', 'pink', 'orange', 'green', 'yellow']; ?>
+        <?php foreach ($departments as $index => $department): ?>
+            <?php
+            $totalTasks = (int)$department['tasks_count'];
+            $completed = (int)$department['completed_count'];
+            $inProgress = (int)$department['in_progress_count'];
+            $pending = (int)$department['pending_count'];
+            $overdue = (int)$department['overdue_count'];
+            $rate = $totalTasks > 0 ? round(($completed / $totalTasks) * 100) : 0;
+            $color = $colors[$index % count($colors)];
+            ?>
+            <article class="panel department-card">
+                <div class="department-header">
+                    <div class="department-identity">
+                        <span class="department-dot <?= $color; ?>" aria-hidden="true"></span>
+                        <div>
+                            <h2><?= sanitize($department['name']); ?></h2>
+                            <p><?= $department['email'] ? sanitize($department['email']) : 'No contact listed'; ?></p>
+                        </div>
+                    </div>
+                    <span class="badge neutral"><?= number_format($totalTasks); ?> tasks</span>
+                </div>
+                <div class="department-stats">
+                    <div>
+                        <span><?= number_format($pending); ?></span>
+                        Pending
+                    </div>
+                    <div>
+                        <span><?= number_format($inProgress); ?></span>
+                        In progress
+                    </div>
+                    <div>
+                        <span><?= number_format($completed); ?></span>
+                        Completed
+                    </div>
+                    <div>
+                        <span><?= number_format($overdue); ?></span>
+                        Overdue
+                    </div>
+                </div>
+                <div class="progress-wrap">
+                    <div class="progress-track">
+                        <span class="progress-fill" style="width: <?= $rate; ?>%"></span>
+                    </div>
+                    <span class="progress-label">Completion rate <?= $rate; ?>%</span>
+                </div>
+            </article>
+        <?php endforeach; ?>
+    <?php endif; ?>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,0 +1,10 @@
+            </main>
+            <footer class="main-footer">
+                <p>© <?= date('Y'); ?> TaskFlow Workspace</p>
+            </footer>
+        </div>
+    </div>
+    <div class="toast" role="alert" aria-live="polite" aria-atomic="true"></div>
+    <script src="assets/js/app.js"></script>
+</body>
+</html>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,70 @@
+<?php
+if (!ini_get('date.timezone')) {
+    date_default_timezone_set('Asia/Riyadh');
+}
+
+function sanitize(string $value = null): string
+{
+    return htmlspecialchars($value ?? '', ENT_QUOTES, 'UTF-8');
+}
+
+function analyze_due_status(?string $dueDate, string $status = 'In Progress'): array
+{
+    $today = new DateTimeImmutable('today');
+    if (strtolower($status) === 'completed') {
+        return [
+            'label' => 'Completed',
+            'class' => 'status-complete',
+        ];
+    }
+
+    if (!$dueDate) {
+        return [
+            'label' => 'No due date',
+            'class' => 'status-open',
+        ];
+    }
+
+    try {
+        $due = new DateTimeImmutable($dueDate);
+    } catch (Exception $e) {
+        return [
+            'label' => 'Invalid due date',
+            'class' => 'status-open',
+        ];
+    }
+
+    if ($due < $today) {
+        return [
+            'label' => 'Overdue',
+            'class' => 'status-overdue',
+        ];
+    }
+
+    $diff = $today->diff($due)->days;
+
+    if ($diff <= 3) {
+        return [
+            'label' => 'Due soon',
+            'class' => 'status-warning',
+        ];
+    }
+
+    return [
+        'label' => 'On track',
+        'class' => 'status-open',
+    ];
+}
+
+function format_date(?string $date): string
+{
+    if (!$date) {
+        return '-';
+    }
+
+    try {
+        return (new DateTimeImmutable($date))->format('Y-m-d');
+    } catch (Exception $e) {
+        return $date;
+    }
+}

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,52 @@
+<?php
+require_once __DIR__ . '/../includes/functions.php';
+$pageTitle = $pageTitle ?? 'Task Management Hub';
+$pageDescription = $pageDescription ?? 'Coordinate departmental workstreams in one place.';
+$workspaceUpdatedAt = date('M j, Y');
+$currentPage = basename($_SERVER['PHP_SELF']);
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= sanitize($pageTitle); ?></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+    <div class="app-shell">
+        <aside class="sidebar" aria-label="Primary">
+            <div class="sidebar-brand">
+                <span class="brand-icon" aria-hidden="true">TF</span>
+                <div class="brand-copy">
+                    <span class="brand-title">TaskFlow</span>
+                    <span class="brand-subtitle">Department Manager</span>
+                </div>
+            </div>
+            <nav class="sidebar-nav" role="navigation">
+                <a href="index.php" class="nav-link <?= $currentPage === 'index.php' ? 'active' : ''; ?>">Dashboard</a>
+                <a href="tasks.php" class="nav-link <?= $currentPage === 'tasks.php' ? 'active' : ''; ?>">Tasks</a>
+                <a href="departments.php" class="nav-link <?= $currentPage === 'departments.php' ? 'active' : ''; ?>">Departments</a>
+                <span class="nav-link muted" aria-disabled="true">Calendar</span>
+            </nav>
+        </aside>
+        <div class="main-area">
+            <header class="page-header">
+                <div class="page-titles">
+                    <h1><?= sanitize($pageTitle); ?></h1>
+                    <?php if (!empty($pageDescription)): ?>
+                        <p><?= sanitize($pageDescription); ?></p>
+                    <?php endif; ?>
+                </div>
+                <div class="header-actions">
+                    <span class="status-pill" role="status">
+                        <span class="status-dot"></span>
+                        Updated <?= sanitize($workspaceUpdatedAt); ?>
+                    </span>
+                    <a href="tasks.php" class="primary-action">New Task</a>
+                </div>
+            </header>
+            <main class="page-content">

--- a/index.php
+++ b/index.php
@@ -1,0 +1,145 @@
+<?php
+$pageTitle = 'Dashboard';
+$pageDescription = 'Overview of all departments and task assignments.';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$totalTasks = (int)$pdo->query('SELECT COUNT(*) FROM tasks')->fetchColumn();
+$inProgressTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status = 'In Progress'")->fetchColumn();
+$completedTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status = 'Completed'")->fetchColumn();
+$overdueTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status != 'Completed' AND due_date IS NOT NULL AND due_date < CURDATE()")
+    ->fetchColumn();
+$departmentCount = (int)$pdo->query('SELECT COUNT(*) FROM departments')->fetchColumn();
+
+$upcomingTasks = $pdo->query("SELECT t.id, t.title, t.due_date, d.name AS department_name, t.priority\n    FROM tasks t\n    JOIN departments d ON d.id = t.department_id\n    WHERE t.status != 'Completed' AND t.due_date IS NOT NULL AND t.due_date >= CURDATE()\n    ORDER BY t.due_date ASC\n    LIMIT 6")->fetchAll();
+
+$recentReminders = $pdo->query("SELECT n.message, DATE_FORMAT(n.created_at, '%b %e, %Y %H:%i') AS created_at,\n    t.title AS task_title\n    FROM notifications n\n    JOIN tasks t ON t.id = n.task_id\n    ORDER BY n.created_at DESC\n    LIMIT 5")->fetchAll();
+
+$departmentPerformance = $pdo->query("SELECT d.name,\n    COUNT(t.id) AS total_tasks,\n    SUM(CASE WHEN t.status = 'Completed' THEN 1 ELSE 0 END) AS completed_tasks,\n    SUM(CASE WHEN t.status = 'In Progress' THEN 1 ELSE 0 END) AS in_progress_tasks,\n    SUM(CASE WHEN t.due_date IS NOT NULL AND t.due_date < CURDATE() AND t.status != 'Completed' THEN 1 ELSE 0 END) AS overdue_tasks\n    FROM departments d\n    LEFT JOIN tasks t ON t.department_id = d.id\n    GROUP BY d.id\n    ORDER BY d.name ASC\n    LIMIT 6")->fetchAll();
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="metrics-grid">
+    <article class="panel metric-card">
+        <span class="metric-label">Total Tasks</span>
+        <span class="metric-value"><?= number_format($totalTasks); ?></span>
+        <span class="metric-footnote">Across all departments</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">In Progress</span>
+        <span class="metric-value"><?= number_format($inProgressTasks); ?></span>
+        <span class="metric-footnote"><?= number_format($completedTasks); ?> completed</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">Overdue</span>
+        <span class="metric-value"><?= number_format($overdueTasks); ?></span>
+        <span class="metric-footnote">Requires attention</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">Departments</span>
+        <span class="metric-value"><?= number_format($departmentCount); ?></span>
+        <span class="metric-footnote">Active divisions</span>
+    </article>
+</section>
+
+<?php if ($overdueTasks > 0): ?>
+    <section class="panel alert-card">
+        <div>
+            <h2>Overdue tasks need attention</h2>
+            <p><?= number_format($overdueTasks); ?> assignments have slipped beyond their due dates.</p>
+        </div>
+        <a href="tasks.php" class="link-button">Review tasks</a>
+    </section>
+<?php endif; ?>
+
+<section class="split-grid">
+    <article class="panel">
+        <div class="panel-header">
+            <h2>Upcoming Deadlines</h2>
+            <span class="panel-subtitle">Next <?= $upcomingTasks ? count($upcomingTasks) : 0; ?> due dates</span>
+        </div>
+        <?php if (!$upcomingTasks): ?>
+            <div class="empty-note">No upcoming due dates found.</div>
+        <?php else: ?>
+            <ul class="deadline-list">
+                <?php foreach ($upcomingTasks as $task): ?>
+                    <?php
+                    $priorityClass = strtolower($task['priority']);
+                    if (!in_array($priorityClass, ['high', 'medium', 'low'], true)) {
+                        $priorityClass = 'medium';
+                    }
+                    ?>
+                    <li class="deadline-item">
+                        <div>
+                            <strong><?= sanitize($task['title']); ?></strong>
+                            <div class="task-meta">
+                                <span><?= sanitize($task['department_name']); ?></span>
+                                <span class="priority-badge <?= $priorityClass; ?>"><?= sanitize($task['priority']); ?></span>
+                            </div>
+                        </div>
+                        <span class="badge warning">Due <?= sanitize(format_date($task['due_date'])); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </article>
+    <article class="panel">
+        <div class="panel-header">
+            <h2>Department Performance</h2>
+            <span class="panel-subtitle">Completion rate</span>
+        </div>
+        <?php if (!$departmentPerformance): ?>
+            <div class="empty-note">Add departments to track performance.</div>
+        <?php else: ?>
+            <ul class="performance-list">
+                <?php foreach ($departmentPerformance as $department): ?>
+                    <?php
+                    $total = (int)$department['total_tasks'];
+                    $completed = (int)$department['completed_tasks'];
+                    $inProgress = (int)$department['in_progress_tasks'];
+                    $overdue = (int)$department['overdue_tasks'];
+                    $rate = $total > 0 ? round(($completed / $total) * 100) : 0;
+                    ?>
+                    <li class="performance-row">
+                        <header>
+                            <strong><?= sanitize($department['name']); ?></strong>
+                            <span class="badge neutral"><?= $rate; ?>% complete</span>
+                        </header>
+                        <div class="progress-track">
+                            <span class="progress-fill" style="width: <?= $rate; ?>%"></span>
+                        </div>
+                        <div class="progress-meta">
+                            <span><?= number_format($completed); ?> completed · <?= number_format($inProgress); ?> in progress</span>
+                            <span><?= number_format($overdue); ?> overdue</span>
+                        </div>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </article>
+</section>
+
+<section class="panel">
+    <div class="panel-header">
+        <h2>Reminder Activity</h2>
+        <span class="panel-subtitle">Latest alerts to departments</span>
+    </div>
+    <?php if (!$recentReminders): ?>
+        <div class="empty-note">No reminders have been issued yet.</div>
+    <?php else: ?>
+        <ul class="activity-list">
+            <?php foreach ($recentReminders as $reminder): ?>
+                <li class="activity-item">
+                    <div>
+                        <strong><?= sanitize($reminder['task_title']); ?></strong>
+                        <div class="task-meta">
+                            <span><?= sanitize($reminder['message']); ?></span>
+                        </div>
+                    </div>
+                    <span class="badge neutral"><?= sanitize($reminder['created_at']); ?></span>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    <?php endif; ?>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/send_reminder.php
+++ b/send_reminder.php
@@ -1,0 +1,46 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['message' => 'Request method not allowed']);
+    exit;
+}
+
+$payload = json_decode(file_get_contents('php://input'), true) ?? [];
+$taskId = isset($payload['taskId']) ? (int) $payload['taskId'] : 0;
+
+if (!$taskId) {
+    http_response_code(400);
+    echo json_encode(['message' => 'Unknown task']);
+    exit;
+}
+
+require_once __DIR__ . '/db.php';
+
+$taskStmt = $pdo->prepare('SELECT id, title, due_date FROM tasks WHERE id = :id');
+$taskStmt->execute(['id' => $taskId]);
+$task = $taskStmt->fetch();
+
+if (!$task) {
+    http_response_code(404);
+    echo json_encode(['message' => 'Task not found']);
+    exit;
+}
+
+$message = sprintf('Reminder for task "%s". Due date: %s', $task['title'], $task['due_date'] ?: 'No due date');
+
+$insert = $pdo->prepare('INSERT INTO notifications (task_id, message, created_at) VALUES (:task_id, :message, NOW())');
+$insert->execute([
+    'task_id' => $taskId,
+    'message' => $message,
+]);
+
+$lastReminder = $pdo->prepare('SELECT DATE_FORMAT(created_at, "%Y-%m-%d %H:%i") as created_at FROM notifications WHERE task_id = :task_id ORDER BY created_at DESC LIMIT 1');
+$lastReminder->execute(['task_id' => $taskId]);
+$stamp = $lastReminder->fetchColumn();
+
+echo json_encode([
+    'message' => 'Reminder sent successfully',
+    'lastReminder' => $stamp,
+]);

--- a/tasks.php
+++ b/tasks.php
@@ -1,0 +1,259 @@
+<?php
+$pageTitle = 'Tasks';
+$pageDescription = 'Manage and track work across every department.';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$errors = [];
+$success = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'create') {
+        $title = trim($_POST['title'] ?? '');
+        $departmentId = (int)($_POST['department_id'] ?? 0);
+        $priority = $_POST['priority'] ?? 'Medium';
+        $dueDate = $_POST['due_date'] ?? null;
+        $description = trim($_POST['description'] ?? '');
+
+        if ($title === '') {
+            $errors[] = 'Task title is required.';
+        }
+
+        if ($departmentId <= 0) {
+            $errors[] = 'Select a responsible department.';
+        }
+
+        if (empty($errors)) {
+            $stmt = $pdo->prepare('INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+                VALUES (:title, :description, :department_id, :priority, :status, :due_date, NOW(), NOW())');
+            $stmt->execute([
+                'title' => $title,
+                'description' => $description,
+                'department_id' => $departmentId,
+                'priority' => $priority,
+                'status' => 'Pending',
+                'due_date' => $dueDate ?: null,
+            ]);
+
+            $success = 'Task created successfully.';
+        }
+    } elseif ($action === 'update_status') {
+        $taskId = (int)($_POST['task_id'] ?? 0);
+        $status = $_POST['status'] ?? 'Pending';
+
+        if ($taskId > 0) {
+            $update = $pdo->prepare('UPDATE tasks SET status = :status, updated_at = NOW() WHERE id = :id');
+            $update->execute([
+                'status' => $status,
+                'id' => $taskId,
+            ]);
+            $success = 'Task status updated.';
+        }
+    } elseif ($action === 'delete') {
+        $taskId = (int)($_POST['task_id'] ?? 0);
+        if ($taskId > 0) {
+            $pdo->prepare('DELETE FROM notifications WHERE task_id = :id')->execute(['id' => $taskId]);
+            $pdo->prepare('DELETE FROM tasks WHERE id = :id')->execute(['id' => $taskId]);
+            $success = 'Task deleted.';
+        }
+    }
+}
+
+$departments = $pdo->query('SELECT id, name FROM departments ORDER BY name ASC')->fetchAll();
+
+$tasksStmt = $pdo->query('SELECT t.*, d.name AS department_name,
+    (SELECT DATE_FORMAT(n.created_at, "%b %e, %Y %H:%i") FROM notifications n WHERE n.task_id = t.id ORDER BY n.created_at DESC LIMIT 1) AS last_reminder
+    FROM tasks t
+    JOIN departments d ON t.department_id = d.id
+    ORDER BY t.due_date IS NULL, t.due_date ASC, t.created_at DESC');
+$tasks = $tasksStmt->fetchAll();
+
+$statusCounts = [
+    'Pending' => 0,
+    'In Progress' => 0,
+    'Completed' => 0,
+];
+
+$statusSummaryStmt = $pdo->query("SELECT status, COUNT(*) AS total FROM tasks GROUP BY status");
+foreach ($statusSummaryStmt as $row) {
+    $status = $row['status'] ?? '';
+    if (isset($statusCounts[$status])) {
+        $statusCounts[$status] = (int)$row['total'];
+    }
+}
+
+$overdueCount = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status != 'Completed' AND due_date IS NOT NULL AND due_date < CURDATE()")
+    ->fetchColumn();
+
+$nextDueTask = $pdo->query("SELECT t.title, t.due_date, d.name AS department_name
+    FROM tasks t
+    JOIN departments d ON d.id = t.department_id
+    WHERE t.status != 'Completed' AND t.due_date IS NOT NULL AND t.due_date >= CURDATE()
+    ORDER BY t.due_date ASC
+    LIMIT 1")
+    ->fetch();
+
+$statusGroups = [
+    'Pending' => [],
+    'In Progress' => [],
+    'Completed' => [],
+    'Overdue' => [],
+];
+
+foreach ($tasks as $task) {
+    $isOverdue = !empty($task['due_date']) && $task['status'] !== 'Completed' && strtotime($task['due_date']) < strtotime(date('Y-m-d'));
+    if ($isOverdue) {
+        $statusGroups['Overdue'][] = $task;
+    } elseif (isset($statusGroups[$task['status']])) {
+        $statusGroups[$task['status']][] = $task;
+    } else {
+        $statusGroups['Pending'][] = $task;
+    }
+}
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="metrics-grid">
+    <article class="panel metric-card">
+        <span class="metric-label">Pending</span>
+        <span class="metric-value"><?= number_format($statusCounts['Pending']); ?></span>
+        <span class="metric-footnote">Awaiting kickoff</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">In Progress</span>
+        <span class="metric-value"><?= number_format($statusCounts['In Progress']); ?></span>
+        <span class="metric-footnote"><?= $nextDueTask ? sanitize(format_date($nextDueTask['due_date'])) : 'No due dates'; ?></span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">Completed</span>
+        <span class="metric-value"><?= number_format($statusCounts['Completed']); ?></span>
+        <span class="metric-footnote">Recently closed work</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">Overdue</span>
+        <span class="metric-value"><?= number_format($overdueCount); ?></span>
+        <span class="metric-footnote">Requires follow-up</span>
+    </article>
+</section>
+
+<section class="panel">
+    <div class="panel-header">
+        <h2>Board view</h2>
+        <span class="panel-subtitle">Status lanes for quick scanning</span>
+    </div>
+    <div class="task-board">
+        <?php
+        $laneOrder = ['Pending', 'In Progress', 'Completed', 'Overdue'];
+        foreach ($laneOrder as $lane):
+            $tasksInLane = $statusGroups[$lane];
+        ?>
+            <div class="board-column">
+                <header>
+                    <h2><?= sanitize($lane); ?></h2>
+                    <span class="badge neutral"><?= count($tasksInLane); ?></span>
+                </header>
+                <div class="column-body">
+                    <?php if (!$tasksInLane): ?>
+                        <div class="empty-note">No tasks in this lane.</div>
+                    <?php else: ?>
+                        <?php foreach ($tasksInLane as $task): ?>
+                            <?php
+                            $priorityClass = strtolower($task['priority']);
+                            if (!in_array($priorityClass, ['high', 'medium', 'low'], true)) {
+                                $priorityClass = 'medium';
+                            }
+                            ?>
+                            <article class="task-card">
+                                <div>
+                                    <h3><?= sanitize($task['title']); ?></h3>
+                                    <div class="task-meta">
+                                        <span><?= sanitize($task['department_name']); ?></span>
+                                        <?php if (!empty($task['due_date'])): ?>
+                                            <span>Due <?= sanitize(format_date($task['due_date'])); ?></span>
+                                        <?php endif; ?>
+                                        <span class="priority-badge <?= $priorityClass; ?>"><?= sanitize($task['priority']); ?></span>
+                                    </div>
+                                </div>
+                                <?php if (!empty($task['description'])): ?>
+                                    <p class="task-description"><?= sanitize($task['description']); ?></p>
+                                <?php endif; ?>
+                                <div class="card-actions">
+                                    <form method="post" class="inline-form">
+                                        <input type="hidden" name="action" value="update_status">
+                                        <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
+                                        <select name="status">
+                                            <option value="Pending" <?= $task['status'] === 'Pending' ? 'selected' : ''; ?>>Pending</option>
+                                            <option value="In Progress" <?= $task['status'] === 'In Progress' ? 'selected' : ''; ?>>In Progress</option>
+                                            <option value="Completed" <?= $task['status'] === 'Completed' ? 'selected' : ''; ?>>Completed</option>
+                                        </select>
+                                        <button type="submit" class="secondary">Update</button>
+                                    </form>
+                                    <div class="action-row">
+                                        <button type="button" class="secondary reminder-button" data-task-id="<?= (int)$task['id']; ?>">Send reminder</button>
+                                        <form method="post" onsubmit="return confirm('Delete this task?');">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
+                                            <button type="submit" class="secondary">Delete</button>
+                                        </form>
+                                    </div>
+                                    <span class="reminder-stamp">Last reminder: <?= $task['last_reminder'] ? sanitize($task['last_reminder']) : 'Not sent yet'; ?></span>
+                                </div>
+                            </article>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+</section>
+
+<section class="panel form-panel">
+    <h2>Create Task</h2>
+    <p class="panel-subtitle">Assign work to departments and set due dates</p>
+    <?php if ($errors): ?>
+        <div class="alert error">
+            <?= implode('<br>', array_map('sanitize', $errors)); ?>
+        </div>
+    <?php endif; ?>
+    <?php if ($success && !$errors): ?>
+        <div class="alert success"><?= sanitize($success); ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <input type="hidden" name="action" value="create">
+        <div>
+            <label for="title">Task title</label>
+            <input type="text" id="title" name="title" required>
+        </div>
+        <div class="task-overview">
+            <div>
+                <label for="department_id">Department</label>
+                <select id="department_id" name="department_id" required>
+                    <option value="">Select department</option>
+                    <?php foreach ($departments as $department): ?>
+                        <option value="<?= (int)$department['id']; ?>"><?= sanitize($department['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div>
+                <label for="priority">Priority</label>
+                <select id="priority" name="priority">
+                    <option value="High">High</option>
+                    <option value="Medium" selected>Medium</option>
+                    <option value="Low">Low</option>
+                </select>
+            </div>
+            <div>
+                <label for="due_date">Due date</label>
+                <input type="date" id="due_date" name="due_date">
+            </div>
+        </div>
+        <div>
+            <label for="description">Task description</label>
+            <textarea id="description" name="description" placeholder="Add details and instructions"></textarea>
+        </div>
+        <button type="submit">Save task</button>
+    </form>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- restructure the shared chrome with a TaskFlow-inspired sidebar, header, and content shell
- restyle the application to match the provided boards and cards, and update the toast helper for the new components
- rebuild the dashboard, tasks board, and department overview with progress metrics, status lanes, and refreshed forms

## Testing
- php -l index.php
- php -l tasks.php
- php -l departments.php
- php -l includes/header.php
- php -l includes/footer.php

------
https://chatgpt.com/codex/tasks/task_e_68ed33eeec68832cba2eeea9e2c18e2b