### PR TITLE
Polish TaskFlow UI and improve database guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# Department Task Management System
+
+A lightweight web portal for coordinating departmental work. The interface is built with HTML, CSS, and JavaScript, while PHP powers the backend and connects the application to a MySQL database (compatible with MAMP on macOS).
+
+## Key features
+- Dashboard with quick metrics, upcoming deadlines, and reminder history.
+- Full CRUD workflow for departmental tasks (create, update status, delete).
+- Department directory with optional contact email and automatic seeding of the provided fourteen departments.
+- Reminder logging endpoint to record when a follow-up notification is sent.
+- Figma-inspired interface with gradient hero header, glassmorphism cards, and responsive insight chips for a polished presentation.
+
+## Requirements
+- PHP 8 or newer.
+- MySQL server (the default MAMP database works well).
+- Web server such as Apache bundled with MAMP.
+
+## Getting started with MAMP
+1. Copy the project into your MAMP web directory (typically `/Applications/MAMP/htdocs`).
+2. Open phpMyAdmin through `http://localhost/phpMyAdmin`.
+3. Import the database schema located at `database/schema.sql`. It creates tables, seeds the fourteen departments, and loads a curated sample data set so dashboards and reminders are populated immediately.
+4. Update the connection values in `db.php` if your credentials differ. The defaults are:
+   - Username: `root`
+   - Password: `root`
+   - Database: `task_manager`
+5. Start MAMP servers and visit `http://localhost/tatarwar/index.php` (or the folder name you chose) to access the portal.
+
+## Database structure
+- `departments`: stores department names and optional email contacts.
+- `tasks`: tracks task details, responsible department, priority, status, and due date.
+- `notifications`: records reminder messages tied to tasks.
+
+## Project structure
+```
+.
+├── assets
+│   ├── css
+│   │   └── style.css
+│   └── js
+│       └── app.js
+├── database
+│   └── schema.sql
+├── includes
+│   ├── footer.php
+│   ├── functions.php
+│   └── header.php
+├── db.php
+├── index.php
+├── tasks.php
+├── departments.php
+└── README.md
+```
+
+## Customising the platform
+- Update the colour palette or typography in `assets/css/style.css`.
+- Extend the reminder logic in `send_reminder.php` to trigger actual emails or integrations.
+- Modify the `departments.php` form to capture additional metadata as required.
+
+## Design highlights
+- **Hero workspace shell:** layered gradient header with live status chip and quick access to navigation plus a new task shortcut.
+- **Insight overview cards:** reusable components show task health, overdue counts, and department activity in a glanceable grid.
+- **Elevated data tables:** floating rows, pill badges, and accent chips make task priorities and statuses readable across devices.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,40 @@
-# Department Task Management System
+# Department TaskMaster Suite
 
-A lightweight web portal for coordinating departmental work. The interface is built with HTML, CSS, and JavaScript, while PHP powers the backend and connects the application to a MySQL database (compatible with MAMP on macOS).
+A classic, data-focused portal for coordinating departmental work. The interface uses HTML, CSS, and vanilla JavaScript, while PHP powers the backend against a MySQL database (fully compatible with MAMP on macOS).
 
 ## Key features
-- Dashboard with quick metrics, upcoming deadlines, and reminder history.
-- Dedicated new-task workspace for capturing assignments with guidance and shortcuts.
-- Calendar view that visualises deadlines across departments with colour-coded priorities.
-- Full CRUD workflow for departmental tasks (create, update status, delete).
-- Department directory with optional contact email and automatic seeding of the provided fourteen departments.
-- Reminder logging endpoint to record when a follow-up notification is sent.
-- Figma-inspired interface with gradient hero header, glassmorphism cards, and responsive insight chips for a polished presentation.
+- Secure authentication with role selection for Presidents, Managers, and Employees.
+- Dashboard with concise metrics, upcoming deadlines, and reminder history laid out in a classic two-column view.
+- Dedicated task creation workspace plus a streamlined task roster with inline status updates and reminder triggers.
+- Calendar view that visualises deadlines across departments with colour-coded priorities and monthly quick stats.
+- Department directory with optional contacts and workload summaries, seeded with the fourteen provided departments.
+- Reminder management page to create follow-up notices and review the log in a separate hub.
 
 ## Requirements
 - PHP 8 or newer.
-- MySQL server (the default MAMP database works well).
+- MySQL server (the default MAMP database works great).
 - Web server such as Apache bundled with MAMP.
 
 ## Getting started with MAMP
 1. Copy the project into your MAMP web directory (typically `/Applications/MAMP/htdocs`).
 2. Open phpMyAdmin through `http://localhost/phpMyAdmin`.
-3. Import the database schema located at `database/schema.sql`. It creates tables, seeds the fourteen departments, and loads curated sample data (including calendar events) so dashboards, boards, and the calendar are populated immediately.
+3. Import the database schema located at `database/schema.sql`. It creates tables, seeds departments, tasks, calendar events, notifications, and three demo user accounts.
 4. Update the connection values in `db.php` if your credentials differ. The defaults are:
    - Username: `root`
    - Password: `root`
    - Database: `task_manager`
-5. Start MAMP servers and visit `http://localhost/tatarwar/index.php` (or the folder name you chose) to access the portal.
+5. Start MAMP servers and visit `http://localhost/tatarwar/login.php` (or the folder name you chose).
+6. Sign in with one of the seeded accounts or create a new one from the registration page.
+   - President: `president@taskmaster.test` / `president123`
+   - Manager: `manager@taskmaster.test` / `manager123`
+   - Employee: `employee@taskmaster.test` / `employee123`
 
 ## Database structure
+- `users`: authentication table with role, hashed password, and audit timestamps.
 - `departments`: stores department names and optional email contacts.
 - `tasks`: tracks task details, responsible department, priority, status, and due date.
 - `notifications`: records reminder messages tied to tasks.
-- `calendar_events`: stores calendar items that power the new monthly schedule view.
+- `calendar_events`: stores calendar items that power the monthly schedule view.
 
 ## Project structure
 ```
@@ -46,22 +50,27 @@ A lightweight web portal for coordinating departmental work. The interface is bu
 │   ├── footer.php
 │   ├── functions.php
 │   └── header.php
-├── db.php
-├── index.php
-├── tasks.php
-├── task_create.php
 ├── calendar.php
+├── db.php
 ├── departments.php
+├── index.php
+├── login.php
+├── logout.php
+├── reminders.php
+├── register.php
+├── send_reminder.php
+├── task_create.php
+├── tasks.php
 └── README.md
 ```
 
-## Customising the platform
-- Update the colour palette or typography in `assets/css/style.css`.
-- Extend the reminder logic in `send_reminder.php` to trigger actual emails or integrations.
-- Modify the `departments.php` form to capture additional metadata as required.
+## Classic design accents
+- **Gradient shell:** requested linear gradient background paired with frosted surfaces for a timeless control room aesthetic.
+- **Summary cards & tables:** reusable cards and elevated tables keep numbers, statuses, and priorities easy to scan.
+- **Dedicated hubs:** separate screens for reminders and task creation make navigation straightforward while keeping the layout tidy.
+- **Responsive layout:** collapses gracefully on smaller screens while preserving the primary navigation and KPI highlights.
 
-## Design highlights
-- **Hero workspace shell:** layered linear-gradient background with live status chip and quick access to navigation plus a new task shortcut.
-- **Insight overview cards:** reusable components show task health, overdue counts, and department activity in a glanceable grid.
-- **Calendar-first visibility:** colour-coded events highlight due dates by department alongside quick stats, mirroring modern productivity suites.
-- **Elevated data tables:** floating rows, pill badges, and accent chips make task priorities and statuses readable across devices.
+## Customisation tips
+- Adjust typography, spacing, or palette inside `assets/css/style.css` to match your brand.
+- Extend reminder delivery in `send_reminder.php` to trigger emails, SMS, or chat integrations.
+- Capture additional metadata by expanding the forms in `task_create.php` or `departments.php` and updating the schema accordingly.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A lightweight web portal for coordinating departmental work. The interface is bu
 
 ## Key features
 - Dashboard with quick metrics, upcoming deadlines, and reminder history.
+- Dedicated new-task workspace for capturing assignments with guidance and shortcuts.
+- Calendar view that visualises deadlines across departments with colour-coded priorities.
 - Full CRUD workflow for departmental tasks (create, update status, delete).
 - Department directory with optional contact email and automatic seeding of the provided fourteen departments.
 - Reminder logging endpoint to record when a follow-up notification is sent.
@@ -17,7 +19,7 @@ A lightweight web portal for coordinating departmental work. The interface is bu
 ## Getting started with MAMP
 1. Copy the project into your MAMP web directory (typically `/Applications/MAMP/htdocs`).
 2. Open phpMyAdmin through `http://localhost/phpMyAdmin`.
-3. Import the database schema located at `database/schema.sql`. It creates tables, seeds the fourteen departments, and loads a curated sample data set so dashboards and reminders are populated immediately.
+3. Import the database schema located at `database/schema.sql`. It creates tables, seeds the fourteen departments, and loads curated sample data (including calendar events) so dashboards, boards, and the calendar are populated immediately.
 4. Update the connection values in `db.php` if your credentials differ. The defaults are:
    - Username: `root`
    - Password: `root`
@@ -28,6 +30,7 @@ A lightweight web portal for coordinating departmental work. The interface is bu
 - `departments`: stores department names and optional email contacts.
 - `tasks`: tracks task details, responsible department, priority, status, and due date.
 - `notifications`: records reminder messages tied to tasks.
+- `calendar_events`: stores calendar items that power the new monthly schedule view.
 
 ## Project structure
 ```
@@ -46,6 +49,8 @@ A lightweight web portal for coordinating departmental work. The interface is bu
 ├── db.php
 ├── index.php
 ├── tasks.php
+├── task_create.php
+├── calendar.php
 ├── departments.php
 └── README.md
 ```
@@ -56,6 +61,7 @@ A lightweight web portal for coordinating departmental work. The interface is bu
 - Modify the `departments.php` form to capture additional metadata as required.
 
 ## Design highlights
-- **Hero workspace shell:** layered gradient header with live status chip and quick access to navigation plus a new task shortcut.
+- **Hero workspace shell:** layered linear-gradient background with live status chip and quick access to navigation plus a new task shortcut.
 - **Insight overview cards:** reusable components show task health, overdue counts, and department activity in a glanceable grid.
+- **Calendar-first visibility:** colour-coded events highlight due dates by department alongside quick stats, mirroring modern productivity suites.
 - **Elevated data tables:** floating rows, pill badges, and accent chips make task priorities and statuses readable across devices.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Department TaskMaster Suite
+# Task Management · Hail Region Municipality
 
 A classic, data-focused portal for coordinating departmental work. The interface uses HTML, CSS, and vanilla JavaScript, while PHP powers the backend against a MySQL database (fully compatible with MAMP on macOS).
 
@@ -25,9 +25,9 @@ A classic, data-focused portal for coordinating departmental work. The interface
    - Database: `task_manager`
 5. Start MAMP servers and visit `http://localhost/tatarwar/login.php` (or the folder name you chose).
 6. Sign in with one of the seeded accounts or create a new one from the registration page.
-   - President: `president@taskmaster.test` / `president123`
-   - Manager: `manager@taskmaster.test` / `manager123`
-   - Employee: `employee@taskmaster.test` / `employee123`
+   - President: `president@hailtasks.test` / `president123`
+   - Manager: `manager@hailtasks.test` / `manager123`
+   - Employee: `employee@hailtasks.test` / `employee123`
 
 ## Database structure
 - `users`: authentication table with role, hashed password, and audit timestamps.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,998 @@
+:root {
+    --gradient-start: #171B34;
+    --gradient-end: #0B0D21;
+    --surface: rgba(18, 22, 45, 0.55);
+    --surface-solid: #12162d;
+    --surface-alt: rgba(36, 43, 78, 0.75);
+    --surface-soft: rgba(255, 255, 255, 0.05);
+    --stroke: rgba(255, 255, 255, 0.08);
+    --stroke-strong: rgba(255, 255, 255, 0.16);
+    --text-strong: #f8fafc;
+    --text-muted: rgba(226, 232, 240, 0.7);
+    --text-subtle: rgba(148, 163, 184, 0.7);
+    --primary: #7c6cff;
+    --primary-strong: #8d7bff;
+    --primary-soft: rgba(124, 108, 255, 0.18);
+    --success: #2dd4bf;
+    --warning: #fbbf24;
+    --danger: #f87171;
+    --glass: blur(22px);
+    --radius-lg: 26px;
+    --radius-md: 18px;
+    --radius-sm: 12px;
+    --shadow-lg: 0 30px 60px rgba(6, 10, 30, 0.45);
+    --shadow-md: 0 20px 40px rgba(6, 10, 30, 0.32);
+    --shadow-sm: 0 10px 30px rgba(6, 10, 30, 0.25);
+    --font-family: 'Plus Jakarta Sans', 'Inter', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: var(--font-family);
+    color: var(--text-strong);
+    background: radial-gradient(circle at 10% 0%, #202a64 0%, transparent 55%),
+        radial-gradient(circle at 80% 0%, rgba(124, 108, 255, 0.25) 0%, transparent 55%),
+        linear-gradient(160deg, var(--gradient-start), var(--gradient-end));
+}
+
+a {
+    color: inherit;
+}
+
+.app-shell {
+    display: flex;
+    min-height: 100vh;
+    padding: 28px;
+    gap: 28px;
+}
+
+.sidebar {
+    width: 280px;
+    padding: 28px;
+    border-radius: var(--radius-lg);
+    background: linear-gradient(160deg, rgba(32, 41, 86, 0.85), rgba(15, 19, 41, 0.95));
+    border: 1px solid var(--stroke);
+    box-shadow: var(--shadow-lg);
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+}
+
+.sidebar-brand {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.brand-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 18px;
+    background: linear-gradient(135deg, #7c6cff, #22d3ee);
+    font-weight: 700;
+    font-size: 1.25rem;
+    letter-spacing: 0.05em;
+    color: #ffffff;
+    box-shadow: 0 14px 30px rgba(20, 10, 90, 0.45);
+}
+
+.brand-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.brand-title {
+    font-size: 1.3rem;
+    font-weight: 700;
+}
+
+.brand-subtitle {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.nav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border-radius: var(--radius-sm);
+    text-decoration: none;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    color: var(--text-subtle);
+    transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.nav-link::before {
+    content: '';
+    position: absolute;
+    inset: 2px;
+    border-radius: var(--radius-sm);
+    border: 1px solid transparent;
+    transition: border-color 0.2s ease;
+}
+
+.nav-link:hover {
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-strong);
+    transform: translateY(-1px);
+}
+
+.nav-link.active {
+    background: var(--primary-soft);
+    color: #ffffff;
+}
+
+.nav-link.active::before {
+    border-color: rgba(124, 108, 255, 0.6);
+}
+
+.nav-link.muted {
+    color: rgba(148, 163, 184, 0.35);
+    cursor: not-allowed;
+}
+
+.sidebar-footer {
+    margin-top: auto;
+    padding: 18px;
+    border-radius: var(--radius-md);
+    background: rgba(10, 12, 26, 0.55);
+    border: 1px solid var(--stroke);
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.main-area {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.page-header {
+    background: linear-gradient(135deg, rgba(26, 32, 61, 0.78), rgba(26, 30, 58, 0.45));
+    border-radius: var(--radius-lg);
+    padding: 32px 36px;
+    border: 1px solid var(--stroke);
+    box-shadow: var(--shadow-md);
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 32px;
+    position: relative;
+    overflow: hidden;
+}
+
+.page-header::after {
+    content: '';
+    position: absolute;
+    width: 220px;
+    height: 220px;
+    right: -90px;
+    top: -70px;
+    background: radial-gradient(circle, rgba(124, 108, 255, 0.45), transparent 60%);
+    pointer-events: none;
+}
+
+.page-titles {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.page-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--text-subtle);
+}
+
+.page-titles h1 {
+    margin: 0;
+    font-size: 2.25rem;
+    letter-spacing: -0.02em;
+}
+
+.page-titles p {
+    margin: 0;
+    max-width: 560px;
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.header-actions {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border-radius: 999px;
+    background: rgba(15, 19, 42, 0.65);
+    border: 1px solid rgba(124, 108, 255, 0.25);
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+}
+
+.status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--success);
+    box-shadow: 0 0 0 6px rgba(45, 212, 191, 0.1);
+}
+
+.ghost-action {
+    padding: 10px 18px;
+    border-radius: 999px;
+    border: 1px solid var(--stroke);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-muted);
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
+}
+
+.ghost-action:hover {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text-strong);
+    transform: translateY(-1px);
+}
+
+.primary-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 22px;
+    border-radius: 999px;
+    text-decoration: none;
+    background: linear-gradient(135deg, #7c6cff, #6ee7b7);
+    color: #0b0d21;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    box-shadow: 0 14px 34px rgba(124, 108, 255, 0.45);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-action:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 40px rgba(124, 108, 255, 0.55);
+}
+
+.page-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+}
+
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 24px;
+}
+
+.panel {
+    position: relative;
+    border-radius: var(--radius-lg);
+    padding: 28px;
+    background: linear-gradient(135deg, rgba(17, 21, 42, 0.8), rgba(16, 20, 44, 0.68));
+    border: 1px solid var(--stroke);
+    box-shadow: var(--shadow-sm);
+    backdrop-filter: var(--glass);
+}
+
+.panel::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid transparent;
+    pointer-events: none;
+    background: linear-gradient(135deg, rgba(124, 108, 255, 0.2), rgba(13, 17, 38, 0));
+    mask: linear-gradient(#fff, transparent 65%);
+    opacity: 0.6;
+}
+
+.metric-card {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.metric-label {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--text-subtle);
+}
+
+.metric-value {
+    font-size: 2.4rem;
+    font-weight: 700;
+}
+
+.metric-footnote {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+
+.alert-card {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+    background: linear-gradient(145deg, rgba(248, 113, 113, 0.18), rgba(15, 19, 42, 0.7));
+    border: 1px solid rgba(248, 113, 113, 0.35);
+}
+
+.alert-card h2 {
+    margin: 0 0 8px;
+}
+
+.link-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 20px;
+    border-radius: 14px;
+    text-decoration: none;
+    background: rgba(248, 250, 252, 0.12);
+    color: #fff;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.link-button:hover {
+    transform: translateY(-1px);
+    background: rgba(248, 250, 252, 0.18);
+}
+
+.split-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 24px;
+}
+
+.panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 22px;
+}
+
+.panel-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.panel-subtitle {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.empty-note {
+    padding: 24px;
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px dashed var(--stroke);
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.deadline-list,
+.performance-list,
+.activity-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.deadline-item,
+.activity-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 18px;
+}
+
+.task-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 6px;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+}
+
+.priority-badge {
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 600;
+}
+
+.priority-badge.high {
+    background: rgba(248, 113, 113, 0.18);
+    color: #fca5a5;
+}
+
+.priority-badge.medium {
+    background: rgba(250, 204, 21, 0.16);
+    color: #fde68a;
+}
+
+.priority-badge.low {
+    background: rgba(45, 212, 191, 0.18);
+    color: #a7f3d0;
+}
+
+.badge {
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    letter-spacing: 0.15em;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.badge.warning {
+    background: rgba(251, 191, 36, 0.2);
+    color: #facc15;
+}
+
+.badge.neutral {
+    background: rgba(148, 163, 184, 0.2);
+    color: #e2e8f0;
+}
+
+.performance-row {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.performance-row header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.progress-track {
+    width: 100%;
+    height: 10px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+    overflow: hidden;
+}
+
+.progress-fill {
+    display: block;
+    height: 100%;
+    background: linear-gradient(90deg, #7c6cff, #22d3ee);
+}
+
+.progress-meta {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.activity-item strong {
+    display: block;
+    margin-bottom: 4px;
+}
+
+.main-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 24px 32px;
+    border-radius: var(--radius-lg);
+    background: rgba(17, 21, 42, 0.7);
+    border: 1px solid var(--stroke);
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.toast {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    padding: 18px 24px;
+    border-radius: 16px;
+    background: rgba(17, 21, 42, 0.9);
+    border: 1px solid var(--stroke-strong);
+    color: var(--text-strong);
+    font-weight: 500;
+    opacity: 0;
+    transform: translateY(16px);
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    box-shadow: var(--shadow-md);
+    backdrop-filter: blur(12px);
+    max-width: 320px;
+    z-index: 10;
+}
+
+.toast.show {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.toast.error {
+    border-color: rgba(248, 113, 113, 0.4);
+    color: #fecaca;
+}
+
+.task-board {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+}
+
+.board-column {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 20px;
+    border-radius: var(--radius-md);
+    background: rgba(15, 19, 42, 0.5);
+    border: 1px solid var(--stroke);
+}
+
+.board-column header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.task-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 20px;
+    border-radius: var(--radius-md);
+    background: rgba(15, 19, 42, 0.75);
+    border: 1px solid rgba(124, 108, 255, 0.12);
+    box-shadow: 0 12px 26px rgba(10, 13, 32, 0.45);
+}
+
+.task-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    pointer-events: none;
+}
+
+.task-card h3 {
+    margin: 0;
+    font-size: 1.05rem;
+}
+
+.task-description {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.card-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.inline-form {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.inline-form select {
+    flex: 1;
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(17, 21, 42, 0.8);
+    color: var(--text-strong);
+}
+
+.secondary {
+    padding: 10px 16px;
+    border-radius: 12px;
+    border: 1px solid rgba(124, 108, 255, 0.25);
+    background: rgba(124, 108, 255, 0.15);
+    color: #e0e7ff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.secondary:hover {
+    background: rgba(124, 108, 255, 0.25);
+    transform: translateY(-1px);
+}
+
+.secondary[disabled] {
+    cursor: wait;
+    opacity: 0.7;
+}
+
+.action-row {
+    display: flex;
+    gap: 12px;
+}
+
+.action-row form {
+    margin: 0;
+}
+
+.reminder-stamp {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+
+.form-panel form {
+    display: grid;
+    gap: 18px;
+    margin-top: 20px;
+}
+
+.form-panel label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 0.9rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.form-panel input,
+.form-panel select,
+.form-panel textarea {
+    width: 100%;
+    padding: 12px 14px;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    background: rgba(14, 18, 38, 0.9);
+    color: var(--text-strong);
+    font-family: inherit;
+    font-size: 0.95rem;
+}
+
+.form-panel textarea {
+    min-height: 120px;
+    resize: vertical;
+}
+
+.form-panel button,
+.form-panel input[type="submit"],
+.form-panel button[type="submit"] {
+    justify-self: start;
+    padding: 12px 22px;
+    border-radius: 14px;
+    border: none;
+    background: linear-gradient(135deg, #7c6cff, #22d3ee);
+    color: #0b0d21;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    box-shadow: 0 18px 36px rgba(17, 12, 60, 0.45);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-panel button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 22px 44px rgba(17, 12, 60, 0.55);
+}
+
+.alert {
+    padding: 14px 18px;
+    border-radius: 14px;
+    font-size: 0.95rem;
+}
+
+.alert.error {
+    background: rgba(248, 113, 113, 0.14);
+    border: 1px solid rgba(248, 113, 113, 0.35);
+    color: #fecaca;
+}
+
+.alert.success {
+    background: rgba(45, 212, 191, 0.14);
+    border: 1px solid rgba(45, 212, 191, 0.35);
+    color: #99f6e4;
+}
+
+.department-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 22px;
+}
+
+.department-card {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.department-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.department-identity {
+    display: flex;
+    gap: 16px;
+}
+
+.department-dot {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    background: rgba(124, 108, 255, 0.25);
+    border: 1px solid rgba(124, 108, 255, 0.45);
+}
+
+.department-dot.blue { background: rgba(37, 99, 235, 0.35); border-color: rgba(37, 99, 235, 0.55); }
+.department-dot.pink { background: rgba(236, 72, 153, 0.35); border-color: rgba(236, 72, 153, 0.55); }
+.department-dot.orange { background: rgba(249, 115, 22, 0.35); border-color: rgba(249, 115, 22, 0.55); }
+.department-dot.green { background: rgba(16, 185, 129, 0.35); border-color: rgba(16, 185, 129, 0.55); }
+.department-dot.yellow { background: rgba(234, 179, 8, 0.35); border-color: rgba(234, 179, 8, 0.55); }
+
+.department-identity h2 {
+    margin: 0 0 6px;
+    font-size: 1.1rem;
+}
+
+.department-identity p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.department-stats {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 16px;
+    text-align: center;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.department-stats span {
+    display: block;
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: var(--text-strong);
+}
+
+.progress-wrap {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.progress-label {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.table-card table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+}
+
+.table-card th,
+.table-card td {
+    padding: 14px 18px;
+    text-align: left;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.table-card th {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-subtle);
+    font-size: 0.8rem;
+}
+
+.table-card tbody tr:hover {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+/* Database error page */
+
+body.db-error-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 40px;
+    text-align: left;
+}
+
+.db-error-card {
+    max-width: 620px;
+    width: 100%;
+    padding: 40px;
+    border-radius: var(--radius-lg);
+    background: linear-gradient(135deg, rgba(24, 28, 56, 0.85), rgba(10, 13, 32, 0.92));
+    border: 1px solid rgba(124, 108, 255, 0.28);
+    box-shadow: var(--shadow-lg);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.db-error-card h1 {
+    margin: 0;
+    font-size: 2rem;
+}
+
+.db-error-card p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.db-error-details {
+    padding: 16px 20px;
+    border-radius: 14px;
+    background: rgba(15, 19, 42, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    font-family: 'JetBrains Mono', 'Menlo', monospace;
+    font-size: 0.85rem;
+    color: #fca5a5;
+}
+
+.db-error-steps {
+    list-style: decimal;
+    padding-left: 20px;
+    margin: 0;
+    display: grid;
+    gap: 12px;
+    color: var(--text-muted);
+}
+
+.db-error-steps strong {
+    color: var(--text-strong);
+}
+
+.db-error-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.db-error-actions a {
+    padding: 12px 20px;
+    border-radius: 14px;
+    text-decoration: none;
+    background: rgba(124, 108, 255, 0.2);
+    border: 1px solid rgba(124, 108, 255, 0.35);
+    color: #ede9fe;
+    font-weight: 600;
+}
+
+/* Responsive adjustments */
+
+@media (max-width: 1200px) {
+    .app-shell {
+        flex-direction: column;
+    }
+
+    .sidebar {
+        width: 100%;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+        padding: 22px;
+    }
+
+    .sidebar-nav {
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+    }
+
+    .sidebar-footer {
+        display: none;
+    }
+}
+
+@media (max-width: 768px) {
+    .app-shell {
+        padding: 20px;
+    }
+
+    .page-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .header-actions {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .metrics-grid,
+    .split-grid,
+    .department-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .board-column {
+        padding: 16px;
+    }
+}
+
+@media (max-width: 520px) {
+    .app-shell {
+        padding: 16px;
+    }
+
+    .sidebar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 18px;
+    }
+
+    .header-actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .ghost-action,
+    .primary-action,
+    .status-pill {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .action-row {
+        flex-direction: column;
+    }
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,233 +1,146 @@
 :root {
-    --gradient-start: #77A1D3;
-    --gradient-mid: #79CBCA;
-    --gradient-end: #E684AE;
-    --surface: rgba(255, 255, 255, 0.78);
-    --surface-solid: rgba(255, 255, 255, 0.94);
-    --surface-alt: rgba(255, 255, 255, 0.68);
-    --surface-soft: rgba(255, 255, 255, 0.42);
-    --stroke: rgba(15, 23, 42, 0.08);
-    --stroke-strong: rgba(15, 23, 42, 0.16);
-    --text-strong: #0f172a;
-    --text-muted: rgba(15, 23, 42, 0.6);
-    --text-subtle: rgba(15, 23, 42, 0.4);
-    --primary: #2563eb;
-    --primary-strong: #1d4ed8;
-    --primary-soft: rgba(37, 99, 235, 0.18);
-    --success: #10b981;
-    --warning: #f59e0b;
-    --danger: #ef4444;
-    --glass: blur(26px) saturate(135%);
-    --radius-lg: 26px;
-    --radius-md: 18px;
-    --radius-sm: 12px;
-    --shadow-lg: 0 28px 60px rgba(15, 23, 42, 0.25);
-    --shadow-md: 0 18px 38px rgba(15, 23, 42, 0.18);
-    --shadow-sm: 0 10px 26px rgba(15, 23, 42, 0.14);
-    --font-family: 'Plus Jakarta Sans', 'Inter', 'Segoe UI', sans-serif;
+    --gradient-bg: linear-gradient(90deg, #77A1D3, #79CBCA, #E684AE);
+    --surface: rgba(255, 255, 255, 0.86);
+    --surface-strong: rgba(255, 255, 255, 0.95);
+    --surface-border: rgba(255, 255, 255, 0.45);
+    --shadow: 0 18px 40px -24px rgba(15, 23, 42, 0.45);
+    --text-primary: #1f2933;
+    --text-muted: #4b5563;
+    --accent: #2d5a88;
+    --accent-strong: #1d3e5c;
+    --danger: #b91c1c;
+    --success: #1e7a4d;
+    --warning: #b45309;
+    --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
-*, *::before, *::after {
+* {
     box-sizing: border-box;
 }
 
 body {
     margin: 0;
-    min-height: 100vh;
     font-family: var(--font-family);
-    color: var(--text-strong);
-    background: linear-gradient(90deg, var(--gradient-start), var(--gradient-mid), var(--gradient-end));
-    background-attachment: fixed;
+    background: var(--gradient-bg);
+    color: var(--text-primary);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
 }
 
 a {
-    color: inherit;
+    color: var(--accent);
+    text-decoration: none;
 }
 
-.app-shell {
+a:hover {
+    color: var(--accent-strong);
+}
+
+.app-body .app-shell {
     display: flex;
     min-height: 100vh;
-    padding: 28px;
-    gap: 28px;
+    backdrop-filter: blur(12px);
 }
 
 .sidebar {
-    width: 280px;
-    padding: 28px;
-    border-radius: var(--radius-lg);
-    background: linear-gradient(160deg, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.72));
-    border: 1px solid var(--stroke);
-    box-shadow: var(--shadow-lg);
-    backdrop-filter: var(--glass);
+    width: 248px;
+    background: var(--surface-strong);
+    border-right: 1px solid var(--surface-border);
     display: flex;
     flex-direction: column;
+    padding: 28px 24px;
     gap: 32px;
 }
 
 .sidebar-brand {
     display: flex;
     align-items: center;
-    gap: 16px;
+    gap: 12px;
 }
 
 .brand-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 56px;
-    height: 56px;
-    border-radius: 18px;
-    background: linear-gradient(135deg, #2563eb, #38bdf8);
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(45, 90, 136, 0.12);
+    color: var(--accent-strong);
     font-weight: 700;
-    font-size: 1.25rem;
-    letter-spacing: 0.05em;
-    color: #ffffff;
-    box-shadow: 0 14px 30px rgba(37, 99, 235, 0.35);
-}
-
-.brand-copy {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
+    font-size: 1.1rem;
+    display: grid;
+    place-items: center;
 }
 
 .brand-title {
-    font-size: 1.3rem;
-    font-weight: 700;
+    font-size: 1rem;
+    font-weight: 600;
 }
 
 .brand-subtitle {
-    font-size: 0.9rem;
+    font-size: 0.82rem;
     color: var(--text-muted);
 }
 
 .sidebar-nav {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 8px;
 }
 
 .nav-link {
-    position: relative;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 12px 16px;
-    border-radius: var(--radius-sm);
-    text-decoration: none;
+    padding: 10px 12px;
+    border-radius: 10px;
     font-weight: 500;
-    letter-spacing: 0.01em;
-    color: var(--text-subtle);
-    transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
-}
-
-.nav-link::before {
-    content: '';
-    position: absolute;
-    inset: 2px;
-    border-radius: var(--radius-sm);
-    border: 1px solid transparent;
-    transition: border-color 0.2s ease;
+    color: var(--text-muted);
+    transition: background 0.2s, color 0.2s;
 }
 
 .nav-link:hover {
-    background: rgba(37, 99, 235, 0.08);
-    color: var(--text-strong);
-    transform: translateY(-1px);
+    background: rgba(45, 90, 136, 0.08);
+    color: var(--accent-strong);
 }
 
 .nav-link.active {
-    background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(56, 189, 248, 0.18));
-    color: var(--primary-strong);
-}
-
-.nav-link.active::before {
-    border-color: rgba(37, 99, 235, 0.3);
-}
-
-.nav-link.muted {
-    color: rgba(148, 163, 184, 0.35);
-    cursor: not-allowed;
+    background: rgba(45, 90, 136, 0.18);
+    color: var(--accent-strong);
 }
 
 .sidebar-footer {
-    margin-top: auto;
-    padding: 18px;
-    border-radius: var(--radius-md);
-    background: rgba(255, 255, 255, 0.65);
-    border: 1px solid var(--stroke);
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     color: var(--text-muted);
+    line-height: 1.4;
 }
 
 .main-area {
     flex: 1;
-    min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 24px;
+    background: rgba(255, 255, 255, 0.72);
 }
 
-.page-header {
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.65));
-    border-radius: var(--radius-lg);
-    padding: 32px 36px;
-    border: 1px solid var(--stroke);
-    box-shadow: var(--shadow-md);
+.topbar {
     display: flex;
     justify-content: space-between;
-    align-items: flex-start;
-    gap: 32px;
-    position: relative;
-    overflow: hidden;
-    backdrop-filter: var(--glass);
+    align-items: center;
+    padding: 24px 32px 12px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.5);
 }
 
-.page-header::after {
-    content: '';
-    position: absolute;
-    width: 220px;
-    height: 220px;
-    right: -80px;
-    top: -90px;
-    background: radial-gradient(circle, rgba(37, 99, 235, 0.25), transparent 60%);
-    pointer-events: none;
-}
-
-.page-titles {
-    position: relative;
-    z-index: 1;
+.topbar-brand {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 2px;
+    color: var(--accent-strong);
+    font-weight: 600;
 }
 
-.page-eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 0.85rem;
+.topbar-eyebrow {
     text-transform: uppercase;
-    letter-spacing: 0.16em;
-    color: var(--text-subtle);
-}
-
-.page-titles h1 {
-    margin: 0;
-    font-size: 2.25rem;
-    letter-spacing: -0.02em;
-}
-
-.page-titles p {
-    margin: 0;
-    max-width: 560px;
+    font-size: 0.7rem;
+    letter-spacing: 0.14em;
     color: var(--text-muted);
-    line-height: 1.6;
 }
 
-.header-actions {
-    position: relative;
-    z-index: 1;
+.topbar-actions {
     display: flex;
     align-items: center;
     gap: 16px;
@@ -236,325 +149,471 @@ a {
 .status-pill {
     display: inline-flex;
     align-items: center;
-    gap: 8px;
-    padding: 10px 16px;
+    gap: 6px;
+    background: rgba(45, 90, 136, 0.1);
+    color: var(--accent-strong);
+    padding: 6px 12px;
     border-radius: 999px;
-    background: rgba(37, 99, 235, 0.12);
-    border: 1px solid rgba(37, 99, 235, 0.18);
-    color: var(--primary-strong);
-    font-size: 0.85rem;
-    letter-spacing: 0.02em;
+    font-size: 0.8rem;
 }
 
 .status-dot {
-    width: 10px;
-    height: 10px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
     background: var(--success);
-    box-shadow: 0 0 0 6px rgba(45, 212, 191, 0.1);
+    box-shadow: 0 0 0 4px rgba(30, 122, 77, 0.2);
 }
 
-.ghost-action {
-    padding: 10px 18px;
-    border-radius: 999px;
-    border: 1px solid rgba(37, 99, 235, 0.18);
-    background: rgba(37, 99, 235, 0.08);
+.user-chip {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 6px 12px;
+    border-radius: 10px;
+    background: rgba(45, 90, 136, 0.08);
+}
+
+.user-name {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.user-role {
+    font-size: 0.75rem;
     color: var(--text-muted);
-    font-weight: 500;
-    letter-spacing: 0.02em;
-    cursor: pointer;
-    transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
 }
 
-.ghost-action:hover {
-    background: rgba(37, 99, 235, 0.16);
-    color: var(--text-strong);
-    transform: translateY(-1px);
+.primary-action,
+.ghost-action {
+    border: none;
+    border-radius: 10px;
+    font-weight: 600;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: transform 0.15s ease, background 0.2s ease;
 }
 
 .primary-action {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 12px 22px;
-    border-radius: 999px;
-    text-decoration: none;
-    background: linear-gradient(135deg, #2563eb, #38bdf8);
-    color: #ffffff;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    box-shadow: 0 16px 36px rgba(37, 99, 235, 0.28);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    background: var(--accent);
+    color: #fff;
+    padding: 10px 20px;
+    box-shadow: 0 12px 24px -16px rgba(45, 90, 136, 0.9);
 }
 
 .primary-action:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 20px 42px rgba(37, 99, 235, 0.36);
+    transform: translateY(-1px);
+    background: var(--accent-strong);
+}
+
+.ghost-action {
+    background: transparent;
+    color: var(--accent-strong);
+    padding: 8px 14px;
+}
+
+.ghost-action:hover {
+    background: rgba(45, 90, 136, 0.12);
+}
+
+.ghost-action.danger {
+    color: var(--danger);
+}
+
+.page-header {
+    padding: 12px 32px 16px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.55);
+}
+
+.page-header-copy h1 {
+    margin: 0 0 6px;
+    font-size: 1.9rem;
+}
+
+.page-header-copy p {
+    margin: 0;
+    color: var(--text-muted);
+    max-width: 720px;
 }
 
 .page-content {
+    padding: 24px 32px 48px;
     flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 28px;
 }
 
-.metrics-grid {
+.summary-cards {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+    margin-bottom: 24px;
 }
 
-.panel {
-    position: relative;
-    border-radius: var(--radius-lg);
-    padding: 28px;
-    background: linear-gradient(135deg, var(--surface-solid), var(--surface-alt));
-    border: 1px solid var(--stroke);
-    box-shadow: var(--shadow-sm);
-    backdrop-filter: var(--glass);
+.summary-card {
+    background: var(--surface);
+    border-radius: 18px;
+    padding: 18px;
+    box-shadow: var(--shadow);
+    border: 1px solid var(--surface-border);
 }
 
-.panel::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    border: 1px solid transparent;
-    pointer-events: none;
-    background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(255, 255, 255, 0));
-    mask: linear-gradient(#fff, transparent 70%);
-    opacity: 0.8;
-}
-
-.metric-card {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.metric-label {
-    font-size: 0.9rem;
+.summary-label {
+    font-size: 0.85rem;
     text-transform: uppercase;
-    letter-spacing: 0.16em;
-    color: var(--text-subtle);
-}
-
-.metric-value {
-    font-size: 2.4rem;
-    font-weight: 700;
-}
-
-.metric-footnote {
-    font-size: 0.95rem;
+    letter-spacing: 0.08em;
     color: var(--text-muted);
 }
 
-.alert-card {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 24px;
-    background: linear-gradient(145deg, rgba(239, 68, 68, 0.12), rgba(255, 255, 255, 0.85));
-    border: 1px solid rgba(239, 68, 68, 0.28);
+.summary-value {
+    display: block;
+    font-size: 2rem;
+    font-weight: 700;
+    margin-top: 6px;
 }
 
-.alert-card h2 {
-    margin: 0 0 8px;
+.summary-footnote {
+    color: var(--text-muted);
+    font-size: 0.85rem;
 }
 
-.link-button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 12px 20px;
-    border-radius: 14px;
-    text-decoration: none;
-    background: rgba(37, 99, 235, 0.12);
-    color: var(--primary-strong);
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    border: 1px solid rgba(37, 99, 235, 0.2);
-    transition: transform 0.2s ease, background 0.2s ease;
+.panel {
+    background: var(--surface);
+    border-radius: 18px;
+    border: 1px solid var(--surface-border);
+    box-shadow: var(--shadow);
+    padding: 22px;
 }
 
-.link-button:hover {
-    transform: translateY(-1px);
-    background: rgba(37, 99, 235, 0.2);
-}
-
-.split-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 24px;
+.classic-panel + .classic-panel {
+    margin-top: 24px;
 }
 
 .panel-header {
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    gap: 16px;
-    margin-bottom: 22px;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 18px;
 }
 
 .panel-header h2 {
     margin: 0;
-    font-size: 1.2rem;
+    font-size: 1.25rem;
 }
 
-.panel-subtitle {
+.panel-header span {
+    font-size: 0.85rem;
     color: var(--text-muted);
-    font-size: 0.95rem;
 }
 
 .empty-note {
-    padding: 24px;
-    border-radius: var(--radius-md);
-    background: rgba(255, 255, 255, 0.7);
-    border: 1px dashed rgba(15, 23, 42, 0.16);
+    padding: 20px;
+    border-radius: 14px;
+    background: rgba(15, 23, 42, 0.05);
+    color: var(--text-muted);
     text-align: center;
+}
+
+.alert {
+    padding: 14px 18px;
+    border-radius: 12px;
+    margin-bottom: 18px;
+    font-weight: 500;
+}
+
+.alert.success {
+    background: rgba(30, 122, 77, 0.12);
+    color: var(--success);
+}
+
+.alert.error {
+    background: rgba(185, 28, 28, 0.12);
+    color: var(--danger);
+}
+
+.global-alert {
+    margin-bottom: 24px;
+}
+
+.content-columns {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 24px;
+    align-items: start;
+}
+
+.content-columns.form-layout {
+    grid-template-columns: 3fr 2fr;
+}
+
+.column-main {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.column-side {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.attention-panel {
+    background: rgba(217, 119, 6, 0.16);
+    border: 1px solid rgba(217, 119, 6, 0.4);
+}
+
+.attention-panel h2 {
+    margin-top: 0;
+}
+
+.stacked-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.stacked-item {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: center;
+}
+
+.item-main strong {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.item-sub {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.item-meta {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.priority-chip {
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.priority-chip.high { background: rgba(220, 38, 38, 0.12); color: #b91c1c; }
+.priority-chip.medium { background: rgba(217, 119, 6, 0.12); color: var(--warning); }
+.priority-chip.low { background: rgba(30, 122, 77, 0.12); color: var(--success); }
+
+.due-chip {
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    background: rgba(45, 90, 136, 0.1);
+    color: var(--accent-strong);
+}
+
+.due-chip.status-overdue {
+    background: rgba(185, 28, 28, 0.12);
+    color: var(--danger);
+}
+
+.due-chip.status-warning {
+    background: rgba(217, 119, 6, 0.12);
+    color: var(--warning);
+}
+
+.table-scroll {
+    overflow-x: auto;
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 720px;
+}
+
+.data-table th,
+.data-table td {
+    padding: 12px 14px;
+    text-align: left;
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    vertical-align: top;
+}
+
+.data-table th {
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
     color: var(--text-muted);
 }
 
-.deadline-list,
-.performance-list,
-.activity-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+.table-note {
+    margin: 6px 0 0;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.inline-form select {
+    border: 1px solid rgba(15, 23, 42, 0.2);
+    border-radius: 8px;
+    padding: 6px 10px;
+    background: #fff;
+    font-family: inherit;
+}
+
+.inline-form select:focus {
+    outline: 2px solid rgba(45, 90, 136, 0.25);
+    outline-offset: 1px;
+}
+
+.action-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.actions-col {
+    width: 180px;
+}
+
+.reminder-stamp {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.progress-inline {
+    width: 100%;
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.08);
+    overflow: hidden;
+    margin-bottom: 6px;
+}
+
+.progress-bar {
+    display: block;
+    height: 100%;
+    background: var(--accent);
+}
+
+.progress-label {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+
+.classic-form {
     display: flex;
     flex-direction: column;
     gap: 18px;
 }
 
-.deadline-item,
-.activity-item {
+.form-row {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    flex-wrap: wrap;
     gap: 18px;
 }
 
-.task-meta {
+.form-group {
+    flex: 1 1 200px;
     display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    margin-top: 6px;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.form-group label {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+    border-radius: 10px;
+    border: 1px solid rgba(15, 23, 42, 0.18);
+    padding: 10px 12px;
+    font-family: inherit;
+    font-size: 0.95rem;
+    background: rgba(255, 255, 255, 0.9);
+}
+
+.form-group textarea {
+    resize: vertical;
+}
+
+.form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+.insight-list {
+    margin: 0 0 18px;
+    padding: 0 0 0 18px;
     color: var(--text-muted);
-    font-size: 0.92rem;
+    line-height: 1.5;
 }
 
-.priority-badge {
-    padding: 4px 10px;
-    border-radius: 999px;
-    font-size: 0.8rem;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
+.calendar-preview {
+    background: rgba(45, 90, 136, 0.08);
+    padding: 18px;
+    border-radius: 14px;
+    text-align: center;
+}
+
+.calendar-preview-month {
+    display: block;
     font-weight: 600;
+    margin-bottom: 6px;
 }
 
-.priority-badge.high {
-    background: rgba(239, 68, 68, 0.14);
-    color: var(--danger);
-}
-
-.priority-badge.medium {
-    background: rgba(245, 158, 11, 0.14);
-    color: var(--warning);
-}
-
-.priority-badge.low {
-    background: rgba(16, 185, 129, 0.14);
-    color: var(--success);
-}
-
-.badge {
-    padding: 6px 14px;
-    border-radius: 999px;
-    font-size: 0.75rem;
-    letter-spacing: 0.15em;
-    font-weight: 600;
-    text-transform: uppercase;
-}
-
-.badge.warning {
-    background: rgba(245, 158, 11, 0.16);
-    color: var(--warning);
-}
-
-.badge.neutral {
-    background: rgba(148, 163, 184, 0.2);
-    color: rgba(15, 23, 42, 0.55);
-}
-
-.performance-row {
+.activity-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
     display: flex;
     flex-direction: column;
     gap: 12px;
 }
 
-.performance-row header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 16px;
-}
-
-.progress-track {
-    width: 100%;
-    height: 10px;
-    border-radius: 999px;
-    background: rgba(15, 23, 42, 0.08);
-    overflow: hidden;
-}
-
-.progress-fill {
+.activity-item strong {
     display: block;
-    height: 100%;
-    background: linear-gradient(90deg, #2563eb, #38bdf8);
+    font-weight: 600;
 }
 
-.progress-meta {
-    display: flex;
-    justify-content: space-between;
+.activity-item span,
+.activity-item time {
     font-size: 0.85rem;
     color: var(--text-muted);
 }
 
-.activity-item strong {
-    display: block;
-    margin-bottom: 4px;
-}
-
 .main-footer {
+    margin-top: auto;
+    padding: 20px 32px 32px;
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    padding: 24px 32px;
-    border-radius: var(--radius-lg);
-    background: rgba(255, 255, 255, 0.72);
-    border: 1px solid var(--stroke);
-    color: var(--text-muted);
-    font-size: 0.9rem;
+    color: rgba(31, 41, 51, 0.7);
+    font-size: 0.85rem;
 }
 
 .toast {
     position: fixed;
     bottom: 24px;
     right: 24px;
-    padding: 18px 24px;
-    border-radius: 16px;
-    background: rgba(255, 255, 255, 0.9);
-    border: 1px solid var(--stroke-strong);
-    color: var(--text-strong);
-    font-weight: 500;
+    background: var(--surface-strong);
+    border-radius: 12px;
+    padding: 12px 18px;
+    box-shadow: 0 10px 30px -20px rgba(15, 23, 42, 0.6);
     opacity: 0;
-    transform: translateY(16px);
-    transition: opacity 0.25s ease, transform 0.25s ease;
-    box-shadow: var(--shadow-md);
-    backdrop-filter: blur(12px);
-    max-width: 320px;
-    z-index: 10;
+    transform: translateY(20px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    pointer-events: none;
 }
 
 .toast.show {
@@ -563,405 +622,26 @@ a {
 }
 
 .toast.error {
-    border-color: rgba(239, 68, 68, 0.4);
-    color: var(--danger);
+    background: rgba(185, 28, 28, 0.9);
+    color: #fff;
 }
 
 .toast.success {
-    border-color: rgba(16, 185, 129, 0.35);
-    color: var(--success);
+    background: rgba(30, 122, 77, 0.92);
+    color: #fff;
 }
 
-.task-board {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 20px;
-}
-
-.board-column {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    padding: 20px;
-    border-radius: var(--radius-md);
-    background: rgba(255, 255, 255, 0.72);
-    border: 1px solid var(--stroke);
-    backdrop-filter: var(--glass);
-}
-
-.board-column header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 16px;
-}
-
-.task-card {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: 14px;
-    padding: 20px;
-    border-radius: var(--radius-md);
-    background: rgba(255, 255, 255, 0.85);
-    border: 1px solid rgba(37, 99, 235, 0.12);
-    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.14);
-}
-
-.task-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    border: 1px solid rgba(37, 99, 235, 0.05);
-    pointer-events: none;
-}
-
-.task-card h3 {
-    margin: 0;
-    font-size: 1.05rem;
-}
-
-.task-description {
-    margin: 0;
-    color: var(--text-muted);
-}
-
-.card-actions {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.inline-form {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-}
-
-.inline-form select {
-    flex: 1;
-    padding: 10px 12px;
-    border-radius: 10px;
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    background: rgba(255, 255, 255, 0.9);
-    color: var(--text-strong);
-}
-
-.secondary {
-    padding: 10px 16px;
-    border-radius: 12px;
-    border: 1px solid rgba(37, 99, 235, 0.2);
-    background: rgba(37, 99, 235, 0.12);
-    color: var(--primary-strong);
-    font-weight: 600;
-    cursor: pointer;
-    transition: transform 0.2s ease, background 0.2s ease;
-}
-
-.secondary:hover {
-    background: rgba(37, 99, 235, 0.2);
-    transform: translateY(-1px);
-}
-
-.secondary[disabled] {
-    cursor: wait;
-    opacity: 0.7;
-}
-
-.action-row {
-    display: flex;
-    gap: 12px;
-}
-
-.action-row form {
-    margin: 0;
-}
-
-.reminder-stamp {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-}
-
-.form-panel form {
-    display: grid;
-    gap: 18px;
-    margin-top: 20px;
-}
-
-.form-panel label {
-    display: block;
-    margin-bottom: 6px;
-    font-size: 0.9rem;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--text-subtle);
-}
-
-.form-panel input,
-.form-panel select,
-.form-panel textarea {
-    width: 100%;
-    padding: 12px 14px;
-    border-radius: 14px;
-    border: 1px solid rgba(148, 163, 184, 0.3);
-    background: rgba(255, 255, 255, 0.92);
-    color: var(--text-strong);
-    font-family: inherit;
-    font-size: 0.95rem;
-}
-
-.form-panel input:focus,
-.form-panel select:focus,
-.form-panel textarea:focus {
-    outline: none;
-    border-color: rgba(37, 99, 235, 0.45);
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
-}
-
-.form-panel textarea {
-    min-height: 120px;
-    resize: vertical;
-}
-
-.form-panel button,
-.form-panel input[type="submit"],
-.form-panel button[type="submit"] {
-    justify-self: start;
-    padding: 12px 22px;
-    border-radius: 14px;
-    border: none;
-    background: linear-gradient(135deg, #2563eb, #38bdf8);
-    color: #ffffff;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    cursor: pointer;
-    box-shadow: 0 18px 36px rgba(37, 99, 235, 0.25);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.form-panel button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 22px 44px rgba(37, 99, 235, 0.35);
-}
-
-.form-page {
-    display: grid;
-    grid-template-columns: minmax(0, 2.1fr) minmax(260px, 1fr);
-    gap: 24px;
-}
-
-.form-primary {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
-}
-
-.form-header h2 {
-    margin: 0 0 6px;
-    font-size: 1.5rem;
-}
-
-.form-header p {
-    margin: 0;
-    color: var(--text-muted);
-    max-width: 420px;
-}
-
-.task-form {
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-}
-
-.form-group {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-}
-
-.form-group label {
-    font-weight: 600;
-    font-size: 0.95rem;
-}
-
-.task-form input[type="text"],
-.task-form input[type="date"],
-.task-form select,
-.task-form textarea {
-    padding: 12px 14px;
-    border-radius: 14px;
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    background: rgba(255, 255, 255, 0.92);
-    font-size: 0.95rem;
-    color: var(--text-strong);
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.task-form textarea {
-    resize: vertical;
-}
-
-.task-form input:focus,
-.task-form select:focus,
-.task-form textarea:focus {
-    outline: none;
-    border-color: rgba(37, 99, 235, 0.5);
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
-}
-
-.form-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 20px;
-}
-
-.priority-pills {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-}
-
-.pill-option {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 16px;
-    border-radius: 999px;
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    background: rgba(255, 255, 255, 0.88);
-    font-weight: 600;
-    cursor: pointer;
-    transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
-}
-
-.pill-option input {
-    display: none;
-}
-
-.pill-option span {
-    font-size: 0.9rem;
-    color: var(--text-muted);
-}
-
-.pill-option input:checked + span,
-.pill-option:hover span {
-    color: var(--primary-strong);
-}
-
-.pill-option input:checked ~ span,
-.pill-option input:checked + span {
-    font-weight: 700;
-}
-
-.pill-option input:checked + span,
-.pill-option input:checked ~ span,
-.pill-option:hover {
-    border-color: rgba(37, 99, 235, 0.38);
-    background: rgba(37, 99, 235, 0.12);
-    transform: translateY(-1px);
-}
-
-.form-actions {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 16px;
-}
-
-.form-actions .ghost-action {
-    order: 1;
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    background: rgba(148, 163, 184, 0.12);
-    color: var(--text-muted);
-}
-
-.form-actions .ghost-action:hover {
-    background: rgba(148, 163, 184, 0.2);
-}
-
-.form-sidebar {
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-}
-
-.form-sidebar h2 {
-    margin: 0;
-    font-size: 1.1rem;
-}
-
-.form-tips {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    color: var(--text-muted);
-    font-size: 0.95rem;
-}
-
-.form-tips strong {
-    color: var(--text-strong);
-}
-
-.calendar-preview {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    padding: 18px;
-    border-radius: var(--radius-md);
-    background: rgba(37, 99, 235, 0.1);
-    border: 1px dashed rgba(37, 99, 235, 0.2);
-}
-
-.calendar-preview-month {
-    font-weight: 700;
-    color: var(--primary-strong);
-}
-
-@media (max-width: 960px) {
-    .form-page {
-        grid-template-columns: 1fr;
-    }
-
-    .form-sidebar {
-        order: -1;
-    }
-
-    .form-actions {
-        flex-direction: column-reverse;
-        align-items: stretch;
-    }
-
-    .form-actions .ghost-action {
-        width: 100%;
-        justify-content: center;
-    }
-
-    .form-actions .primary-action {
-        width: 100%;
-        justify-content: center;
-    }
-}
-
+/* Calendar */
 .calendar-hero {
     display: flex;
     justify-content: space-between;
     align-items: center;
     gap: 24px;
+    margin-bottom: 24px;
 }
 
 .calendar-hero h2 {
-    margin: 0 0 6px;
-    font-size: 2rem;
-}
-
-.calendar-hero p {
     margin: 0;
-    color: var(--text-muted);
-    max-width: 520px;
 }
 
 .calendar-nav {
@@ -972,534 +652,282 @@ a {
 
 .calendar-nav-current {
     font-weight: 600;
-    color: var(--text-strong);
-}
-
-.calendar-nav .ghost-action {
-    background: rgba(255, 255, 255, 0.92);
-    border: 1px solid rgba(148, 163, 184, 0.32);
-    color: var(--text-strong);
-}
-
-.calendar-nav .ghost-action:hover {
-    background: rgba(37, 99, 235, 0.12);
 }
 
 .calendar-layout {
     display: grid;
-    grid-template-columns: minmax(240px, 0.9fr) minmax(0, 2.6fr);
+    grid-template-columns: 1fr 3fr;
     gap: 24px;
 }
 
-.calendar-meta {
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-}
-
-.calendar-meta h3 {
-    margin: 0;
-    font-size: 1rem;
-}
-
 .calendar-meta ul {
+    list-style: none;
     margin: 0;
     padding: 0;
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
 }
 
 .calendar-meta li {
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    font-size: 0.95rem;
+    padding: 6px 0;
+    font-size: 0.9rem;
     color: var(--text-muted);
 }
 
-.calendar-meta li strong {
-    color: var(--text-strong);
-    font-size: 1.05rem;
-}
-
 .legend {
-    gap: 10px;
-}
-
-.legend li {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 10px;
+    margin-top: 12px;
+    display: grid;
+    gap: 6px;
 }
 
 .legend-dot {
-    width: 12px;
-    height: 12px;
+    width: 10px;
+    height: 10px;
     border-radius: 50%;
     display: inline-block;
+    margin-right: 8px;
 }
 
 .calendar-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    padding: 24px;
+    display: grid;
+    grid-template-rows: auto 1fr;
+    gap: 12px;
 }
 
 .calendar-grid-head {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
-    gap: 12px;
-    font-size: 0.9rem;
-    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
     color: var(--text-muted);
 }
 
 .calendar-grid-body {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
-    gap: 12px;
+    grid-auto-rows: minmax(110px, auto);
+    gap: 6px;
 }
 
 .calendar-cell {
-    min-height: 140px;
-    border-radius: var(--radius-md);
-    border: 1px solid rgba(148, 163, 184, 0.28);
-    background: rgba(255, 255, 255, 0.9);
-    padding: 12px;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    padding: 10px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.calendar-cell.today {
-    border-color: rgba(37, 99, 235, 0.45);
-    box-shadow: 0 12px 28px rgba(37, 99, 235, 0.18);
+    gap: 6px;
 }
 
 .calendar-cell.muted {
-    opacity: 0.55;
+    opacity: 0.5;
 }
 
-.calendar-cell:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.18);
+.calendar-cell.today {
+    border-color: rgba(45, 90, 136, 0.6);
+    box-shadow: inset 0 0 0 2px rgba(45, 90, 136, 0.3);
 }
 
 .calendar-cell-header {
     display: flex;
-    justify-content: flex-end;
-}
-
-.calendar-date-number {
-    font-weight: 700;
-    color: var(--text-strong);
+    justify-content: space-between;
+    font-weight: 600;
 }
 
 .calendar-events {
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    flex: 1;
+    gap: 4px;
 }
 
 .calendar-event {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    padding: 10px 12px;
-    border-radius: 12px;
-    border: 1px solid rgba(148, 163, 184, 0.24);
-    background: rgba(255, 255, 255, 0.94);
-    font-size: 0.85rem;
+    padding: 6px;
+    border-radius: 10px;
+    font-size: 0.75rem;
+    background: rgba(45, 90, 136, 0.12);
 }
 
-.calendar-event .event-title {
-    font-weight: 600;
-    color: var(--text-strong);
+.priority-high {
+    border-left: 3px solid #b91c1c;
 }
 
-.calendar-event .event-meta {
-    color: var(--text-muted);
-    font-size: 0.8rem;
+.priority-medium {
+    border-left: 3px solid #b45309;
 }
 
-.calendar-event.priority-high {
-    border-color: rgba(239, 68, 68, 0.3);
+.priority-low {
+    border-left: 3px solid #1e7a4d;
 }
 
-.calendar-event.priority-medium {
-    border-color: rgba(245, 158, 11, 0.3);
-}
+.tag-blue { background: rgba(59, 130, 246, 0.18); }
+.tag-purple { background: rgba(168, 85, 247, 0.18); }
+.tag-green { background: rgba(16, 185, 129, 0.18); }
+.tag-amber { background: rgba(245, 158, 11, 0.18); }
+.tag-pink { background: rgba(236, 72, 153, 0.18); }
+.tag-teal { background: rgba(13, 148, 136, 0.18); }
+.tag-indigo { background: rgba(99, 102, 241, 0.18); }
+.tag-coral { background: rgba(249, 115, 22, 0.18); }
 
-.calendar-event.priority-low {
-    border-color: rgba(16, 185, 129, 0.3);
-}
-
-.empty-slot {
-    color: rgba(148, 163, 184, 0.6);
-    font-size: 0.8rem;
-}
-
-.tag-blue {
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.25), rgba(59, 130, 246, 0.05));
-}
-
-.tag-purple {
-    background: linear-gradient(135deg, rgba(147, 51, 234, 0.25), rgba(147, 51, 234, 0.05));
-}
-
-.tag-green {
-    background: linear-gradient(135deg, rgba(16, 185, 129, 0.25), rgba(16, 185, 129, 0.05));
-}
-
-.tag-amber {
-    background: linear-gradient(135deg, rgba(245, 158, 11, 0.25), rgba(245, 158, 11, 0.05));
-}
-
-.tag-pink {
-    background: linear-gradient(135deg, rgba(236, 72, 153, 0.25), rgba(236, 72, 153, 0.05));
-}
-
-.tag-teal {
-    background: linear-gradient(135deg, rgba(20, 184, 166, 0.25), rgba(20, 184, 166, 0.05));
-}
-
-.tag-indigo {
-    background: linear-gradient(135deg, rgba(99, 102, 241, 0.25), rgba(99, 102, 241, 0.05));
-}
-
-.tag-coral {
-    background: linear-gradient(135deg, rgba(244, 114, 182, 0.25), rgba(244, 114, 182, 0.05));
-}
-
-.legend-dot.tag-blue { background: #3b82f6; }
-.legend-dot.tag-purple { background: #9333ea; }
-.legend-dot.tag-green { background: #10b981; }
-.legend-dot.tag-amber { background: #f59e0b; }
-.legend-dot.tag-pink { background: #ec4899; }
-.legend-dot.tag-teal { background: #14b8a6; }
-.legend-dot.tag-indigo { background: #6366f1; }
-.legend-dot.tag-coral { background: #f472b6; }
-
-@media (max-width: 1100px) {
-    .calendar-layout {
-        grid-template-columns: 1fr;
-    }
-
-    .calendar-meta {
-        order: -1;
-        flex-direction: row;
-        flex-wrap: wrap;
-    }
-
-    .calendar-meta h3 {
-        width: 100%;
-    }
-
-    .calendar-meta ul {
-        flex: 1;
-    }
-}
-
-@media (max-width: 720px) {
-    .calendar-grid-body,
-    .calendar-grid-head {
-        gap: 8px;
-    }
-
-    .calendar-cell {
-        min-height: 120px;
-        padding: 10px;
-    }
-
-    .calendar-hero {
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
-    .calendar-nav {
-        width: 100%;
-        justify-content: space-between;
-    }
-}
-
-.alert {
-    padding: 14px 18px;
-    border-radius: 14px;
-    font-size: 0.95rem;
-    border: 1px solid var(--stroke);
-    background: rgba(255, 255, 255, 0.85);
-    color: var(--text-strong);
-    box-shadow: 0 12px 20px rgba(15, 23, 42, 0.12);
-}
-
-.alert.error {
-    background: rgba(239, 68, 68, 0.12);
-    border-color: rgba(239, 68, 68, 0.32);
-    color: var(--danger);
-}
-
-.alert.success {
-    background: rgba(16, 185, 129, 0.12);
-    border-color: rgba(16, 185, 129, 0.3);
-    color: var(--success);
-}
-
-.global-alert {
-    margin-top: -8px;
-}
-
-.department-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 22px;
-}
-
-.department-card {
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-}
-
-.department-header {
-    display: flex;
-    justify-content: space-between;
-    gap: 16px;
-}
-
-.department-identity {
-    display: flex;
-    gap: 16px;
-}
-
-.department-dot {
-    width: 44px;
-    height: 44px;
-    border-radius: 14px;
-    background: rgba(124, 108, 255, 0.25);
-    border: 1px solid rgba(124, 108, 255, 0.45);
-}
-
-.department-dot.blue { background: rgba(37, 99, 235, 0.35); border-color: rgba(37, 99, 235, 0.55); }
-.department-dot.pink { background: rgba(236, 72, 153, 0.35); border-color: rgba(236, 72, 153, 0.55); }
-.department-dot.orange { background: rgba(249, 115, 22, 0.35); border-color: rgba(249, 115, 22, 0.55); }
-.department-dot.green { background: rgba(16, 185, 129, 0.35); border-color: rgba(16, 185, 129, 0.55); }
-.department-dot.yellow { background: rgba(234, 179, 8, 0.35); border-color: rgba(234, 179, 8, 0.55); }
-
-.department-identity h2 {
-    margin: 0 0 6px;
-    font-size: 1.1rem;
-}
-
-.department-identity p {
-    margin: 0;
-    color: var(--text-muted);
-}
-
-.department-stats {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 16px;
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--text-muted);
-}
-
-.department-stats span {
-    display: block;
-    font-size: 1.3rem;
-    font-weight: 700;
-    color: var(--text-strong);
-}
-
-.progress-wrap {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-}
-
-.progress-label {
-    font-size: 0.9rem;
-    color: var(--text-muted);
-}
-
-.table-card table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.95rem;
-}
-
-.table-card th,
-.table-card td {
-    padding: 14px 18px;
-    text-align: left;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.table-card th {
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: var(--text-subtle);
-    font-size: 0.8rem;
-}
-
-.table-card tbody tr:hover {
-    background: rgba(255, 255, 255, 0.04);
-}
-
-/* Database error page */
-
-body.db-error-page {
+/* Auth */
+.auth-page {
+    min-height: 100vh;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 40px;
-    text-align: left;
+    padding: 40px 16px;
+    background: var(--gradient-bg);
+}
+
+.auth-card {
+    width: min(420px, 100%);
+    background: var(--surface-strong);
+    border-radius: 20px;
+    padding: 32px;
+    box-shadow: var(--shadow);
+    border: 1px solid var(--surface-border);
+}
+
+.auth-card h1 {
+    margin-top: 0;
+    margin-bottom: 6px;
+}
+
+.auth-card p {
+    margin-top: 0;
+    color: var(--text-muted);
+}
+
+.auth-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 18px;
+}
+
+.auth-note {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+/* Database error */
+.db-error-page {
+    background: var(--gradient-bg);
+    font-family: var(--font-family);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    margin: 0;
 }
 
 .db-error-card {
-    max-width: 620px;
-    width: 100%;
-    padding: 40px;
-    border-radius: var(--radius-lg);
-    background: linear-gradient(135deg, rgba(24, 28, 56, 0.85), rgba(10, 13, 32, 0.92));
-    border: 1px solid rgba(124, 108, 255, 0.28);
-    box-shadow: var(--shadow-lg);
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
+    background: var(--surface-strong);
+    border-radius: 20px;
+    padding: 32px;
+    width: min(520px, 90%);
+    box-shadow: var(--shadow);
+    border: 1px solid var(--surface-border);
 }
 
 .db-error-card h1 {
-    margin: 0;
-    font-size: 2rem;
-}
-
-.db-error-card p {
-    margin: 0;
-    color: var(--text-muted);
+    margin-top: 0;
 }
 
 .db-error-details {
-    padding: 16px 20px;
-    border-radius: 14px;
-    background: rgba(15, 19, 42, 0.65);
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    font-family: 'JetBrains Mono', 'Menlo', monospace;
-    font-size: 0.85rem;
-    color: #fca5a5;
+    background: rgba(185, 28, 28, 0.1);
+    color: var(--danger);
+    padding: 12px;
+    border-radius: 12px;
+    margin-bottom: 16px;
 }
 
 .db-error-steps {
-    list-style: decimal;
-    padding-left: 20px;
-    margin: 0;
-    display: grid;
-    gap: 12px;
+    padding-left: 18px;
     color: var(--text-muted);
 }
 
-.db-error-steps strong {
-    color: var(--text-strong);
-}
-
 .db-error-actions {
+    margin-top: 18px;
     display: flex;
-    flex-wrap: wrap;
     gap: 12px;
 }
 
 .db-error-actions a {
-    padding: 12px 20px;
-    border-radius: 14px;
-    text-decoration: none;
-    background: rgba(124, 108, 255, 0.2);
-    border: 1px solid rgba(124, 108, 255, 0.35);
-    color: #ede9fe;
-    font-weight: 600;
+    padding: 8px 14px;
+    border-radius: 10px;
+    background: rgba(45, 90, 136, 0.1);
+    color: var(--accent-strong);
 }
 
-/* Responsive adjustments */
-
-@media (max-width: 1200px) {
-    .app-shell {
-        flex-direction: column;
-    }
-
-    .sidebar {
-        width: 100%;
-        flex-direction: row;
-        align-items: center;
-        justify-content: space-between;
-        padding: 22px;
-    }
-
-    .sidebar-nav {
-        flex-direction: row;
-        flex-wrap: wrap;
-        justify-content: flex-end;
-    }
-
-    .sidebar-footer {
-        display: none;
-    }
-}
-
-@media (max-width: 768px) {
-    .app-shell {
-        padding: 20px;
-    }
-
-    .page-header {
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
-    .header-actions {
-        width: 100%;
-        justify-content: space-between;
-    }
-
-    .metrics-grid,
-    .split-grid,
-    .department-grid {
+@media (max-width: 1100px) {
+    .content-columns,
+    .calendar-layout,
+    .content-columns.form-layout {
         grid-template-columns: 1fr;
     }
 
-    .board-column {
-        padding: 16px;
+    .sidebar {
+        display: none;
+    }
+
+    .main-area {
+        border-radius: 0;
+    }
+
+    .topbar {
+        padding: 20px;
+    }
+
+    .page-header,
+    .page-content {
+        padding: 20px;
     }
 }
 
-@media (max-width: 520px) {
-    .app-shell {
-        padding: 16px;
+@media (max-width: 640px) {
+    .summary-cards {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
     }
 
-    .sidebar {
+    .topbar-actions {
         flex-direction: column;
-        align-items: flex-start;
-        gap: 18px;
+        align-items: flex-end;
+        gap: 10px;
     }
 
-    .header-actions {
+    .form-actions {
         flex-direction: column;
-        align-items: flex-start;
+        align-items: stretch;
     }
 
-    .ghost-action,
-    .primary-action,
-    .status-pill {
+    .form-actions .primary-action,
+    .form-actions .ghost-action {
         width: 100%;
-        justify-content: center;
+        text-align: center;
     }
+}
+.event-title {
+    display: block;
+    font-weight: 600;
+}
 
-    .action-row {
-        flex-direction: column;
-    }
+.event-meta {
+    display: block;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}
+
+.empty-slot {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+.due-chip.status-open {
+    background: rgba(45, 90, 136, 0.12);
+    color: var(--accent-strong);
+}
+
+.due-chip.status-complete {
+    background: rgba(30, 122, 77, 0.15);
+    color: var(--success);
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,16 +1,18 @@
 :root {
     --gradient-bg: linear-gradient(90deg, #77A1D3, #79CBCA, #E684AE);
-    --surface: rgba(255, 255, 255, 0.86);
-    --surface-strong: rgba(255, 255, 255, 0.95);
-    --surface-border: rgba(255, 255, 255, 0.45);
-    --shadow: 0 18px 40px -24px rgba(15, 23, 42, 0.45);
-    --text-primary: #1f2933;
-    --text-muted: #4b5563;
-    --accent: #2d5a88;
-    --accent-strong: #1d3e5c;
-    --danger: #b91c1c;
-    --success: #1e7a4d;
-    --warning: #b45309;
+    --surface: rgba(255, 255, 255, 0.92);
+    --surface-strong: #ffffff;
+    --surface-soft: rgba(255, 255, 255, 0.75);
+    --surface-border: rgba(148, 163, 184, 0.28);
+    --shadow: 0 28px 60px -36px rgba(15, 23, 42, 0.45);
+    --text-primary: #0f172a;
+    --text-muted: #64748b;
+    --text-inverse: #ffffff;
+    --accent: #2563eb;
+    --accent-soft: rgba(37, 99, 235, 0.1);
+    --danger: #ef4444;
+    --success: #22c55e;
+    --warning: #f59e0b;
     --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
@@ -33,22 +35,22 @@ a {
 }
 
 a:hover {
-    color: var(--accent-strong);
+    color: #1d4ed8;
 }
 
 .app-body .app-shell {
     display: flex;
     min-height: 100vh;
-    backdrop-filter: blur(12px);
+    backdrop-filter: blur(10px);
 }
 
 .sidebar {
-    width: 248px;
+    width: 260px;
     background: var(--surface-strong);
     border-right: 1px solid var(--surface-border);
+    padding: 32px 26px;
     display: flex;
     flex-direction: column;
-    padding: 28px 24px;
     gap: 32px;
 }
 
@@ -59,11 +61,11 @@ a:hover {
 }
 
 .brand-icon {
-    width: 44px;
-    height: 44px;
-    border-radius: 12px;
-    background: rgba(45, 90, 136, 0.12);
-    color: var(--accent-strong);
+    width: 48px;
+    height: 48px;
+    border-radius: 14px;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(14, 165, 233, 0.2));
+    color: #1d4ed8;
     font-weight: 700;
     font-size: 1.1rem;
     display: grid;
@@ -71,12 +73,12 @@ a:hover {
 }
 
 .brand-title {
-    font-size: 1rem;
+    font-size: 1.05rem;
     font-weight: 600;
 }
 
 .brand-subtitle {
-    font-size: 0.82rem;
+    font-size: 0.84rem;
     color: var(--text-muted);
 }
 
@@ -88,54 +90,53 @@ a:hover {
 
 .nav-link {
     padding: 10px 12px;
-    border-radius: 10px;
+    border-radius: 12px;
     font-weight: 500;
     color: var(--text-muted);
-    transition: background 0.2s, color 0.2s;
+    transition: background 0.2s ease, color 0.2s ease;
 }
 
 .nav-link:hover {
-    background: rgba(45, 90, 136, 0.08);
-    color: var(--accent-strong);
+    background: rgba(37, 99, 235, 0.08);
+    color: var(--accent);
 }
 
 .nav-link.active {
-    background: rgba(45, 90, 136, 0.18);
-    color: var(--accent-strong);
+    background: rgba(37, 99, 235, 0.16);
+    color: var(--accent);
 }
 
 .sidebar-footer {
     font-size: 0.85rem;
     color: var(--text-muted);
-    line-height: 1.4;
+    line-height: 1.5;
 }
 
 .main-area {
     flex: 1;
     display: flex;
     flex-direction: column;
-    background: rgba(255, 255, 255, 0.72);
+    background: var(--surface-soft);
 }
 
 .topbar {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 24px 32px 12px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.5);
+    padding: 28px 36px 18px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.45);
 }
 
 .topbar-brand {
     display: flex;
     flex-direction: column;
-    gap: 2px;
-    color: var(--accent-strong);
-    font-weight: 600;
+    gap: 4px;
+    color: var(--accent);
 }
 
 .topbar-eyebrow {
     text-transform: uppercase;
-    font-size: 0.7rem;
+    font-size: 0.72rem;
     letter-spacing: 0.14em;
     color: var(--text-muted);
 }
@@ -150,10 +151,10 @@ a:hover {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    background: rgba(45, 90, 136, 0.1);
-    color: var(--accent-strong);
     padding: 6px 12px;
     border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent);
     font-size: 0.8rem;
 }
 
@@ -162,21 +163,21 @@ a:hover {
     height: 8px;
     border-radius: 50%;
     background: var(--success);
-    box-shadow: 0 0 0 4px rgba(30, 122, 77, 0.2);
+    box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.2);
 }
 
 .user-chip {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    background: rgba(37, 99, 235, 0.08);
     padding: 6px 12px;
-    border-radius: 10px;
-    background: rgba(45, 90, 136, 0.08);
+    border-radius: 12px;
 }
 
 .user-name {
     font-weight: 600;
-    font-size: 0.9rem;
+    font-size: 0.92rem;
 }
 
 .user-role {
@@ -187,33 +188,31 @@ a:hover {
 .primary-action,
 .ghost-action {
     border: none;
-    border-radius: 10px;
+    border-radius: 12px;
     font-weight: 600;
     cursor: pointer;
     font-size: 0.9rem;
-    transition: transform 0.15s ease, background 0.2s ease;
+    transition: transform 0.15s ease, background 0.2s ease, color 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
 }
 
 .primary-action {
-    background: var(--accent);
-    color: #fff;
-    padding: 10px 20px;
-    box-shadow: 0 12px 24px -16px rgba(45, 90, 136, 0.9);
+    background: linear-gradient(135deg, #2563eb, #7c3aed);
+    color: var(--text-inverse);
+    padding: 10px 22px;
+    box-shadow: 0 10px 30px -18px rgba(37, 99, 235, 0.8);
 }
 
 .primary-action:hover {
     transform: translateY(-1px);
-    background: var(--accent-strong);
 }
 
 .ghost-action {
-    background: transparent;
-    color: var(--accent-strong);
-    padding: 8px 14px;
-}
-
-.ghost-action:hover {
-    background: rgba(45, 90, 136, 0.12);
+    background: rgba(255, 255, 255, 0.7);
+    color: var(--accent);
+    padding: 10px 16px;
 }
 
 .ghost-action.danger {
@@ -221,42 +220,103 @@ a:hover {
 }
 
 .page-header {
-    padding: 12px 32px 16px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.55);
+    padding: 12px 36px 0;
 }
 
-.page-header-copy h1 {
+.page-header h1 {
     margin: 0 0 6px;
-    font-size: 1.9rem;
+    font-size: 1.8rem;
 }
 
-.page-header-copy p {
+.page-header p {
     margin: 0;
     color: var(--text-muted);
-    max-width: 720px;
+    font-size: 0.95rem;
 }
 
 .page-content {
-    padding: 24px 32px 48px;
-    flex: 1;
+    padding: 24px 36px 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.page-alert {
+    display: flex;
+    gap: 16px;
+    padding: 20px 24px;
+    border-radius: 18px;
+    background: var(--surface-strong);
+    border: 1px solid rgba(239, 68, 68, 0.15);
+    box-shadow: var(--shadow);
+}
+
+.deadline-alert {
+    border-left: 6px solid var(--danger);
+}
+
+.alert-icon {
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+.alert-body h2 {
+    margin: 0 0 8px;
+    font-size: 1.15rem;
+}
+
+.alert-body p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.alert-list {
+    margin: 0;
+    padding-left: 16px;
+    color: var(--text-muted);
+    display: grid;
+    gap: 4px;
+}
+
+.alert-task-title {
+    font-weight: 600;
+    color: var(--text-primary);
 }
 
 .summary-cards {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 16px;
-    margin-bottom: 24px;
 }
 
 .summary-card {
-    background: var(--surface);
+    background: var(--surface-strong);
     border-radius: 18px;
-    padding: 18px;
-    box-shadow: var(--shadow);
+    padding: 18px 20px;
     border: 1px solid var(--surface-border);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    min-height: 110px;
+    box-shadow: 0 12px 32px -30px rgba(15, 23, 42, 0.5);
+}
+
+.summary-card > div {
+    flex: 1;
+}
+
+.summary-icon {
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    display: grid;
+    place-items: center;
+    background: rgba(37, 99, 235, 0.12);
+    font-size: 1.2rem;
 }
 
 .summary-label {
+    display: block;
     font-size: 0.85rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -265,39 +325,52 @@ a:hover {
 
 .summary-value {
     display: block;
-    font-size: 2rem;
-    font-weight: 700;
-    margin-top: 6px;
+    font-size: 1.6rem;
+    font-weight: 600;
 }
 
 .summary-footnote {
+    font-size: 0.8rem;
     color: var(--text-muted);
-    font-size: 0.85rem;
+}
+
+.content-columns {
+    display: grid;
+    grid-template-columns: 1fr minmax(260px, 320px);
+    gap: 24px;
+}
+
+.column-main,
+.column-side {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
 }
 
 .panel {
-    background: var(--surface);
-    border-radius: 18px;
+    background: var(--surface-strong);
+    border-radius: 20px;
     border: 1px solid var(--surface-border);
-    box-shadow: var(--shadow);
-    padding: 22px;
+    box-shadow: 0 18px 40px -36px rgba(15, 23, 42, 0.6);
 }
 
-.classic-panel + .classic-panel {
-    margin-top: 24px;
+.classic-panel {
+    padding: 22px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
 }
 
 .panel-header {
     display: flex;
     justify-content: space-between;
-    align-items: baseline;
-    gap: 12px;
-    margin-bottom: 18px;
+    align-items: flex-start;
+    gap: 16px;
 }
 
 .panel-header h2 {
     margin: 0;
-    font-size: 1.25rem;
+    font-size: 1.1rem;
 }
 
 .panel-header span {
@@ -305,87 +378,46 @@ a:hover {
     color: var(--text-muted);
 }
 
-.empty-note {
-    padding: 20px;
-    border-radius: 14px;
-    background: rgba(15, 23, 42, 0.05);
-    color: var(--text-muted);
-    text-align: center;
-}
-
-.alert {
-    padding: 14px 18px;
-    border-radius: 12px;
-    margin-bottom: 18px;
-    font-weight: 500;
-}
-
-.alert.success {
-    background: rgba(30, 122, 77, 0.12);
-    color: var(--success);
-}
-
-.alert.error {
-    background: rgba(185, 28, 28, 0.12);
-    color: var(--danger);
-}
-
-.global-alert {
-    margin-bottom: 24px;
-}
-
-.content-columns {
-    display: grid;
-    grid-template-columns: 2fr 1fr;
-    gap: 24px;
-    align-items: start;
-}
-
-.content-columns.form-layout {
-    grid-template-columns: 3fr 2fr;
-}
-
-.column-main {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
-}
-
-.column-side {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
-}
-
 .attention-panel {
-    background: rgba(217, 119, 6, 0.16);
-    border: 1px solid rgba(217, 119, 6, 0.4);
+    padding: 22px 24px;
+    background: linear-gradient(135deg, rgba(239, 68, 68, 0.08), rgba(239, 68, 68, 0.16));
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 20px;
 }
 
 .attention-panel h2 {
     margin-top: 0;
 }
 
-.stacked-list {
+.attention-panel p {
+    color: var(--text-muted);
+    margin-bottom: 16px;
+}
+
+.stacked-list,
+.activity-list {
     list-style: none;
-    padding: 0;
     margin: 0;
-    display: flex;
-    flex-direction: column;
+    padding: 0;
+    display: grid;
     gap: 14px;
 }
 
-.stacked-item {
+.stacked-item,
+.activity-item {
     display: flex;
     justify-content: space-between;
-    gap: 16px;
     align-items: center;
+    gap: 16px;
+    padding: 14px 16px;
+    border-radius: 14px;
+    background: rgba(148, 163, 184, 0.12);
 }
 
-.item-main strong {
-    display: block;
-    font-weight: 600;
-    margin-bottom: 4px;
+.item-main {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
 }
 
 .item-sub {
@@ -395,38 +427,59 @@ a:hover {
 
 .item-meta {
     display: flex;
-    gap: 8px;
     align-items: center;
+    gap: 10px;
 }
 
 .priority-chip {
     padding: 4px 10px;
     border-radius: 999px;
-    font-size: 0.75rem;
+    font-size: 0.78rem;
     font-weight: 600;
-    text-transform: uppercase;
+    text-transform: capitalize;
 }
 
-.priority-chip.high { background: rgba(220, 38, 38, 0.12); color: #b91c1c; }
-.priority-chip.medium { background: rgba(217, 119, 6, 0.12); color: var(--warning); }
-.priority-chip.low { background: rgba(30, 122, 77, 0.12); color: var(--success); }
+.priority-chip.high {
+    background: rgba(239, 68, 68, 0.12);
+    color: #b91c1c;
+}
+
+.priority-chip.medium {
+    background: rgba(249, 115, 22, 0.12);
+    color: #b45309;
+}
+
+.priority-chip.low {
+    background: rgba(34, 197, 94, 0.12);
+    color: #15803d;
+}
 
 .due-chip {
     padding: 4px 10px;
     border-radius: 999px;
-    font-size: 0.75rem;
-    background: rgba(45, 90, 136, 0.1);
-    color: var(--accent-strong);
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--accent);
+    font-size: 0.78rem;
+    font-weight: 600;
 }
 
-.due-chip.status-overdue {
-    background: rgba(185, 28, 28, 0.12);
-    color: var(--danger);
+.due-chip.overdue {
+    background: rgba(239, 68, 68, 0.12);
+    color: #b91c1c;
 }
 
-.due-chip.status-warning {
-    background: rgba(217, 119, 6, 0.12);
-    color: var(--warning);
+.due-chip.upcoming {
+    background: rgba(37, 99, 235, 0.15);
+    color: var(--accent);
+}
+
+.empty-note {
+    padding: 18px;
+    border-radius: 14px;
+    background: rgba(148, 163, 184, 0.12);
+    color: var(--text-muted);
+    text-align: center;
+    font-size: 0.95rem;
 }
 
 .table-scroll {
@@ -436,51 +489,208 @@ a:hover {
 .data-table {
     width: 100%;
     border-collapse: collapse;
-    min-width: 720px;
+    font-size: 0.92rem;
 }
 
 .data-table th,
 .data-table td {
-    padding: 12px 14px;
     text-align: left;
-    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-    vertical-align: top;
+    padding: 12px 14px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
 }
 
-.data-table th {
-    font-size: 0.82rem;
+.data-table thead th {
     text-transform: uppercase;
+    font-size: 0.72rem;
     letter-spacing: 0.08em;
     color: var(--text-muted);
 }
 
+.data-table tbody tr:hover {
+    background: rgba(37, 99, 235, 0.04);
+}
+
 .table-note {
-    margin: 6px 0 0;
+    margin: 4px 0 0;
     color: var(--text-muted);
-    font-size: 0.85rem;
+    font-size: 0.8rem;
 }
 
-.inline-form select {
-    border: 1px solid rgba(15, 23, 42, 0.2);
-    border-radius: 8px;
-    padding: 6px 10px;
-    background: #fff;
-    font-family: inherit;
-}
-
-.inline-form select:focus {
-    outline: 2px solid rgba(45, 90, 136, 0.25);
-    outline-offset: 1px;
+.actions-col {
+    width: 220px;
 }
 
 .action-stack {
     display: flex;
     flex-direction: column;
+    gap: 8px;
+}
+
+.inline-form select {
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    padding: 8px 10px;
+    font-size: 0.85rem;
+    background: var(--surface-strong);
+}
+
+.progress-inline {
+    position: relative;
+    width: 100%;
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.24);
+    margin-bottom: 6px;
+}
+
+.progress-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #2563eb, #7c3aed);
+}
+
+.progress-label {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.alert {
+    padding: 12px 16px;
+    border-radius: 12px;
+    font-size: 0.9rem;
+}
+
+.alert.success {
+    background: rgba(34, 197, 94, 0.12);
+    color: #047857;
+}
+
+.alert.error {
+    background: rgba(239, 68, 68, 0.12);
+    color: #b91c1c;
+}
+
+.global-alert {
+    border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.tasks-header {
+    align-items: center;
+}
+
+.tasks-header h2 {
+    margin-bottom: 4px;
+}
+
+.tasks-filter {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.tasks-filter input[type="search"] {
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    padding: 10px 14px;
+    font-size: 0.88rem;
+    width: 240px;
+    background: rgba(248, 250, 252, 0.9);
+}
+
+.task-collection {
+    display: grid;
+    gap: 18px;
+}
+
+.task-card {
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: 18px;
+    padding: 20px;
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.5);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.task-card-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.task-card-header h3 {
+    margin: 0 0 6px;
+    font-size: 1.05rem;
+}
+
+.task-card-header p {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.task-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.task-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+    margin: 0;
+}
+
+.task-meta div {
+    background: rgba(148, 163, 184, 0.12);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
     gap: 6px;
 }
 
-.actions-col {
-    width: 180px;
+.task-meta dt {
+    margin: 0;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.task-meta dd {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.task-card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.task-card-actions select {
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    padding: 10px 12px;
+    font-size: 0.88rem;
+    background: rgba(248, 250, 252, 0.95);
+}
+
+.task-card.status-completed {
+    border-color: rgba(34, 197, 94, 0.35);
+}
+
+.task-card.status-in-progress {
+    border-color: rgba(37, 99, 235, 0.3);
 }
 
 .reminder-stamp {
@@ -488,132 +698,107 @@ a:hover {
     color: var(--text-muted);
 }
 
-.progress-inline {
-    width: 100%;
-    height: 6px;
-    border-radius: 999px;
-    background: rgba(15, 23, 42, 0.08);
-    overflow: hidden;
-    margin-bottom: 6px;
+.reminders-layout {
+    display: grid;
+    grid-template-columns: minmax(280px, 340px) 1fr;
+    gap: 24px;
 }
 
-.progress-bar {
-    display: block;
-    height: 100%;
-    background: var(--accent);
+.reminder-compose {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    padding: 22px 24px;
 }
 
-.progress-label {
-    font-size: 0.8rem;
+.reminder-compose header h2 {
+    margin: 0 0 6px;
+}
+
+.reminder-compose header p {
+    margin: 0;
     color: var(--text-muted);
+}
+
+.reminder-log {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    padding: 22px 24px;
 }
 
 .classic-form {
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 16px;
 }
 
 .form-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 18px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
 }
 
 .form-group {
-    flex: 1 1 200px;
     display: flex;
     flex-direction: column;
     gap: 8px;
 }
 
 .form-group label {
+    font-size: 0.85rem;
     font-weight: 600;
-    font-size: 0.9rem;
+    color: var(--text-muted);
 }
 
 .form-group input,
 .form-group select,
 .form-group textarea {
-    border-radius: 10px;
-    border: 1px solid rgba(15, 23, 42, 0.18);
-    padding: 10px 12px;
-    font-family: inherit;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    padding: 11px 14px;
     font-size: 0.95rem;
-    background: rgba(255, 255, 255, 0.9);
+    background: rgba(255, 255, 255, 0.98);
+    transition: border 0.2s ease, box-shadow 0.2s ease;
 }
 
-.form-group textarea {
-    resize: vertical;
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+    outline: none;
+    border-color: rgba(37, 99, 235, 0.6);
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
 }
 
 .form-actions {
     display: flex;
-    justify-content: flex-end;
     gap: 12px;
-}
-
-.insight-list {
-    margin: 0 0 18px;
-    padding: 0 0 0 18px;
-    color: var(--text-muted);
-    line-height: 1.5;
-}
-
-.calendar-preview {
-    background: rgba(45, 90, 136, 0.08);
-    padding: 18px;
-    border-radius: 14px;
-    text-align: center;
-}
-
-.calendar-preview-month {
-    display: block;
-    font-weight: 600;
-    margin-bottom: 6px;
-}
-
-.activity-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.activity-item strong {
-    display: block;
-    font-weight: 600;
-}
-
-.activity-item span,
-.activity-item time {
-    font-size: 0.85rem;
-    color: var(--text-muted);
 }
 
 .main-footer {
     margin-top: auto;
-    padding: 20px 32px 32px;
+    padding: 18px 36px 30px;
     display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
     justify-content: space-between;
-    color: rgba(31, 41, 51, 0.7);
     font-size: 0.85rem;
+    color: var(--text-muted);
 }
 
 .toast {
     position: fixed;
-    bottom: 24px;
-    right: 24px;
+    bottom: 32px;
+    right: 32px;
     background: var(--surface-strong);
+    color: var(--text-primary);
+    padding: 14px 18px;
     border-radius: 12px;
-    padding: 12px 18px;
-    box-shadow: 0 10px 30px -20px rgba(15, 23, 42, 0.6);
+    box-shadow: 0 18px 45px -25px rgba(15, 23, 42, 0.55);
     opacity: 0;
-    transform: translateY(20px);
-    transition: opacity 0.2s ease, transform 0.2s ease;
     pointer-events: none;
+    transform: translateY(10px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 .toast.show {
@@ -622,26 +807,112 @@ a:hover {
 }
 
 .toast.error {
-    background: rgba(185, 28, 28, 0.9);
-    color: #fff;
+    border-left: 4px solid var(--danger);
 }
 
 .toast.success {
-    background: rgba(30, 122, 77, 0.92);
-    color: #fff;
+    border-left: 4px solid var(--success);
 }
 
-/* Calendar */
+.auth-page {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 48px 24px;
+    background: var(--gradient-bg);
+}
+
+.auth-wrapper {
+    max-width: 960px;
+    width: 100%;
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 28px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    overflow: hidden;
+    box-shadow: 0 28px 80px -36px rgba(15, 23, 42, 0.65);
+}
+
+.auth-intro {
+    padding: 40px 48px;
+    background: linear-gradient(160deg, rgba(37, 99, 235, 0.1), rgba(236, 72, 153, 0.18));
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.auth-intro h1 {
+    margin: 0;
+    font-size: 1.8rem;
+}
+
+.auth-intro p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.auth-intro ul {
+    margin: 0;
+    padding-left: 18px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    display: grid;
+    gap: 6px;
+}
+
+.auth-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--accent);
+    font-weight: 600;
+    font-size: 0.8rem;
+}
+
+.auth-card {
+    padding: 40px 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.auth-card h2 {
+    margin: 0;
+    font-size: 1.4rem;
+}
+
+.auth-card p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.auth-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.auth-note {
+    color: var(--text-muted);
+}
+
 .calendar-hero {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 24px;
-    margin-bottom: 24px;
+    padding: 24px 28px;
+    gap: 16px;
 }
 
 .calendar-hero h2 {
-    margin: 0;
+    margin: 0 0 8px;
 }
 
 .calendar-nav {
@@ -656,28 +927,35 @@ a:hover {
 
 .calendar-layout {
     display: grid;
-    grid-template-columns: 1fr 3fr;
+    grid-template-columns: minmax(260px, 320px) 1fr;
     gap: 24px;
+}
+
+.calendar-meta {
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
 }
 
 .calendar-meta ul {
     list-style: none;
     margin: 0;
     padding: 0;
-}
-
-.calendar-meta li {
-    display: flex;
-    justify-content: space-between;
-    padding: 6px 0;
-    font-size: 0.9rem;
+    display: grid;
+    gap: 10px;
     color: var(--text-muted);
 }
 
-.legend {
-    margin-top: 12px;
-    display: grid;
-    gap: 6px;
+.calendar-meta ul li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.calendar-meta .legend li {
+    justify-content: flex-start;
+    gap: 10px;
 }
 
 .legend-dot {
@@ -685,39 +963,40 @@ a:hover {
     height: 10px;
     border-radius: 50%;
     display: inline-block;
-    margin-right: 8px;
 }
 
 .calendar-grid {
-    display: grid;
-    grid-template-rows: auto 1fr;
-    gap: 12px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
 }
 
 .calendar-grid-head {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
-    text-transform: uppercase;
-    font-size: 0.75rem;
-    letter-spacing: 0.08em;
+    text-align: center;
+    font-size: 0.85rem;
     color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
 }
 
 .calendar-grid-body {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
-    grid-auto-rows: minmax(110px, auto);
-    gap: 6px;
+    gap: 12px;
 }
 
 .calendar-cell {
-    border-radius: 14px;
-    background: rgba(255, 255, 255, 0.85);
-    border: 1px solid rgba(255, 255, 255, 0.4);
-    padding: 10px;
+    min-height: 140px;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    padding: 12px;
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 8px;
+    background: rgba(255, 255, 255, 0.92);
 }
 
 .calendar-cell.muted {
@@ -725,209 +1004,154 @@ a:hover {
 }
 
 .calendar-cell.today {
-    border-color: rgba(45, 90, 136, 0.6);
-    box-shadow: inset 0 0 0 2px rgba(45, 90, 136, 0.3);
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
 }
 
 .calendar-cell-header {
     display: flex;
     justify-content: space-between;
+    align-items: center;
+}
+
+.calendar-date-number {
     font-weight: 600;
 }
 
 .calendar-events {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 8px;
 }
 
 .calendar-event {
-    padding: 6px;
-    border-radius: 10px;
-    font-size: 0.75rem;
-    background: rgba(45, 90, 136, 0.12);
-}
-
-.priority-high {
-    border-left: 3px solid #b91c1c;
-}
-
-.priority-medium {
-    border-left: 3px solid #b45309;
-}
-
-.priority-low {
-    border-left: 3px solid #1e7a4d;
-}
-
-.tag-blue { background: rgba(59, 130, 246, 0.18); }
-.tag-purple { background: rgba(168, 85, 247, 0.18); }
-.tag-green { background: rgba(16, 185, 129, 0.18); }
-.tag-amber { background: rgba(245, 158, 11, 0.18); }
-.tag-pink { background: rgba(236, 72, 153, 0.18); }
-.tag-teal { background: rgba(13, 148, 136, 0.18); }
-.tag-indigo { background: rgba(99, 102, 241, 0.18); }
-.tag-coral { background: rgba(249, 115, 22, 0.18); }
-
-/* Auth */
-.auth-page {
-    min-height: 100vh;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 40px 16px;
-    background: var(--gradient-bg);
-}
-
-.auth-card {
-    width: min(420px, 100%);
-    background: var(--surface-strong);
-    border-radius: 20px;
-    padding: 32px;
-    box-shadow: var(--shadow);
-    border: 1px solid var(--surface-border);
-}
-
-.auth-card h1 {
-    margin-top: 0;
-    margin-bottom: 6px;
-}
-
-.auth-card p {
-    margin-top: 0;
-    color: var(--text-muted);
-}
-
-.auth-actions {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-top: 18px;
-}
-
-.auth-note {
-    font-size: 0.85rem;
-    color: var(--text-muted);
-}
-
-/* Database error */
-.db-error-page {
-    background: var(--gradient-bg);
-    font-family: var(--font-family);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 100vh;
-    margin: 0;
-}
-
-.db-error-card {
-    background: var(--surface-strong);
-    border-radius: 20px;
-    padding: 32px;
-    width: min(520px, 90%);
-    box-shadow: var(--shadow);
-    border: 1px solid var(--surface-border);
-}
-
-.db-error-card h1 {
-    margin-top: 0;
-}
-
-.db-error-details {
-    background: rgba(185, 28, 28, 0.1);
-    color: var(--danger);
-    padding: 12px;
     border-radius: 12px;
-    margin-bottom: 16px;
-}
-
-.db-error-steps {
-    padding-left: 18px;
-    color: var(--text-muted);
-}
-
-.db-error-actions {
-    margin-top: 18px;
+    padding: 8px 10px;
+    font-size: 0.82rem;
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--text-primary);
     display: flex;
-    gap: 12px;
+    flex-direction: column;
+    gap: 4px;
 }
 
-.db-error-actions a {
-    padding: 8px 14px;
-    border-radius: 10px;
-    background: rgba(45, 90, 136, 0.1);
-    color: var(--accent-strong);
-}
-
-@media (max-width: 1100px) {
-    .content-columns,
-    .calendar-layout,
-    .content-columns.form-layout {
-        grid-template-columns: 1fr;
-    }
-
-    .sidebar {
-        display: none;
-    }
-
-    .main-area {
-        border-radius: 0;
-    }
-
-    .topbar {
-        padding: 20px;
-    }
-
-    .page-header,
-    .page-content {
-        padding: 20px;
-    }
-}
-
-@media (max-width: 640px) {
-    .summary-cards {
-        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    }
-
-    .topbar-actions {
-        flex-direction: column;
-        align-items: flex-end;
-        gap: 10px;
-    }
-
-    .form-actions {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .form-actions .primary-action,
-    .form-actions .ghost-action {
-        width: 100%;
-        text-align: center;
-    }
-}
-.event-title {
-    display: block;
+.calendar-event .event-title {
     font-weight: 600;
 }
 
-.event-meta {
-    display: block;
+.calendar-event .event-meta {
     color: var(--text-muted);
     font-size: 0.75rem;
 }
 
 .empty-slot {
     color: var(--text-muted);
-    font-size: 0.85rem;
-}
-.due-chip.status-open {
-    background: rgba(45, 90, 136, 0.12);
-    color: var(--accent-strong);
+    font-size: 0.75rem;
 }
 
-.due-chip.status-complete {
-    background: rgba(30, 122, 77, 0.15);
-    color: var(--success);
+.tag-blue { background: rgba(37, 99, 235, 0.16); }
+.tag-purple { background: rgba(168, 85, 247, 0.16); }
+.tag-green { background: rgba(34, 197, 94, 0.16); }
+.tag-amber { background: rgba(245, 158, 11, 0.16); }
+.tag-pink { background: rgba(236, 72, 153, 0.16); }
+.tag-teal { background: rgba(20, 184, 166, 0.16); }
+.tag-indigo { background: rgba(99, 102, 241, 0.16); }
+.tag-coral { background: rgba(248, 113, 113, 0.16); }
+
+.priority-high { border-left: 3px solid #ef4444; }
+.priority-medium { border-left: 3px solid #f59e0b; }
+.priority-low { border-left: 3px solid #22c55e; }
+
+.main-footer a {
+    color: inherit;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 1080px) {
+    .content-columns {
+        grid-template-columns: 1fr;
+    }
+
+    .reminders-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .calendar-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .topbar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 18px;
+    }
+
+    .topbar-actions {
+        align-self: stretch;
+        justify-content: space-between;
+        flex-wrap: wrap;
+    }
+}
+
+@media (max-width: 860px) {
+    .app-shell {
+        flex-direction: column;
+    }
+
+    .sidebar {
+        width: 100%;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+        border-right: none;
+        border-bottom: 1px solid var(--surface-border);
+    }
+
+    .sidebar-nav {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .main-area {
+        min-height: calc(100vh - 120px);
+    }
+}
+
+@media (max-width: 640px) {
+    .page-content {
+        padding: 20px;
+    }
+
+    .summary-cards {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+
+    .task-card-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .tasks-filter input[type="search"] {
+        width: 100%;
+    }
+
+    .auth-wrapper {
+        border-radius: 20px;
+    }
+
+    .auth-intro,
+    .auth-card {
+        padding: 32px;
+    }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,17 +1,18 @@
 :root {
-    --gradient-bg: linear-gradient(90deg, #77A1D3, #79CBCA, #E684AE);
+    --gradient-bg: linear-gradient(120deg, #0b7d62, #0ab5a9, #8ce9df);
     --surface: rgba(255, 255, 255, 0.92);
     --surface-strong: #ffffff;
-    --surface-soft: rgba(255, 255, 255, 0.75);
-    --surface-border: rgba(148, 163, 184, 0.28);
-    --shadow: 0 28px 60px -36px rgba(15, 23, 42, 0.45);
+    --surface-soft: rgba(255, 255, 255, 0.78);
+    --surface-border: rgba(15, 118, 110, 0.18);
+    --shadow: 0 28px 60px -36px rgba(15, 23, 42, 0.38);
     --text-primary: #0f172a;
-    --text-muted: #64748b;
+    --text-muted: #5f7684;
     --text-inverse: #ffffff;
-    --accent: #2563eb;
-    --accent-soft: rgba(37, 99, 235, 0.1);
+    --accent: #0b9275;
+    --accent-strong: #0f9d58;
+    --accent-soft: rgba(11, 146, 117, 0.12);
     --danger: #ef4444;
-    --success: #22c55e;
+    --success: #1dbb7f;
     --warning: #f59e0b;
     --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
@@ -30,12 +31,12 @@ body {
 }
 
 a {
-    color: var(--accent);
+    color: var(--accent-strong, var(--accent));
     text-decoration: none;
 }
 
 a:hover {
-    color: #1d4ed8;
+    color: #086f57;
 }
 
 .app-body .app-shell {
@@ -45,13 +46,14 @@ a:hover {
 }
 
 .sidebar {
-    width: 260px;
-    background: var(--surface-strong);
+    width: 272px;
+    background: rgba(255, 255, 255, 0.96);
     border-right: 1px solid var(--surface-border);
-    padding: 32px 26px;
+    padding: 36px 28px;
     display: flex;
     flex-direction: column;
     gap: 32px;
+    box-shadow: 18px 0 40px -30px rgba(4, 55, 49, 0.35);
 }
 
 .sidebar-brand {
@@ -61,10 +63,10 @@ a:hover {
 }
 
 .brand-logo {
-    width: 68px;
+    width: 92px;
     height: auto;
     display: block;
-    filter: drop-shadow(0 10px 18px rgba(15, 23, 42, 0.25));
+    filter: drop-shadow(0 16px 22px rgba(11, 146, 117, 0.35));
 }
 
 .brand-title {
@@ -84,21 +86,21 @@ a:hover {
 }
 
 .nav-link {
-    padding: 10px 12px;
-    border-radius: 12px;
-    font-weight: 500;
+    padding: 12px 14px;
+    border-radius: 14px;
+    font-weight: 600;
     color: var(--text-muted);
     transition: background 0.2s ease, color 0.2s ease;
 }
 
 .nav-link:hover {
-    background: rgba(37, 99, 235, 0.08);
-    color: var(--accent);
+    background: rgba(11, 146, 117, 0.14);
+    color: var(--accent-strong);
 }
 
 .nav-link.active {
-    background: rgba(37, 99, 235, 0.16);
-    color: var(--accent);
+    background: rgba(11, 146, 117, 0.22);
+    color: var(--accent-strong);
 }
 
 .sidebar-footer {
@@ -126,7 +128,7 @@ a:hover {
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--accent);
+    color: var(--accent-strong);
 }
 
 .topbar-eyebrow {
@@ -149,7 +151,7 @@ a:hover {
     padding: 6px 12px;
     border-radius: 999px;
     background: var(--accent-soft);
-    color: var(--accent);
+    color: var(--accent-strong);
     font-size: 0.8rem;
 }
 
@@ -165,7 +167,7 @@ a:hover {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    background: rgba(37, 99, 235, 0.08);
+    background: rgba(11, 146, 117, 0.12);
     padding: 6px 12px;
     border-radius: 12px;
 }
@@ -194,10 +196,10 @@ a:hover {
 }
 
 .primary-action {
-    background: linear-gradient(135deg, #2563eb, #7c3aed);
+    background: linear-gradient(135deg, var(--accent-strong), #07b7a5);
     color: var(--text-inverse);
-    padding: 10px 22px;
-    box-shadow: 0 10px 30px -18px rgba(37, 99, 235, 0.8);
+    padding: 10px 24px;
+    box-shadow: 0 10px 30px -18px rgba(11, 146, 117, 0.6);
 }
 
 .primary-action:hover {
@@ -205,8 +207,8 @@ a:hover {
 }
 
 .ghost-action {
-    background: rgba(255, 255, 255, 0.7);
-    color: var(--accent);
+    background: rgba(11, 146, 117, 0.08);
+    color: var(--accent-strong);
     padding: 10px 16px;
 }
 
@@ -301,13 +303,14 @@ a:hover {
 }
 
 .summary-icon {
-    width: 42px;
-    height: 42px;
-    border-radius: 14px;
+    width: 56px;
+    height: 56px;
+    border-radius: 18px;
     display: grid;
     place-items: center;
-    background: rgba(37, 99, 235, 0.12);
-    font-size: 1.2rem;
+    background: rgba(11, 146, 117, 0.16);
+    font-size: 1.6rem;
+    color: var(--accent-strong);
 }
 
 .summary-label {
@@ -398,6 +401,12 @@ a:hover {
     gap: 14px;
 }
 
+.reminder-panel .activity-list {
+    max-height: 320px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+
 .stacked-item,
 .activity-item {
     display: flex;
@@ -452,8 +461,8 @@ a:hover {
 .due-chip {
     padding: 4px 10px;
     border-radius: 999px;
-    background: rgba(37, 99, 235, 0.12);
-    color: var(--accent);
+    background: rgba(11, 146, 117, 0.18);
+    color: var(--accent-strong);
     font-size: 0.78rem;
     font-weight: 600;
 }
@@ -464,8 +473,8 @@ a:hover {
 }
 
 .due-chip.upcoming {
-    background: rgba(37, 99, 235, 0.15);
-    color: var(--accent);
+    background: rgba(11, 146, 117, 0.2);
+    color: var(--accent-strong);
 }
 
 .empty-note {
@@ -502,7 +511,7 @@ a:hover {
 }
 
 .data-table tbody tr:hover {
-    background: rgba(37, 99, 235, 0.04);
+    background: rgba(11, 146, 117, 0.08);
 }
 
 .table-note {
@@ -685,7 +694,7 @@ a:hover {
 }
 
 .task-card.status-in-progress {
-    border-color: rgba(37, 99, 235, 0.3);
+    border-color: rgba(11, 146, 117, 0.3);
 }
 
 .reminder-stamp {
@@ -761,8 +770,8 @@ a:hover {
 .form-group select:focus,
 .form-group textarea:focus {
     outline: none;
-    border-color: rgba(37, 99, 235, 0.6);
-    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
+    border-color: rgba(11, 146, 117, 0.6);
+    box-shadow: 0 0 0 4px rgba(11, 146, 117, 0.2);
 }
 
 .form-actions {
@@ -818,88 +827,94 @@ a:hover {
     background: var(--gradient-bg);
 }
 
-.auth-wrapper {
-    max-width: 960px;
+.auth-shell {
+    max-width: 1080px;
     width: 100%;
-    background: rgba(255, 255, 255, 0.9);
-    border-radius: 28px;
-    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(255, 255, 255, 0.94);
+    border-radius: 32px;
+    border: 1px solid rgba(11, 146, 117, 0.18);
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: minmax(320px, 1.1fr) minmax(340px, 0.9fr);
     overflow: hidden;
-    box-shadow: 0 28px 80px -36px rgba(15, 23, 42, 0.65);
+    box-shadow: 0 32px 90px -36px rgba(15, 23, 42, 0.6);
 }
 
-.auth-intro {
-    padding: 40px 48px;
-    background: linear-gradient(160deg, rgba(37, 99, 235, 0.1), rgba(236, 72, 153, 0.18));
+.auth-illustration {
+    background: linear-gradient(135deg, rgba(11, 146, 117, 0.18), rgba(14, 165, 115, 0.12));
     display: flex;
-    flex-direction: column;
-    gap: 16px;
-}
-
-.auth-intro h1 {
-    margin: 0;
-    font-size: 1.8rem;
-}
-
-.auth-intro p {
-    margin: 0;
-    color: var(--text-muted);
-}
-
-.auth-intro ul {
-    margin: 0;
-    padding-left: 18px;
-    color: var(--text-muted);
-    font-size: 0.95rem;
-    display: grid;
-    gap: 6px;
-}
-
-.auth-badge {
-    display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 6px 12px;
-    border-radius: 999px;
-    background: rgba(37, 99, 235, 0.12);
-    color: var(--accent);
-    font-weight: 600;
-    font-size: 0.8rem;
-}
-
-.auth-card {
-    padding: 40px 48px;
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-}
-
-.auth-logo {
-    display: flex;
     justify-content: center;
+    padding: 48px;
+    border-right: 1px solid rgba(11, 146, 117, 0.12);
+}
+
+.auth-illustration-inner {
+    max-width: 420px;
+    text-align: center;
+    display: grid;
+    gap: 20px;
+    color: #0b3d31;
+}
+
+.auth-masthead-logo {
+    width: 100%;
+    max-width: 360px;
+    height: auto;
+    filter: drop-shadow(0 18px 36px rgba(11, 146, 117, 0.25));
+}
+
+.auth-illustration-inner h1 {
+    margin: 0;
+    font-size: 1.95rem;
+    font-weight: 700;
+}
+
+.auth-illustration-inner p {
+    margin: 0;
+    font-size: 1rem;
+    color: rgba(12, 53, 45, 0.82);
+}
+
+.auth-panel {
+    padding: 48px 56px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    background: rgba(255, 255, 255, 0.98);
+    border-left: 1px solid rgba(11, 146, 117, 0.12);
+}
+
+.auth-panel-header {
+    display: grid;
+    gap: 12px;
+}
+
+.auth-panel-header .auth-logo {
+    width: 140px;
+    display: flex;
     align-items: center;
-    padding: 12px;
-    border-radius: 18px;
-    background: rgba(255, 255, 255, 0.9);
-    border: 1px solid rgba(148, 163, 184, 0.25);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    justify-content: flex-start;
 }
 
 .auth-logo img {
-    max-width: 220px;
+    width: 100%;
     height: auto;
+    display: block;
 }
 
-.auth-card h2 {
+.auth-panel-header h2 {
     margin: 0;
-    font-size: 1.4rem;
+    font-size: 1.65rem;
 }
 
-.auth-card p {
+.auth-panel-header p {
     margin: 0;
     color: var(--text-muted);
+}
+
+.auth-panel-body {
+    display: grid;
+    gap: 18px;
 }
 
 .auth-actions {
@@ -1015,8 +1030,8 @@ a:hover {
 }
 
 .calendar-cell.today {
-    border-color: var(--accent);
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+    border-color: var(--accent-strong);
+    box-shadow: 0 0 0 3px rgba(11, 146, 117, 0.22);
 }
 
 .calendar-cell-header {
@@ -1039,11 +1054,11 @@ a:hover {
     border-radius: 12px;
     padding: 8px 10px;
     font-size: 0.82rem;
-    background: rgba(37, 99, 235, 0.12);
+    background: rgba(11, 146, 117, 0.12);
     color: var(--text-primary);
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 6px;
 }
 
 .calendar-event .event-title {
@@ -1053,6 +1068,37 @@ a:hover {
 .calendar-event .event-meta {
     color: var(--text-muted);
     font-size: 0.75rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+}
+
+.status-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    padding: 4px 8px;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.status-chip.status-pending {
+    background: rgba(253, 224, 71, 0.22);
+    color: #a16207;
+}
+
+.status-chip.status-in-progress {
+    background: rgba(11, 146, 117, 0.18);
+    color: var(--accent-strong);
+}
+
+.status-chip.status-completed {
+    background: rgba(34, 197, 94, 0.22);
+    color: #0f5132;
 }
 
 .empty-slot {
@@ -1060,14 +1106,14 @@ a:hover {
     font-size: 0.75rem;
 }
 
-.tag-blue { background: rgba(37, 99, 235, 0.16); }
-.tag-purple { background: rgba(168, 85, 247, 0.16); }
-.tag-green { background: rgba(34, 197, 94, 0.16); }
-.tag-amber { background: rgba(245, 158, 11, 0.16); }
-.tag-pink { background: rgba(236, 72, 153, 0.16); }
-.tag-teal { background: rgba(20, 184, 166, 0.16); }
-.tag-indigo { background: rgba(99, 102, 241, 0.16); }
-.tag-coral { background: rgba(248, 113, 113, 0.16); }
+.tag-blue { background: rgba(11, 146, 117, 0.18); }
+.tag-purple { background: rgba(20, 184, 166, 0.18); }
+.tag-green { background: rgba(34, 197, 94, 0.2); }
+.tag-amber { background: rgba(245, 158, 11, 0.18); }
+.tag-pink { background: rgba(236, 72, 153, 0.18); }
+.tag-teal { background: rgba(13, 148, 136, 0.2); }
+.tag-indigo { background: rgba(59, 130, 246, 0.18); }
+.tag-coral { background: rgba(248, 113, 113, 0.18); }
 
 .priority-high { border-left: 3px solid #ef4444; }
 .priority-medium { border-left: 3px solid #f59e0b; }
@@ -1113,6 +1159,18 @@ a:hover {
         justify-content: space-between;
         flex-wrap: wrap;
     }
+
+    .auth-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .auth-illustration {
+        padding: 40px 36px;
+    }
+
+    .auth-panel {
+        padding: 40px 36px;
+    }
 }
 
 @media (max-width: 860px) {
@@ -1157,16 +1215,23 @@ a:hover {
         width: 100%;
     }
 
-    .auth-wrapper {
-        border-radius: 20px;
+    .auth-shell {
+        border-radius: 24px;
+        grid-template-columns: 1fr;
     }
 
-    .auth-intro,
-    .auth-card {
-        padding: 32px;
+    .auth-illustration {
+        padding: 36px 28px;
+        border-right: none;
     }
 
-    .auth-logo img {
-        max-width: 180px;
+    .auth-panel {
+        padding: 36px 28px;
+        border-left: none;
+        border-top: 1px solid rgba(11, 146, 117, 0.12);
+    }
+
+    .auth-panel-header .auth-logo {
+        width: 120px;
     }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,28 +1,29 @@
 :root {
-    --gradient-start: #171B34;
-    --gradient-end: #0B0D21;
-    --surface: rgba(18, 22, 45, 0.55);
-    --surface-solid: #12162d;
-    --surface-alt: rgba(36, 43, 78, 0.75);
-    --surface-soft: rgba(255, 255, 255, 0.05);
-    --stroke: rgba(255, 255, 255, 0.08);
-    --stroke-strong: rgba(255, 255, 255, 0.16);
-    --text-strong: #f8fafc;
-    --text-muted: rgba(226, 232, 240, 0.7);
-    --text-subtle: rgba(148, 163, 184, 0.7);
-    --primary: #7c6cff;
-    --primary-strong: #8d7bff;
-    --primary-soft: rgba(124, 108, 255, 0.18);
-    --success: #2dd4bf;
-    --warning: #fbbf24;
-    --danger: #f87171;
-    --glass: blur(22px);
+    --gradient-start: #77A1D3;
+    --gradient-mid: #79CBCA;
+    --gradient-end: #E684AE;
+    --surface: rgba(255, 255, 255, 0.78);
+    --surface-solid: rgba(255, 255, 255, 0.94);
+    --surface-alt: rgba(255, 255, 255, 0.68);
+    --surface-soft: rgba(255, 255, 255, 0.42);
+    --stroke: rgba(15, 23, 42, 0.08);
+    --stroke-strong: rgba(15, 23, 42, 0.16);
+    --text-strong: #0f172a;
+    --text-muted: rgba(15, 23, 42, 0.6);
+    --text-subtle: rgba(15, 23, 42, 0.4);
+    --primary: #2563eb;
+    --primary-strong: #1d4ed8;
+    --primary-soft: rgba(37, 99, 235, 0.18);
+    --success: #10b981;
+    --warning: #f59e0b;
+    --danger: #ef4444;
+    --glass: blur(26px) saturate(135%);
     --radius-lg: 26px;
     --radius-md: 18px;
     --radius-sm: 12px;
-    --shadow-lg: 0 30px 60px rgba(6, 10, 30, 0.45);
-    --shadow-md: 0 20px 40px rgba(6, 10, 30, 0.32);
-    --shadow-sm: 0 10px 30px rgba(6, 10, 30, 0.25);
+    --shadow-lg: 0 28px 60px rgba(15, 23, 42, 0.25);
+    --shadow-md: 0 18px 38px rgba(15, 23, 42, 0.18);
+    --shadow-sm: 0 10px 26px rgba(15, 23, 42, 0.14);
     --font-family: 'Plus Jakarta Sans', 'Inter', 'Segoe UI', sans-serif;
 }
 
@@ -35,9 +36,8 @@ body {
     min-height: 100vh;
     font-family: var(--font-family);
     color: var(--text-strong);
-    background: radial-gradient(circle at 10% 0%, #202a64 0%, transparent 55%),
-        radial-gradient(circle at 80% 0%, rgba(124, 108, 255, 0.25) 0%, transparent 55%),
-        linear-gradient(160deg, var(--gradient-start), var(--gradient-end));
+    background: linear-gradient(90deg, var(--gradient-start), var(--gradient-mid), var(--gradient-end));
+    background-attachment: fixed;
 }
 
 a {
@@ -55,9 +55,10 @@ a {
     width: 280px;
     padding: 28px;
     border-radius: var(--radius-lg);
-    background: linear-gradient(160deg, rgba(32, 41, 86, 0.85), rgba(15, 19, 41, 0.95));
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.72));
     border: 1px solid var(--stroke);
     box-shadow: var(--shadow-lg);
+    backdrop-filter: var(--glass);
     display: flex;
     flex-direction: column;
     gap: 32px;
@@ -76,12 +77,12 @@ a {
     width: 56px;
     height: 56px;
     border-radius: 18px;
-    background: linear-gradient(135deg, #7c6cff, #22d3ee);
+    background: linear-gradient(135deg, #2563eb, #38bdf8);
     font-weight: 700;
     font-size: 1.25rem;
     letter-spacing: 0.05em;
     color: #ffffff;
-    box-shadow: 0 14px 30px rgba(20, 10, 90, 0.45);
+    box-shadow: 0 14px 30px rgba(37, 99, 235, 0.35);
 }
 
 .brand-copy {
@@ -130,18 +131,18 @@ a {
 }
 
 .nav-link:hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: rgba(37, 99, 235, 0.08);
     color: var(--text-strong);
     transform: translateY(-1px);
 }
 
 .nav-link.active {
-    background: var(--primary-soft);
-    color: #ffffff;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(56, 189, 248, 0.18));
+    color: var(--primary-strong);
 }
 
 .nav-link.active::before {
-    border-color: rgba(124, 108, 255, 0.6);
+    border-color: rgba(37, 99, 235, 0.3);
 }
 
 .nav-link.muted {
@@ -153,9 +154,9 @@ a {
     margin-top: auto;
     padding: 18px;
     border-radius: var(--radius-md);
-    background: rgba(10, 12, 26, 0.55);
+    background: rgba(255, 255, 255, 0.65);
     border: 1px solid var(--stroke);
-    font-size: 0.85rem;
+    font-size: 0.9rem;
     color: var(--text-muted);
 }
 
@@ -168,7 +169,7 @@ a {
 }
 
 .page-header {
-    background: linear-gradient(135deg, rgba(26, 32, 61, 0.78), rgba(26, 30, 58, 0.45));
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.65));
     border-radius: var(--radius-lg);
     padding: 32px 36px;
     border: 1px solid var(--stroke);
@@ -179,6 +180,7 @@ a {
     gap: 32px;
     position: relative;
     overflow: hidden;
+    backdrop-filter: var(--glass);
 }
 
 .page-header::after {
@@ -186,9 +188,9 @@ a {
     position: absolute;
     width: 220px;
     height: 220px;
-    right: -90px;
-    top: -70px;
-    background: radial-gradient(circle, rgba(124, 108, 255, 0.45), transparent 60%);
+    right: -80px;
+    top: -90px;
+    background: radial-gradient(circle, rgba(37, 99, 235, 0.25), transparent 60%);
     pointer-events: none;
 }
 
@@ -237,9 +239,9 @@ a {
     gap: 8px;
     padding: 10px 16px;
     border-radius: 999px;
-    background: rgba(15, 19, 42, 0.65);
-    border: 1px solid rgba(124, 108, 255, 0.25);
-    color: var(--text-muted);
+    background: rgba(37, 99, 235, 0.12);
+    border: 1px solid rgba(37, 99, 235, 0.18);
+    color: var(--primary-strong);
     font-size: 0.85rem;
     letter-spacing: 0.02em;
 }
@@ -255,8 +257,8 @@ a {
 .ghost-action {
     padding: 10px 18px;
     border-radius: 999px;
-    border: 1px solid var(--stroke);
-    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(37, 99, 235, 0.18);
+    background: rgba(37, 99, 235, 0.08);
     color: var(--text-muted);
     font-weight: 500;
     letter-spacing: 0.02em;
@@ -265,7 +267,7 @@ a {
 }
 
 .ghost-action:hover {
-    background: rgba(255, 255, 255, 0.08);
+    background: rgba(37, 99, 235, 0.16);
     color: var(--text-strong);
     transform: translateY(-1px);
 }
@@ -277,17 +279,17 @@ a {
     padding: 12px 22px;
     border-radius: 999px;
     text-decoration: none;
-    background: linear-gradient(135deg, #7c6cff, #6ee7b7);
-    color: #0b0d21;
+    background: linear-gradient(135deg, #2563eb, #38bdf8);
+    color: #ffffff;
     font-weight: 700;
     letter-spacing: 0.04em;
-    box-shadow: 0 14px 34px rgba(124, 108, 255, 0.45);
+    box-shadow: 0 16px 36px rgba(37, 99, 235, 0.28);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .primary-action:hover {
     transform: translateY(-2px);
-    box-shadow: 0 18px 40px rgba(124, 108, 255, 0.55);
+    box-shadow: 0 20px 42px rgba(37, 99, 235, 0.36);
 }
 
 .page-content {
@@ -307,7 +309,7 @@ a {
     position: relative;
     border-radius: var(--radius-lg);
     padding: 28px;
-    background: linear-gradient(135deg, rgba(17, 21, 42, 0.8), rgba(16, 20, 44, 0.68));
+    background: linear-gradient(135deg, var(--surface-solid), var(--surface-alt));
     border: 1px solid var(--stroke);
     box-shadow: var(--shadow-sm);
     backdrop-filter: var(--glass);
@@ -320,9 +322,9 @@ a {
     border-radius: inherit;
     border: 1px solid transparent;
     pointer-events: none;
-    background: linear-gradient(135deg, rgba(124, 108, 255, 0.2), rgba(13, 17, 38, 0));
-    mask: linear-gradient(#fff, transparent 65%);
-    opacity: 0.6;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(255, 255, 255, 0));
+    mask: linear-gradient(#fff, transparent 70%);
+    opacity: 0.8;
 }
 
 .metric-card {
@@ -353,8 +355,8 @@ a {
     justify-content: space-between;
     align-items: center;
     gap: 24px;
-    background: linear-gradient(145deg, rgba(248, 113, 113, 0.18), rgba(15, 19, 42, 0.7));
-    border: 1px solid rgba(248, 113, 113, 0.35);
+    background: linear-gradient(145deg, rgba(239, 68, 68, 0.12), rgba(255, 255, 255, 0.85));
+    border: 1px solid rgba(239, 68, 68, 0.28);
 }
 
 .alert-card h2 {
@@ -368,17 +370,17 @@ a {
     padding: 12px 20px;
     border-radius: 14px;
     text-decoration: none;
-    background: rgba(248, 250, 252, 0.12);
-    color: #fff;
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--primary-strong);
     font-weight: 600;
     letter-spacing: 0.03em;
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(37, 99, 235, 0.2);
     transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .link-button:hover {
     transform: translateY(-1px);
-    background: rgba(248, 250, 252, 0.18);
+    background: rgba(37, 99, 235, 0.2);
 }
 
 .split-grid {
@@ -408,8 +410,8 @@ a {
 .empty-note {
     padding: 24px;
     border-radius: var(--radius-md);
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px dashed var(--stroke);
+    background: rgba(255, 255, 255, 0.7);
+    border: 1px dashed rgba(15, 23, 42, 0.16);
     text-align: center;
     color: var(--text-muted);
 }
@@ -452,18 +454,18 @@ a {
 }
 
 .priority-badge.high {
-    background: rgba(248, 113, 113, 0.18);
-    color: #fca5a5;
+    background: rgba(239, 68, 68, 0.14);
+    color: var(--danger);
 }
 
 .priority-badge.medium {
-    background: rgba(250, 204, 21, 0.16);
-    color: #fde68a;
+    background: rgba(245, 158, 11, 0.14);
+    color: var(--warning);
 }
 
 .priority-badge.low {
-    background: rgba(45, 212, 191, 0.18);
-    color: #a7f3d0;
+    background: rgba(16, 185, 129, 0.14);
+    color: var(--success);
 }
 
 .badge {
@@ -476,13 +478,13 @@ a {
 }
 
 .badge.warning {
-    background: rgba(251, 191, 36, 0.2);
-    color: #facc15;
+    background: rgba(245, 158, 11, 0.16);
+    color: var(--warning);
 }
 
 .badge.neutral {
     background: rgba(148, 163, 184, 0.2);
-    color: #e2e8f0;
+    color: rgba(15, 23, 42, 0.55);
 }
 
 .performance-row {
@@ -502,14 +504,14 @@ a {
     width: 100%;
     height: 10px;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.06);
+    background: rgba(15, 23, 42, 0.08);
     overflow: hidden;
 }
 
 .progress-fill {
     display: block;
     height: 100%;
-    background: linear-gradient(90deg, #7c6cff, #22d3ee);
+    background: linear-gradient(90deg, #2563eb, #38bdf8);
 }
 
 .progress-meta {
@@ -530,7 +532,7 @@ a {
     align-items: center;
     padding: 24px 32px;
     border-radius: var(--radius-lg);
-    background: rgba(17, 21, 42, 0.7);
+    background: rgba(255, 255, 255, 0.72);
     border: 1px solid var(--stroke);
     color: var(--text-muted);
     font-size: 0.9rem;
@@ -542,7 +544,7 @@ a {
     right: 24px;
     padding: 18px 24px;
     border-radius: 16px;
-    background: rgba(17, 21, 42, 0.9);
+    background: rgba(255, 255, 255, 0.9);
     border: 1px solid var(--stroke-strong);
     color: var(--text-strong);
     font-weight: 500;
@@ -561,8 +563,13 @@ a {
 }
 
 .toast.error {
-    border-color: rgba(248, 113, 113, 0.4);
-    color: #fecaca;
+    border-color: rgba(239, 68, 68, 0.4);
+    color: var(--danger);
+}
+
+.toast.success {
+    border-color: rgba(16, 185, 129, 0.35);
+    color: var(--success);
 }
 
 .task-board {
@@ -577,8 +584,9 @@ a {
     gap: 16px;
     padding: 20px;
     border-radius: var(--radius-md);
-    background: rgba(15, 19, 42, 0.5);
+    background: rgba(255, 255, 255, 0.72);
     border: 1px solid var(--stroke);
+    backdrop-filter: var(--glass);
 }
 
 .board-column header {
@@ -595,9 +603,9 @@ a {
     gap: 14px;
     padding: 20px;
     border-radius: var(--radius-md);
-    background: rgba(15, 19, 42, 0.75);
-    border: 1px solid rgba(124, 108, 255, 0.12);
-    box-shadow: 0 12px 26px rgba(10, 13, 32, 0.45);
+    background: rgba(255, 255, 255, 0.85);
+    border: 1px solid rgba(37, 99, 235, 0.12);
+    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.14);
 }
 
 .task-card::after {
@@ -605,7 +613,7 @@ a {
     position: absolute;
     inset: 0;
     border-radius: inherit;
-    border: 1px solid rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(37, 99, 235, 0.05);
     pointer-events: none;
 }
 
@@ -636,23 +644,23 @@ a {
     padding: 10px 12px;
     border-radius: 10px;
     border: 1px solid rgba(148, 163, 184, 0.35);
-    background: rgba(17, 21, 42, 0.8);
+    background: rgba(255, 255, 255, 0.9);
     color: var(--text-strong);
 }
 
 .secondary {
     padding: 10px 16px;
     border-radius: 12px;
-    border: 1px solid rgba(124, 108, 255, 0.25);
-    background: rgba(124, 108, 255, 0.15);
-    color: #e0e7ff;
+    border: 1px solid rgba(37, 99, 235, 0.2);
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--primary-strong);
     font-weight: 600;
     cursor: pointer;
     transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .secondary:hover {
-    background: rgba(124, 108, 255, 0.25);
+    background: rgba(37, 99, 235, 0.2);
     transform: translateY(-1px);
 }
 
@@ -687,7 +695,7 @@ a {
     font-size: 0.9rem;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: var(--text-muted);
+    color: var(--text-subtle);
 }
 
 .form-panel input,
@@ -697,10 +705,18 @@ a {
     padding: 12px 14px;
     border-radius: 14px;
     border: 1px solid rgba(148, 163, 184, 0.3);
-    background: rgba(14, 18, 38, 0.9);
+    background: rgba(255, 255, 255, 0.92);
     color: var(--text-strong);
     font-family: inherit;
     font-size: 0.95rem;
+}
+
+.form-panel input:focus,
+.form-panel select:focus,
+.form-panel textarea:focus {
+    outline: none;
+    border-color: rgba(37, 99, 235, 0.45);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
 }
 
 .form-panel textarea {
@@ -715,36 +731,527 @@ a {
     padding: 12px 22px;
     border-radius: 14px;
     border: none;
-    background: linear-gradient(135deg, #7c6cff, #22d3ee);
-    color: #0b0d21;
+    background: linear-gradient(135deg, #2563eb, #38bdf8);
+    color: #ffffff;
     font-weight: 700;
     letter-spacing: 0.04em;
     cursor: pointer;
-    box-shadow: 0 18px 36px rgba(17, 12, 60, 0.45);
+    box-shadow: 0 18px 36px rgba(37, 99, 235, 0.25);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .form-panel button:hover {
     transform: translateY(-2px);
-    box-shadow: 0 22px 44px rgba(17, 12, 60, 0.55);
+    box-shadow: 0 22px 44px rgba(37, 99, 235, 0.35);
+}
+
+.form-page {
+    display: grid;
+    grid-template-columns: minmax(0, 2.1fr) minmax(260px, 1fr);
+    gap: 24px;
+}
+
+.form-primary {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.form-header h2 {
+    margin: 0 0 6px;
+    font-size: 1.5rem;
+}
+
+.form-header p {
+    margin: 0;
+    color: var(--text-muted);
+    max-width: 420px;
+}
+
+.task-form {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.form-group label {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.task-form input[type="text"],
+.task-form input[type="date"],
+.task-form select,
+.task-form textarea {
+    padding: 12px 14px;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(255, 255, 255, 0.92);
+    font-size: 0.95rem;
+    color: var(--text-strong);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.task-form textarea {
+    resize: vertical;
+}
+
+.task-form input:focus,
+.task-form select:focus,
+.task-form textarea:focus {
+    outline: none;
+    border-color: rgba(37, 99, 235, 0.5);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 20px;
+}
+
+.priority-pills {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.pill-option {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(255, 255, 255, 0.88);
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.pill-option input {
+    display: none;
+}
+
+.pill-option span {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.pill-option input:checked + span,
+.pill-option:hover span {
+    color: var(--primary-strong);
+}
+
+.pill-option input:checked ~ span,
+.pill-option input:checked + span {
+    font-weight: 700;
+}
+
+.pill-option input:checked + span,
+.pill-option input:checked ~ span,
+.pill-option:hover {
+    border-color: rgba(37, 99, 235, 0.38);
+    background: rgba(37, 99, 235, 0.12);
+    transform: translateY(-1px);
+}
+
+.form-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.form-actions .ghost-action {
+    order: 1;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(148, 163, 184, 0.12);
+    color: var(--text-muted);
+}
+
+.form-actions .ghost-action:hover {
+    background: rgba(148, 163, 184, 0.2);
+}
+
+.form-sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.form-sidebar h2 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.form-tips {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.form-tips strong {
+    color: var(--text-strong);
+}
+
+.calendar-preview {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 18px;
+    border-radius: var(--radius-md);
+    background: rgba(37, 99, 235, 0.1);
+    border: 1px dashed rgba(37, 99, 235, 0.2);
+}
+
+.calendar-preview-month {
+    font-weight: 700;
+    color: var(--primary-strong);
+}
+
+@media (max-width: 960px) {
+    .form-page {
+        grid-template-columns: 1fr;
+    }
+
+    .form-sidebar {
+        order: -1;
+    }
+
+    .form-actions {
+        flex-direction: column-reverse;
+        align-items: stretch;
+    }
+
+    .form-actions .ghost-action {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .form-actions .primary-action {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
+.calendar-hero {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+}
+
+.calendar-hero h2 {
+    margin: 0 0 6px;
+    font-size: 2rem;
+}
+
+.calendar-hero p {
+    margin: 0;
+    color: var(--text-muted);
+    max-width: 520px;
+}
+
+.calendar-nav {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.calendar-nav-current {
+    font-weight: 600;
+    color: var(--text-strong);
+}
+
+.calendar-nav .ghost-action {
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(148, 163, 184, 0.32);
+    color: var(--text-strong);
+}
+
+.calendar-nav .ghost-action:hover {
+    background: rgba(37, 99, 235, 0.12);
+}
+
+.calendar-layout {
+    display: grid;
+    grid-template-columns: minmax(240px, 0.9fr) minmax(0, 2.6fr);
+    gap: 24px;
+}
+
+.calendar-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.calendar-meta h3 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.calendar-meta ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.calendar-meta li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+
+.calendar-meta li strong {
+    color: var(--text-strong);
+    font-size: 1.05rem;
+}
+
+.legend {
+    gap: 10px;
+}
+
+.legend li {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 10px;
+}
+
+.legend-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.calendar-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 24px;
+}
+
+.calendar-grid-head {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 12px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+.calendar-grid-body {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 12px;
+}
+
+.calendar-cell {
+    min-height: 140px;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    background: rgba(255, 255, 255, 0.9);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.calendar-cell.today {
+    border-color: rgba(37, 99, 235, 0.45);
+    box-shadow: 0 12px 28px rgba(37, 99, 235, 0.18);
+}
+
+.calendar-cell.muted {
+    opacity: 0.55;
+}
+
+.calendar-cell:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.18);
+}
+
+.calendar-cell-header {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.calendar-date-number {
+    font-weight: 700;
+    color: var(--text-strong);
+}
+
+.calendar-events {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex: 1;
+}
+
+.calendar-event {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    background: rgba(255, 255, 255, 0.94);
+    font-size: 0.85rem;
+}
+
+.calendar-event .event-title {
+    font-weight: 600;
+    color: var(--text-strong);
+}
+
+.calendar-event .event-meta {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+}
+
+.calendar-event.priority-high {
+    border-color: rgba(239, 68, 68, 0.3);
+}
+
+.calendar-event.priority-medium {
+    border-color: rgba(245, 158, 11, 0.3);
+}
+
+.calendar-event.priority-low {
+    border-color: rgba(16, 185, 129, 0.3);
+}
+
+.empty-slot {
+    color: rgba(148, 163, 184, 0.6);
+    font-size: 0.8rem;
+}
+
+.tag-blue {
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.25), rgba(59, 130, 246, 0.05));
+}
+
+.tag-purple {
+    background: linear-gradient(135deg, rgba(147, 51, 234, 0.25), rgba(147, 51, 234, 0.05));
+}
+
+.tag-green {
+    background: linear-gradient(135deg, rgba(16, 185, 129, 0.25), rgba(16, 185, 129, 0.05));
+}
+
+.tag-amber {
+    background: linear-gradient(135deg, rgba(245, 158, 11, 0.25), rgba(245, 158, 11, 0.05));
+}
+
+.tag-pink {
+    background: linear-gradient(135deg, rgba(236, 72, 153, 0.25), rgba(236, 72, 153, 0.05));
+}
+
+.tag-teal {
+    background: linear-gradient(135deg, rgba(20, 184, 166, 0.25), rgba(20, 184, 166, 0.05));
+}
+
+.tag-indigo {
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.25), rgba(99, 102, 241, 0.05));
+}
+
+.tag-coral {
+    background: linear-gradient(135deg, rgba(244, 114, 182, 0.25), rgba(244, 114, 182, 0.05));
+}
+
+.legend-dot.tag-blue { background: #3b82f6; }
+.legend-dot.tag-purple { background: #9333ea; }
+.legend-dot.tag-green { background: #10b981; }
+.legend-dot.tag-amber { background: #f59e0b; }
+.legend-dot.tag-pink { background: #ec4899; }
+.legend-dot.tag-teal { background: #14b8a6; }
+.legend-dot.tag-indigo { background: #6366f1; }
+.legend-dot.tag-coral { background: #f472b6; }
+
+@media (max-width: 1100px) {
+    .calendar-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .calendar-meta {
+        order: -1;
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .calendar-meta h3 {
+        width: 100%;
+    }
+
+    .calendar-meta ul {
+        flex: 1;
+    }
+}
+
+@media (max-width: 720px) {
+    .calendar-grid-body,
+    .calendar-grid-head {
+        gap: 8px;
+    }
+
+    .calendar-cell {
+        min-height: 120px;
+        padding: 10px;
+    }
+
+    .calendar-hero {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .calendar-nav {
+        width: 100%;
+        justify-content: space-between;
+    }
 }
 
 .alert {
     padding: 14px 18px;
     border-radius: 14px;
     font-size: 0.95rem;
+    border: 1px solid var(--stroke);
+    background: rgba(255, 255, 255, 0.85);
+    color: var(--text-strong);
+    box-shadow: 0 12px 20px rgba(15, 23, 42, 0.12);
 }
 
 .alert.error {
-    background: rgba(248, 113, 113, 0.14);
-    border: 1px solid rgba(248, 113, 113, 0.35);
-    color: #fecaca;
+    background: rgba(239, 68, 68, 0.12);
+    border-color: rgba(239, 68, 68, 0.32);
+    color: var(--danger);
 }
 
 .alert.success {
-    background: rgba(45, 212, 191, 0.14);
-    border: 1px solid rgba(45, 212, 191, 0.35);
-    color: #99f6e4;
+    background: rgba(16, 185, 129, 0.12);
+    border-color: rgba(16, 185, 129, 0.3);
+    color: var(--success);
+}
+
+.global-alert {
+    margin-top: -8px;
 }
 
 .department-grid {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -60,16 +60,11 @@ a:hover {
     gap: 12px;
 }
 
-.brand-icon {
-    width: 48px;
-    height: 48px;
-    border-radius: 14px;
-    background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(14, 165, 233, 0.2));
-    color: #1d4ed8;
-    font-weight: 700;
-    font-size: 1.1rem;
-    display: grid;
-    place-items: center;
+.brand-logo {
+    width: 68px;
+    height: auto;
+    display: block;
+    filter: drop-shadow(0 10px 18px rgba(15, 23, 42, 0.25));
 }
 
 .brand-title {
@@ -881,6 +876,22 @@ a:hover {
     gap: 18px;
 }
 
+.auth-logo {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 12px;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.auth-logo img {
+    max-width: 220px;
+    height: auto;
+}
+
 .auth-card h2 {
     margin: 0;
     font-size: 1.4rem;
@@ -1153,5 +1164,9 @@ a:hover {
     .auth-intro,
     .auth-card {
         padding: 32px;
+    }
+
+    .auth-logo img {
+        max-width: 180px;
     }
 }

--- a/assets/img/hail-region-municipality-logo.svg
+++ b/assets/img/hail-region-municipality-logo.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 260" role="img" aria-labelledby="title desc">
+  <title id="title">Hail Region Municipality Logo</title>
+  <desc id="desc">Stylized bilingual wordmark with geometric palm crest used by the Hail Region Municipality</desc>
+  <defs>
+    <linearGradient id="triangleGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0b7743" />
+      <stop offset="100%" stop-color="#36a168" />
+    </linearGradient>
+    <linearGradient id="triangleGradientAlt" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1c9c5f" />
+      <stop offset="100%" stop-color="#5ad28c" />
+    </linearGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="transparent" />
+  <g transform="translate(40, 60)">
+    <text x="0" y="40" font-family="'Tajawal', 'Amiri', 'Segoe UI', sans-serif" font-size="60" font-weight="600" fill="#1f1f1f">أمانة منطقة حائل</text>
+    <text x="2" y="110" font-family="'Inter', 'Segoe UI', sans-serif" font-size="42" font-weight="600" letter-spacing="4" fill="#1f1f1f">HAIL REGION MUNICIPALITY</text>
+    <text x="4" y="160" font-family="'Tajawal', 'Segoe UI', sans-serif" font-size="32" font-weight="500" fill="#1f1f1f">أمانة منطقة حائل</text>
+  </g>
+  <g transform="translate(560, 20)">
+    <polygon points="120,0 240,0 180,100" fill="url(#triangleGradient)" />
+    <polygon points="0,120 120,120 60,220" fill="url(#triangleGradientAlt)" />
+    <polygon points="120,120 240,120 180,220" fill="url(#triangleGradient)" />
+    <polygon points="240,120 360,120 300,220" fill="url(#triangleGradientAlt)" />
+    <polygon points="120,0 180,100 60,100" fill="#0c8f4d" opacity="0.85" />
+    <polygon points="240,0 300,100 180,100" fill="#2fa766" opacity="0.85" />
+    <g transform="translate(150, -10)">
+      <path d="M58 62c-8-17-24-26-24-26s5 18 0 30c0 0 9-3 24-4z" fill="#0b7743" />
+      <path d="M58 62c8-17 24-26 24-26s-5 18 0 30c0 0-9-3-24-4z" fill="#0b7743" />
+      <rect x="53" y="62" width="10" height="18" fill="#0b7743" />
+      <circle cx="58" cy="44" r="6" fill="#0b7743" />
+    </g>
+    <text x="120" y="250" font-family="'Tajawal', 'Segoe UI', sans-serif" font-size="28" font-weight="600" fill="#1f1f1f">أمانة منطقة حائل</text>
+  </g>
+</svg>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,45 @@
+document.addEventListener('DOMContentLoaded', () => {
+    let toast = document.querySelector('.toast');
+
+    if (!toast) {
+        toast = document.createElement('div');
+        toast.className = 'toast';
+        document.body.appendChild(toast);
+    }
+
+    function showToast(message, type = 'success') {
+        toast.textContent = message;
+        toast.classList.remove('error', 'success');
+        toast.classList.add('show', type);
+        setTimeout(() => toast.classList.remove('show'), 3000);
+    }
+
+    document.querySelectorAll('.reminder-button').forEach(button => {
+        button.addEventListener('click', async () => {
+            const taskId = button.dataset.taskId;
+            button.disabled = true;
+            try {
+                const response = await fetch('send_reminder.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ taskId })
+                });
+
+                const result = await response.json();
+                if (response.ok) {
+                    showToast(result.message, 'success');
+                    const stamp = button.closest('.task-card')?.querySelector('.reminder-stamp');
+                    if (stamp) {
+                        stamp.textContent = result.lastReminder;
+                    }
+                } else {
+                    throw new Error(result.message || 'Unable to send reminder');
+                }
+            } catch (error) {
+                showToast(error.message, 'error');
+            } finally {
+                button.disabled = false;
+            }
+        });
+    });
+});

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -17,6 +17,9 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.reminder-button').forEach(button => {
         button.addEventListener('click', async () => {
             const taskId = button.dataset.taskId;
+            const targetSelector = button.dataset.target;
+            const target = targetSelector ? document.querySelector(targetSelector) : null;
+
             button.disabled = true;
             try {
                 const response = await fetch('send_reminder.php', {
@@ -28,9 +31,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const result = await response.json();
                 if (response.ok) {
                     showToast(result.message, 'success');
-                    const stamp = button.closest('.task-card')?.querySelector('.reminder-stamp');
-                    if (stamp) {
-                        stamp.textContent = result.lastReminder;
+                    if (target && result.lastReminder) {
+                        target.textContent = result.lastReminder;
                     }
                 } else {
                     throw new Error(result.message || 'Unable to send reminder');

--- a/calendar.php
+++ b/calendar.php
@@ -158,10 +158,15 @@ include __DIR__ . '/includes/header.php';
                                 <?php
                                 $priorityClass = 'priority-' . strtolower($event['priority'] ?? 'medium');
                                 $tagClass = calendar_tag_class($event['department_name']);
+                                $statusLabel = $event['status'] ?? 'Pending';
+                                $statusClass = 'status-' . strtolower(str_replace(' ', '-', $statusLabel));
                                 ?>
                                 <article class="calendar-event <?= $tagClass; ?> <?= $priorityClass; ?>">
                                     <span class="event-title"><?= sanitize($event['title']); ?></span>
-                                    <span class="event-meta"><?= sanitize($event['department_name']); ?> · <?= sanitize($event['priority']); ?></span>
+                                    <span class="event-meta">
+                                        <span><?= sanitize($event['department_name']); ?> · <?= sanitize($event['priority']); ?></span>
+                                        <span class="status-chip <?= sanitize($statusClass); ?>"><?= sanitize($statusLabel); ?></span>
+                                    </span>
                                 </article>
                             <?php endforeach; ?>
                         <?php else: ?>

--- a/calendar.php
+++ b/calendar.php
@@ -1,8 +1,9 @@
 <?php
 $pageTitle = 'Calendar';
 $pageDescription = 'View all task deadlines in calendar format.';
-require_once __DIR__ . '/db.php';
 require_once __DIR__ . '/includes/functions.php';
+require_login();
+require_once __DIR__ . '/db.php';
 
 $today = new DateTimeImmutable('today');
 $monthParam = $_GET['month'] ?? $today->format('Y-m');

--- a/calendar.php
+++ b/calendar.php
@@ -1,0 +1,175 @@
+<?php
+$pageTitle = 'Calendar';
+$pageDescription = 'View all task deadlines in calendar format.';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$today = new DateTimeImmutable('today');
+$monthParam = $_GET['month'] ?? $today->format('Y-m');
+if (!preg_match('/^\d{4}-\d{2}$/', $monthParam)) {
+    $monthParam = $today->format('Y-m');
+}
+[$year, $month] = array_map('intval', explode('-', $monthParam));
+if ($month < 1 || $month > 12) {
+    $year = (int)$today->format('Y');
+    $month = (int)$today->format('n');
+}
+
+try {
+    $currentMonth = new DateTimeImmutable(sprintf('%04d-%02d-01', $year, $month));
+} catch (Exception $exception) {
+    $currentMonth = new DateTimeImmutable('first day of this month');
+}
+
+$start = $currentMonth;
+if ($currentMonth->format('w') !== '0') {
+    $start = $currentMonth->modify('last sunday');
+}
+$end = $start->modify('+41 days');
+
+$eventsStmt = $pdo->prepare('SELECT ce.event_date, ce.title, ce.priority, ce.status, d.name AS department_name
+    FROM calendar_events ce
+    JOIN departments d ON d.id = ce.department_id
+    WHERE ce.event_date BETWEEN :start AND :end
+    ORDER BY ce.event_date ASC, FIELD(ce.priority, "High", "Medium", "Low"), ce.title ASC');
+$eventsStmt->execute([
+    'start' => $start->format('Y-m-d'),
+    'end' => $end->format('Y-m-d'),
+]);
+$events = $eventsStmt->fetchAll();
+
+$eventsByDate = [];
+$monthKey = $currentMonth->format('Y-m');
+$monthStats = [
+    'total' => 0,
+    'high' => 0,
+    'medium' => 0,
+    'low' => 0,
+    'pending' => 0,
+];
+$legend = [];
+
+foreach ($events as $event) {
+    $date = $event['event_date'];
+    $eventsByDate[$date][] = $event;
+
+    if (strpos($date, $monthKey) === 0) {
+        $monthStats['total']++;
+        $priority = strtolower($event['priority'] ?? 'medium');
+        if (isset($monthStats[$priority])) {
+            $monthStats[$priority]++;
+        }
+        if (strtolower($event['status']) !== 'completed') {
+            $monthStats['pending']++;
+        }
+    }
+
+    $legend[$event['department_name']] = true;
+}
+
+ksort($legend);
+
+$prevMonth = $currentMonth->modify('-1 month')->format('Y-m');
+$nextMonth = $currentMonth->modify('+1 month')->format('Y-m');
+
+function calendar_tag_class(string $label): string
+{
+    static $palette = [
+        'tag-blue',
+        'tag-purple',
+        'tag-green',
+        'tag-amber',
+        'tag-pink',
+        'tag-teal',
+        'tag-indigo',
+        'tag-coral',
+    ];
+    $index = abs(crc32($label)) % count($palette);
+    return $palette[$index];
+}
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="calendar-hero panel">
+    <div>
+        <h2><?= $currentMonth->format('F Y'); ?></h2>
+        <p>Stay ahead of deadlines with a single view of due dates and department commitments.</p>
+    </div>
+    <div class="calendar-nav">
+        <a class="ghost-action" href="calendar.php?month=<?= sanitize($prevMonth); ?>">Prev</a>
+        <span class="calendar-nav-current"><?= $currentMonth->format('F Y'); ?></span>
+        <a class="ghost-action" href="calendar.php?month=<?= sanitize($nextMonth); ?>">Next</a>
+    </div>
+</section>
+
+<section class="calendar-layout">
+    <aside class="panel calendar-meta">
+        <h3>Quick stats</h3>
+        <ul>
+            <li><span>Items this month</span><strong><?= number_format($monthStats['total']); ?></strong></li>
+            <li><span>High priority</span><strong><?= number_format($monthStats['high']); ?></strong></li>
+            <li><span>Medium priority</span><strong><?= number_format($monthStats['medium']); ?></strong></li>
+            <li><span>Open statuses</span><strong><?= number_format($monthStats['pending']); ?></strong></li>
+        </ul>
+        <h3>Department colors</h3>
+        <ul class="legend">
+            <?php if (!$legend): ?>
+                <li>No events scheduled.</li>
+            <?php else: ?>
+                <?php foreach (array_keys($legend) as $departmentName): ?>
+                    <li>
+                        <span class="legend-dot <?= calendar_tag_class($departmentName); ?>"></span>
+                        <?= sanitize($departmentName); ?>
+                    </li>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </ul>
+    </aside>
+    <div class="panel calendar-grid">
+        <header class="calendar-grid-head">
+            <?php foreach (['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as $day): ?>
+                <span><?= $day; ?></span>
+            <?php endforeach; ?>
+        </header>
+        <div class="calendar-grid-body">
+            <?php for ($offset = 0; $offset < 42; $offset++): ?>
+                <?php
+                $date = $start->modify('+' . $offset . ' days');
+                $dateKey = $date->format('Y-m-d');
+                $isCurrentMonth = $date->format('m') === $currentMonth->format('m');
+                $isToday = $dateKey === $today->format('Y-m-d');
+                $cellClasses = [];
+                if (!$isCurrentMonth) {
+                    $cellClasses[] = 'muted';
+                }
+                if ($isToday) {
+                    $cellClasses[] = 'today';
+                }
+                $cellClass = $cellClasses ? ' ' . implode(' ', $cellClasses) : '';
+                ?>
+                <div class="calendar-cell<?= $cellClass; ?>">
+                    <div class="calendar-cell-header">
+                        <span class="calendar-date-number"><?= $date->format('j'); ?></span>
+                    </div>
+                    <div class="calendar-events">
+                        <?php if (!empty($eventsByDate[$dateKey])): ?>
+                            <?php foreach ($eventsByDate[$dateKey] as $event): ?>
+                                <?php
+                                $priorityClass = 'priority-' . strtolower($event['priority'] ?? 'medium');
+                                $tagClass = calendar_tag_class($event['department_name']);
+                                ?>
+                                <article class="calendar-event <?= $tagClass; ?> <?= $priorityClass; ?>">
+                                    <span class="event-title"><?= sanitize($event['title']); ?></span>
+                                    <span class="event-meta"><?= sanitize($event['department_name']); ?> · <?= sanitize($event['priority']); ?></span>
+                                </article>
+                            <?php endforeach; ?>
+                        <?php else: ?>
+                            <span class="empty-slot">—</span>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            <?php endfor; ?>
+        </div>
+    </div>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,159 @@
+CREATE DATABASE IF NOT EXISTS task_manager CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE task_manager;
+
+CREATE TABLE IF NOT EXISTS departments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    email VARCHAR(190) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(180) NOT NULL,
+    description TEXT NULL,
+    department_id INT NOT NULL,
+    priority VARCHAR(20) DEFAULT 'Medium',
+    status VARCHAR(30) DEFAULT 'Pending',
+    due_date DATE NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_tasks_departments FOREIGN KEY (department_id) REFERENCES departments(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    task_id INT NOT NULL,
+    message TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_notifications_tasks FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO departments (name) VALUES
+    ('Office of the Secretary General'),
+    ('General Department of Information Technology'),
+    ('Cybersecurity Department'),
+    ('Investment Agency'),
+    ('General Department of Gardens and Landscaping'),
+    ('General Department of Internal Audits'),
+    ('General Department of Operations and Emergencies'),
+    ('Department of Safety and Security'),
+    ('Central Unit for Plan Approval'),
+    ('Department of Land Affairs'),
+    ('Environmental Health Department'),
+    ('General Department of Cleaning'),
+    ('Central City Municipality'),
+    ('Northern Municipality')
+ON DUPLICATE KEY UPDATE name = VALUES(name);
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Digital Infrastructure Audit', 'Complete the resiliency assessment for core datacenter services and report findings to the steering committee.', d.id, 'High', 'In Progress', DATE_ADD(CURDATE(), INTERVAL 5 DAY), NOW(), NOW()
+FROM departments d
+WHERE d.name = 'General Department of Information Technology'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Digital Infrastructure Audit' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Emergency Drill Readiness', 'Confirm equipment checklists and submit the cross-department readiness memo ahead of the city-wide drill.', d.id, 'Medium', 'Pending', DATE_ADD(CURDATE(), INTERVAL 2 DAY), NOW(), NOW()
+FROM departments d
+WHERE d.name = 'General Department of Operations and Emergencies'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Emergency Drill Readiness' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Investment Portfolio Review', 'Prepare quarterly briefing with performance highlights and risk actions for executive approval.', d.id, 'Medium', 'Completed', DATE_SUB(CURDATE(), INTERVAL 1 DAY), DATE_SUB(NOW(), INTERVAL 6 DAY), DATE_SUB(NOW(), INTERVAL 1 DAY)
+FROM departments d
+WHERE d.name = 'Investment Agency'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Investment Portfolio Review' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Public Park Revitalization', 'Finalize vendor contracts for the Riverside Park renovation and submit landscaping schedules.', d.id, 'High', 'Pending', DATE_SUB(CURDATE(), INTERVAL 3 DAY), DATE_SUB(NOW(), INTERVAL 14 DAY), DATE_SUB(NOW(), INTERVAL 3 DAY)
+FROM departments d
+WHERE d.name = 'General Department of Gardens and Landscaping'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Public Park Revitalization' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'City Clean-Up Campaign', 'Launch the awareness campaign and coordinate resources with district offices.', d.id, 'Low', 'In Progress', DATE_ADD(CURDATE(), INTERVAL 9 DAY), DATE_SUB(NOW(), INTERVAL 2 DAY), NOW()
+FROM departments d
+WHERE d.name = 'General Department of Cleaning'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'City Clean-Up Campaign' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Cybersecurity Incident Simulation', 'Coordinate the tabletop exercise with remediation playbooks and report findings to leadership.', d.id, 'High', 'In Progress', DATE_ADD(CURDATE(), INTERVAL 7 DAY), NOW(), NOW()
+FROM departments d
+WHERE d.name = 'Cybersecurity Department'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Cybersecurity Incident Simulation' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Land Use Compliance Audit', 'Compile zoning approvals and flag parcels that require renewal before the quarterly review.', d.id, 'Medium', 'Pending', DATE_ADD(CURDATE(), INTERVAL 4 DAY), DATE_SUB(NOW(), INTERVAL 5 DAY), NOW()
+FROM departments d
+WHERE d.name = 'Department of Land Affairs'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Land Use Compliance Audit' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Environmental Inspection Sweep', 'Deliver inspection summaries for high-risk districts and escalate unresolved breaches.', d.id, 'High', 'In Progress', DATE_ADD(CURDATE(), INTERVAL 3 DAY), DATE_SUB(NOW(), INTERVAL 1 DAY), NOW()
+FROM departments d
+WHERE d.name = 'Environmental Health Department'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Environmental Inspection Sweep' AND t.department_id = d.id
+  );
+
+INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+SELECT 'Safety Drill Certification', 'Gather drill sign-offs from facility leads and publish the compliance dashboard update.', d.id, 'Medium', 'Pending', DATE_ADD(CURDATE(), INTERVAL 6 DAY), DATE_SUB(NOW(), INTERVAL 3 DAY), NOW()
+FROM departments d
+WHERE d.name = 'Department of Safety and Security'
+  AND NOT EXISTS (
+      SELECT 1 FROM tasks t WHERE t.title = 'Safety Drill Certification' AND t.department_id = d.id
+  );
+
+INSERT INTO notifications (task_id, message, created_at)
+SELECT t.id, 'Reminder sent to confirm infrastructure resiliency updates.', DATE_SUB(NOW(), INTERVAL 1 DAY)
+FROM tasks t
+JOIN departments d ON d.id = t.department_id
+WHERE t.title = 'Digital Infrastructure Audit'
+  AND d.name = 'General Department of Information Technology'
+  AND NOT EXISTS (
+      SELECT 1 FROM notifications n WHERE n.task_id = t.id
+  );
+
+INSERT INTO notifications (task_id, message, created_at)
+SELECT t.id, 'Security exercise materials distributed to stakeholders.', DATE_SUB(NOW(), INTERVAL 3 HOUR)
+FROM tasks t
+JOIN departments d ON d.id = t.department_id
+WHERE t.title = 'Cybersecurity Incident Simulation'
+  AND d.name = 'Cybersecurity Department'
+  AND NOT EXISTS (
+      SELECT 1 FROM notifications n WHERE n.task_id = t.id
+  );
+
+INSERT INTO notifications (task_id, message, created_at)
+SELECT t.id, 'Follow-up issued for environmental inspection deliverables.', DATE_SUB(NOW(), INTERVAL 8 HOUR)
+FROM tasks t
+JOIN departments d ON d.id = t.department_id
+WHERE t.title = 'Environmental Inspection Sweep'
+  AND d.name = 'Environmental Health Department'
+  AND NOT EXISTS (
+      SELECT 1 FROM notifications n WHERE n.task_id = t.id
+  );
+
+INSERT INTO notifications (task_id, message, created_at)
+SELECT t.id, 'Follow-up issued for upcoming emergency readiness drill.', DATE_SUB(NOW(), INTERVAL 6 HOUR)
+FROM tasks t
+JOIN departments d ON d.id = t.department_id
+WHERE t.title = 'Emergency Drill Readiness'
+  AND d.name = 'General Department of Operations and Emergencies'
+  AND NOT EXISTS (
+      SELECT 1 FROM notifications n WHERE n.task_id = t.id
+  );

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -29,6 +29,20 @@ CREATE TABLE IF NOT EXISTS notifications (
     CONSTRAINT fk_notifications_tasks FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS calendar_events (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    task_id INT NULL,
+    department_id INT NOT NULL,
+    title VARCHAR(180) NOT NULL,
+    event_date DATE NOT NULL,
+    priority VARCHAR(20) DEFAULT 'Medium',
+    status VARCHAR(30) DEFAULT 'Scheduled',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    KEY idx_calendar_event_date (event_date),
+    CONSTRAINT fk_calendar_events_tasks FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE SET NULL,
+    CONSTRAINT fk_calendar_events_departments FOREIGN KEY (department_id) REFERENCES departments(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 INSERT INTO departments (name) VALUES
     ('Office of the Secretary General'),
     ('General Department of Information Technology'),
@@ -156,4 +170,72 @@ WHERE t.title = 'Emergency Drill Readiness'
   AND d.name = 'General Department of Operations and Emergencies'
   AND NOT EXISTS (
       SELECT 1 FROM notifications n WHERE n.task_id = t.id
+  );
+
+INSERT INTO calendar_events (task_id, department_id, title, event_date, priority, status)
+SELECT t.id, t.department_id, CONCAT(t.title, ' Deadline'), t.due_date, t.priority, t.status
+FROM tasks t
+WHERE t.due_date IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM calendar_events ce WHERE ce.task_id = t.id
+  );
+
+INSERT INTO calendar_events (department_id, title, event_date, priority, status)
+SELECT d.id, 'Employee Onboarding Workshop', DATE_FORMAT(CURDATE(), '%Y-%m-05'), 'Medium', 'Scheduled'
+FROM departments d
+WHERE d.name = 'Office of the Secretary General'
+  AND NOT EXISTS (
+      SELECT 1 FROM calendar_events ce WHERE ce.title = 'Employee Onboarding Workshop'
+        AND ce.event_date = DATE_FORMAT(CURDATE(), '%Y-%m-05')
+        AND ce.department_id = d.id
+  );
+
+INSERT INTO calendar_events (department_id, title, event_date, priority, status)
+SELECT d.id, 'Mobile App Beta Check-in', DATE_FORMAT(CURDATE(), '%Y-%m-12'), 'High', 'In Progress'
+FROM departments d
+WHERE d.name = 'General Department of Information Technology'
+  AND NOT EXISTS (
+      SELECT 1 FROM calendar_events ce WHERE ce.title = 'Mobile App Beta Check-in'
+        AND ce.event_date = DATE_FORMAT(CURDATE(), '%Y-%m-12')
+        AND ce.department_id = d.id
+  );
+
+INSERT INTO calendar_events (department_id, title, event_date, priority, status)
+SELECT d.id, 'Quarterly Plan Review', DATE_FORMAT(CURDATE(), '%Y-%m-17'), 'Medium', 'Scheduled'
+FROM departments d
+WHERE d.name = 'Central Unit for Plan Approval'
+  AND NOT EXISTS (
+      SELECT 1 FROM calendar_events ce WHERE ce.title = 'Quarterly Plan Review'
+        AND ce.event_date = DATE_FORMAT(CURDATE(), '%Y-%m-17')
+        AND ce.department_id = d.id
+  );
+
+INSERT INTO calendar_events (department_id, title, event_date, priority, status)
+SELECT d.id, 'Brand Refresh Showcase', DATE_FORMAT(CURDATE(), '%Y-%m-21'), 'Medium', 'Scheduled'
+FROM departments d
+WHERE d.name = 'Investment Agency'
+  AND NOT EXISTS (
+      SELECT 1 FROM calendar_events ce WHERE ce.title = 'Brand Refresh Showcase'
+        AND ce.event_date = DATE_FORMAT(CURDATE(), '%Y-%m-21')
+        AND ce.department_id = d.id
+  );
+
+INSERT INTO calendar_events (department_id, title, event_date, priority, status)
+SELECT d.id, 'Safety Compliance Walkthrough', DATE_FORMAT(CURDATE(), '%Y-%m-24'), 'High', 'Scheduled'
+FROM departments d
+WHERE d.name = 'Department of Safety and Security'
+  AND NOT EXISTS (
+      SELECT 1 FROM calendar_events ce WHERE ce.title = 'Safety Compliance Walkthrough'
+        AND ce.event_date = DATE_FORMAT(CURDATE(), '%Y-%m-24')
+        AND ce.department_id = d.id
+  );
+
+INSERT INTO calendar_events (department_id, title, event_date, priority, status)
+SELECT d.id, 'Green Corridor Site Visit', DATE_FORMAT(CURDATE(), '%Y-%m-28'), 'Low', 'Planned'
+FROM departments d
+WHERE d.name = 'General Department of Gardens and Landscaping'
+  AND NOT EXISTS (
+      SELECT 1 FROM calendar_events ce WHERE ce.title = 'Green Corridor Site Visit'
+        AND ce.event_date = DATE_FORMAT(CURDATE(), '%Y-%m-28')
+        AND ce.department_id = d.id
   );

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -12,9 +12,9 @@ CREATE TABLE IF NOT EXISTS users (
 
 INSERT INTO users (name, email, password_hash, role)
 VALUES
-    ('Amina Al-Faisal', 'president@taskmaster.test', '$2y$12$j65mli2D4LRBmSjRqekwbe6BETddZniVqrQSrPq7XI7P4m1qPMwLG', 'president'),
-    ('Omar Al-Hassan', 'manager@taskmaster.test', '$2y$12$KfuNnAYsRc5iWGUJV5omBu8nRfxcRLXlGgyIXoPKzQ/O..cuEqUBW', 'manager'),
-    ('Layla Al-Salem', 'employee@taskmaster.test', '$2y$12$r4o2bbtALudjyN/x0z0jX.LaNQT12Y0RD45HV0NBCfshr1hJi3fGy', 'employee')
+    ('Amina Al-Faisal', 'president@hailtasks.test', '$2y$12$j65mli2D4LRBmSjRqekwbe6BETddZniVqrQSrPq7XI7P4m1qPMwLG', 'president'),
+    ('Omar Al-Hassan', 'manager@hailtasks.test', '$2y$12$KfuNnAYsRc5iWGUJV5omBu8nRfxcRLXlGgyIXoPKzQ/O..cuEqUBW', 'manager'),
+    ('Layla Al-Salem', 'employee@hailtasks.test', '$2y$12$r4o2bbtALudjyN/x0z0jX.LaNQT12Y0RD45HV0NBCfshr1hJi3fGy', 'employee')
 ON DUPLICATE KEY UPDATE
     name = VALUES(name),
     password_hash = VALUES(password_hash),

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,6 +1,25 @@
 CREATE DATABASE IF NOT EXISTS task_manager CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 USE task_manager;
 
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    email VARCHAR(190) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    role VARCHAR(30) NOT NULL DEFAULT 'employee',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO users (name, email, password_hash, role)
+VALUES
+    ('Amina Al-Faisal', 'president@taskmaster.test', '$2y$12$j65mli2D4LRBmSjRqekwbe6BETddZniVqrQSrPq7XI7P4m1qPMwLG', 'president'),
+    ('Omar Al-Hassan', 'manager@taskmaster.test', '$2y$12$KfuNnAYsRc5iWGUJV5omBu8nRfxcRLXlGgyIXoPKzQ/O..cuEqUBW', 'manager'),
+    ('Layla Al-Salem', 'employee@taskmaster.test', '$2y$12$r4o2bbtALudjyN/x0z0jX.LaNQT12Y0RD45HV0NBCfshr1hJi3fGy', 'employee')
+ON DUPLICATE KEY UPDATE
+    name = VALUES(name),
+    password_hash = VALUES(password_hash),
+    role = VALUES(role);
+
 CREATE TABLE IF NOT EXISTS departments (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(150) NOT NULL,

--- a/db.php
+++ b/db.php
@@ -1,0 +1,23 @@
+<?php
+$host = getenv('DB_HOST') ?: 'localhost';
+$port = getenv('DB_PORT') ?: '3306';
+$name = getenv('DB_NAME') ?: 'task_manager';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASSWORD') !== false ? getenv('DB_PASSWORD') : 'root';
+$charset = 'utf8mb4';
+$dsn = "mysql:host={$host};port={$port};dbname={$name};charset={$charset}";
+$options = [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $exception) {
+    http_response_code(500);
+    $dbError = $exception->getMessage();
+    require_once __DIR__ . '/includes/functions.php';
+    include __DIR__ . '/includes/db_error.php';
+    exit;
+}

--- a/departments.php
+++ b/departments.php
@@ -1,0 +1,175 @@
+<?php
+$pageTitle = 'Departments';
+$pageDescription = 'Manage departments and view their task performance.';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$errors = [];
+$success = '';
+
+$defaultDepartments = [
+    'Office of the Secretary General',
+    'General Department of Information Technology',
+    'Cybersecurity Department',
+    'Investment Agency',
+    'General Department of Gardens and Landscaping',
+    'General Department of Internal Audits',
+    'General Department of Operations and Emergencies',
+    'Department of Safety and Security',
+    'Central Unit for Plan Approval',
+    'Department of Land Affairs',
+    'Environmental Health Department',
+    'General Department of Cleaning',
+    'Central City Municipality',
+    'Northern Municipality',
+];
+
+$count = (int)$pdo->query('SELECT COUNT(*) FROM departments')->fetchColumn();
+if ($count === 0) {
+    $insert = $pdo->prepare('INSERT INTO departments (name) VALUES (:name)');
+    foreach ($defaultDepartments as $departmentName) {
+        $insert->execute(['name' => $departmentName]);
+    }
+    $success = 'Default departments were added automatically.';
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+
+    if ($name === '') {
+        $errors[] = 'Department name is required.';
+    }
+
+    if (empty($errors)) {
+        $stmt = $pdo->prepare('INSERT INTO departments (name, email) VALUES (:name, :email)');
+        $stmt->execute([
+            'name' => $name,
+            'email' => $email ?: null,
+        ]);
+        $success = 'Department created successfully.';
+    }
+}
+
+$departments = $pdo->query('SELECT d.*, COUNT(t.id) AS tasks_count,
+    SUM(CASE WHEN t.status = "Completed" THEN 1 ELSE 0 END) AS completed_count,
+    SUM(CASE WHEN t.status = "In Progress" THEN 1 ELSE 0 END) AS in_progress_count,
+    SUM(CASE WHEN t.status = "Pending" THEN 1 ELSE 0 END) AS pending_count,
+    SUM(CASE WHEN t.due_date IS NOT NULL AND t.due_date < CURDATE() AND t.status != "Completed" THEN 1 ELSE 0 END) AS overdue_count
+    FROM departments d
+    LEFT JOIN tasks t ON t.department_id = d.id
+    GROUP BY d.id
+    ORDER BY d.name ASC')->fetchAll();
+
+$totalDepartments = count($departments);
+$withContacts = 0;
+$activeWorkloads = 0;
+
+foreach ($departments as $department) {
+    if (!empty($department['email'])) {
+        $withContacts++;
+    }
+    if ((int)$department['tasks_count'] > 0) {
+        $activeWorkloads++;
+    }
+}
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="metrics-grid">
+    <article class="panel metric-card">
+        <span class="metric-label">Active units</span>
+        <span class="metric-value"><?= number_format($totalDepartments); ?></span>
+        <span class="metric-footnote">Participating in the workspace</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">Contacts listed</span>
+        <span class="metric-value"><?= number_format($withContacts); ?></span>
+        <span class="metric-footnote">Teams with escalation emails</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">Active workloads</span>
+        <span class="metric-value"><?= number_format($activeWorkloads); ?></span>
+        <span class="metric-footnote">Departments with assigned tasks</span>
+    </article>
+</section>
+
+<section class="panel form-panel">
+    <h2>Add Department</h2>
+    <p class="panel-subtitle">Create a new department to assign work</p>
+    <?php if ($errors): ?>
+        <div class="alert error">
+            <?= implode('<br>', array_map('sanitize', $errors)); ?>
+        </div>
+    <?php endif; ?>
+    <?php if ($success && !$errors): ?>
+        <div class="alert success"><?= sanitize($success); ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <div>
+            <label for="name">Department name</label>
+            <input type="text" id="name" name="name" required>
+        </div>
+        <div>
+            <label for="email">Email (optional)</label>
+            <input type="email" id="email" name="email" placeholder="team@example.com">
+        </div>
+        <button type="submit">Add department</button>
+    </form>
+</section>
+
+<section class="department-grid">
+    <?php if (!$departments): ?>
+        <div class="panel empty-note">No departments available. Add one to get started.</div>
+    <?php else: ?>
+        <?php $colors = ['blue', 'pink', 'orange', 'green', 'yellow']; ?>
+        <?php foreach ($departments as $index => $department): ?>
+            <?php
+            $totalTasks = (int)$department['tasks_count'];
+            $completed = (int)$department['completed_count'];
+            $inProgress = (int)$department['in_progress_count'];
+            $pending = (int)$department['pending_count'];
+            $overdue = (int)$department['overdue_count'];
+            $rate = $totalTasks > 0 ? round(($completed / $totalTasks) * 100) : 0;
+            $color = $colors[$index % count($colors)];
+            ?>
+            <article class="panel department-card">
+                <div class="department-header">
+                    <div class="department-identity">
+                        <span class="department-dot <?= $color; ?>" aria-hidden="true"></span>
+                        <div>
+                            <h2><?= sanitize($department['name']); ?></h2>
+                            <p><?= $department['email'] ? sanitize($department['email']) : 'No contact listed'; ?></p>
+                        </div>
+                    </div>
+                    <span class="badge neutral"><?= number_format($totalTasks); ?> tasks</span>
+                </div>
+                <div class="department-stats">
+                    <div>
+                        <span><?= number_format($pending); ?></span>
+                        Pending
+                    </div>
+                    <div>
+                        <span><?= number_format($inProgress); ?></span>
+                        In progress
+                    </div>
+                    <div>
+                        <span><?= number_format($completed); ?></span>
+                        Completed
+                    </div>
+                    <div>
+                        <span><?= number_format($overdue); ?></span>
+                        Overdue
+                    </div>
+                </div>
+                <div class="progress-wrap">
+                    <div class="progress-track">
+                        <span class="progress-fill" style="width: <?= $rate; ?>%"></span>
+                    </div>
+                    <span class="progress-label">Completion rate <?= $rate; ?>%</span>
+                </div>
+            </article>
+        <?php endforeach; ?>
+    <?php endif; ?>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/departments.php
+++ b/departments.php
@@ -1,8 +1,9 @@
 <?php
 $pageTitle = 'Departments';
-$pageDescription = 'Manage departments and view their task performance.';
-require_once __DIR__ . '/db.php';
+$pageDescription = 'Maintain department records and workload summaries.';
 require_once __DIR__ . '/includes/functions.php';
+require_login();
+require_once __DIR__ . '/db.php';
 
 $errors = [];
 $success = '';
@@ -76,100 +77,103 @@ foreach ($departments as $department) {
 
 include __DIR__ . '/includes/header.php';
 ?>
-<section class="metrics-grid">
-    <article class="panel metric-card">
-        <span class="metric-label">Active units</span>
-        <span class="metric-value"><?= number_format($totalDepartments); ?></span>
-        <span class="metric-footnote">Participating in the workspace</span>
+<?php if ($success && !$errors): ?>
+    <div class="alert success global-alert"><?= sanitize($success); ?></div>
+<?php endif; ?>
+<?php if ($errors): ?>
+    <div class="alert error global-alert">
+        <?= implode('<br>', array_map('sanitize', $errors)); ?>
+    </div>
+<?php endif; ?>
+<section class="summary-cards">
+    <article class="summary-card">
+        <span class="summary-label">Active units</span>
+        <span class="summary-value"><?= number_format($totalDepartments); ?></span>
+        <span class="summary-footnote">Participating in the workspace</span>
     </article>
-    <article class="panel metric-card">
-        <span class="metric-label">Contacts listed</span>
-        <span class="metric-value"><?= number_format($withContacts); ?></span>
-        <span class="metric-footnote">Teams with escalation emails</span>
+    <article class="summary-card">
+        <span class="summary-label">Contacts listed</span>
+        <span class="summary-value"><?= number_format($withContacts); ?></span>
+        <span class="summary-footnote">Teams with escalation emails</span>
     </article>
-    <article class="panel metric-card">
-        <span class="metric-label">Active workloads</span>
-        <span class="metric-value"><?= number_format($activeWorkloads); ?></span>
-        <span class="metric-footnote">Departments with assigned tasks</span>
+    <article class="summary-card">
+        <span class="summary-label">Active workloads</span>
+        <span class="summary-value"><?= number_format($activeWorkloads); ?></span>
+        <span class="summary-footnote">Departments with assigned tasks</span>
     </article>
 </section>
 
-<section class="panel form-panel">
-    <h2>Add Department</h2>
-    <p class="panel-subtitle">Create a new department to assign work</p>
-    <?php if ($errors): ?>
-        <div class="alert error">
-            <?= implode('<br>', array_map('sanitize', $errors)); ?>
+<section class="panel classic-panel">
+    <header class="panel-header">
+        <h2>Add department</h2>
+        <span>Create a new division record</span>
+    </header>
+    <form method="post" class="classic-form">
+        <div class="form-row">
+            <div class="form-group">
+                <label for="name">Department name</label>
+                <input type="text" id="name" name="name" required placeholder="e.g. Transportation Affairs">
+            </div>
+            <div class="form-group">
+                <label for="email">Email (optional)</label>
+                <input type="email" id="email" name="email" placeholder="team@example.com">
+            </div>
         </div>
-    <?php endif; ?>
-    <?php if ($success && !$errors): ?>
-        <div class="alert success"><?= sanitize($success); ?></div>
-    <?php endif; ?>
-    <form method="post">
-        <div>
-            <label for="name">Department name</label>
-            <input type="text" id="name" name="name" required>
+        <div class="form-actions">
+            <button type="submit" class="primary-action">Add department</button>
         </div>
-        <div>
-            <label for="email">Email (optional)</label>
-            <input type="email" id="email" name="email" placeholder="team@example.com">
-        </div>
-        <button type="submit">Add department</button>
     </form>
 </section>
 
-<section class="department-grid">
+<section class="panel classic-panel">
+    <header class="panel-header">
+        <h2>Department directory</h2>
+        <span>Task distribution by team</span>
+    </header>
     <?php if (!$departments): ?>
-        <div class="panel empty-note">No departments available. Add one to get started.</div>
+        <div class="empty-note">No departments available. Add one to get started.</div>
     <?php else: ?>
-        <?php $colors = ['blue', 'pink', 'orange', 'green', 'yellow']; ?>
-        <?php foreach ($departments as $index => $department): ?>
-            <?php
-            $totalTasks = (int)$department['tasks_count'];
-            $completed = (int)$department['completed_count'];
-            $inProgress = (int)$department['in_progress_count'];
-            $pending = (int)$department['pending_count'];
-            $overdue = (int)$department['overdue_count'];
-            $rate = $totalTasks > 0 ? round(($completed / $totalTasks) * 100) : 0;
-            $color = $colors[$index % count($colors)];
-            ?>
-            <article class="panel department-card">
-                <div class="department-header">
-                    <div class="department-identity">
-                        <span class="department-dot <?= $color; ?>" aria-hidden="true"></span>
-                        <div>
-                            <h2><?= sanitize($department['name']); ?></h2>
-                            <p><?= $department['email'] ? sanitize($department['email']) : 'No contact listed'; ?></p>
-                        </div>
-                    </div>
-                    <span class="badge neutral"><?= number_format($totalTasks); ?> tasks</span>
-                </div>
-                <div class="department-stats">
-                    <div>
-                        <span><?= number_format($pending); ?></span>
-                        Pending
-                    </div>
-                    <div>
-                        <span><?= number_format($inProgress); ?></span>
-                        In progress
-                    </div>
-                    <div>
-                        <span><?= number_format($completed); ?></span>
-                        Completed
-                    </div>
-                    <div>
-                        <span><?= number_format($overdue); ?></span>
-                        Overdue
-                    </div>
-                </div>
-                <div class="progress-wrap">
-                    <div class="progress-track">
-                        <span class="progress-fill" style="width: <?= $rate; ?>%"></span>
-                    </div>
-                    <span class="progress-label">Completion rate <?= $rate; ?>%</span>
-                </div>
-            </article>
-        <?php endforeach; ?>
+        <div class="table-scroll">
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th scope="col">Department</th>
+                        <th scope="col">Contact</th>
+                        <th scope="col">Pending</th>
+                        <th scope="col">In progress</th>
+                        <th scope="col">Completed</th>
+                        <th scope="col">Overdue</th>
+                        <th scope="col">Completion rate</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($departments as $department): ?>
+                        <?php
+                        $totalTasks = (int)$department['tasks_count'];
+                        $completed = (int)$department['completed_count'];
+                        $inProgress = (int)$department['in_progress_count'];
+                        $pending = (int)$department['pending_count'];
+                        $overdue = (int)$department['overdue_count'];
+                        $rate = $totalTasks > 0 ? round(($completed / max($totalTasks, 1)) * 100) : 0;
+                        ?>
+                        <tr>
+                            <td><?= sanitize($department['name']); ?></td>
+                            <td><?= $department['email'] ? sanitize($department['email']) : '—'; ?></td>
+                            <td><?= number_format($pending); ?></td>
+                            <td><?= number_format($inProgress); ?></td>
+                            <td><?= number_format($completed); ?></td>
+                            <td><?= number_format($overdue); ?></td>
+                            <td>
+                                <div class="progress-inline">
+                                    <span class="progress-bar" style="width: <?= $rate; ?>%"></span>
+                                </div>
+                                <span class="progress-label"><?= $rate; ?>%</span>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
     <?php endif; ?>
 </section>
 <?php include __DIR__ . '/includes/footer.php'; ?>

--- a/includes/db_error.php
+++ b/includes/db_error.php
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Database connection issue</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body class="db-error-page">
+    <section class="db-error-card" role="alert" aria-live="assertive">
+        <header>
+            <h1>We couldn’t reach your MySQL database</h1>
+            <p>The workspace UI is ready, but the data layer still needs to be configured. Follow the steps below and refresh when you’re ready.</p>
+        </header>
+        <?php if (!empty($dbError)): ?>
+            <div class="db-error-details"><?= sanitize($dbError); ?></div>
+        <?php endif; ?>
+        <ol class="db-error-steps">
+            <li><strong>Start MySQL in MAMP</strong> and confirm the server is running.</li>
+            <li><strong>Import <code>database/schema.sql</code></strong> into your MySQL instance (use phpMyAdmin or the MySQL CLI).</li>
+            <li><strong>Update credentials if needed</strong> by editing <code>db.php</code> to match your MAMP username and password.</li>
+            <li>Reload this page once the database is available—the dashboard, tasks, and departments will populate automatically.</li>
+        </ol>
+        <div class="db-error-actions">
+            <a href="database/schema.sql" download>Download schema</a>
+            <a href="README.md" target="_blank" rel="noopener">Open setup guide</a>
+        </div>
+    </section>
+</body>
+</html>

--- a/includes/db_error.php
+++ b/includes/db_error.php
@@ -6,7 +6,7 @@
     <title>Database connection issue</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body class="db-error-page">

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,7 +1,7 @@
             </main>
             <footer class="main-footer">
-                <span>© <?= date('Y'); ?> TaskFlow Workspace</span>
-                <span>Built for cross-department execution</span>
+                <span>© <?= date('Y'); ?> TaskMaster Coordination Suite</span>
+                <span>Keeping departments aligned with classic clarity</span>
             </footer>
         </div>
     </div>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,7 +1,7 @@
             </main>
             <footer class="main-footer">
-                <span>© <?= date('Y'); ?> TaskMaster Coordination Suite</span>
-                <span>Keeping departments aligned with classic clarity</span>
+                <span>© <?= date('Y'); ?> Task Management · Hail Region Municipality</span>
+                <span>Coordinating departments across the region</span>
             </footer>
         </div>
     </div>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,0 +1,11 @@
+            </main>
+            <footer class="main-footer">
+                <span>© <?= date('Y'); ?> TaskFlow Workspace</span>
+                <span>Built for cross-department execution</span>
+            </footer>
+        </div>
+    </div>
+    <div class="toast" role="status" aria-live="polite" aria-atomic="true"></div>
+    <script src="assets/js/app.js"></script>
+</body>
+</html>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3,9 +3,62 @@ if (!ini_get('date.timezone')) {
     date_default_timezone_set('Asia/Riyadh');
 }
 
-function sanitize(string $value = null): string
+function ensure_session(): void
+{
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start();
+    }
+}
+
+function sanitize(?string $value = null): string
 {
     return htmlspecialchars($value ?? '', ENT_QUOTES, 'UTF-8');
+}
+
+function current_user(): ?array
+{
+    ensure_session();
+    return $_SESSION['user'] ?? null;
+}
+
+function require_login(): array
+{
+    $user = current_user();
+    if (!$user) {
+        header('Location: login.php');
+        exit;
+    }
+
+    return $user;
+}
+
+function user_role_label(string $role): string
+{
+    return match (strtolower($role)) {
+        'president' => 'President',
+        'manager' => 'Manager',
+        'employee' => 'Employee',
+        default => ucfirst($role),
+    };
+}
+
+function set_flash(string $key, string $message): void
+{
+    ensure_session();
+    $_SESSION['flash'][$key] = $message;
+}
+
+function get_flash(string $key): ?string
+{
+    ensure_session();
+    if (!isset($_SESSION['flash'][$key])) {
+        return null;
+    }
+
+    $message = $_SESSION['flash'][$key];
+    unset($_SESSION['flash'][$key]);
+
+    return $message;
 }
 
 function analyze_due_status(?string $dueDate, string $status = 'In Progress'): array

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,70 @@
+<?php
+if (!ini_get('date.timezone')) {
+    date_default_timezone_set('Asia/Riyadh');
+}
+
+function sanitize(string $value = null): string
+{
+    return htmlspecialchars($value ?? '', ENT_QUOTES, 'UTF-8');
+}
+
+function analyze_due_status(?string $dueDate, string $status = 'In Progress'): array
+{
+    $today = new DateTimeImmutable('today');
+    if (strtolower($status) === 'completed') {
+        return [
+            'label' => 'Completed',
+            'class' => 'status-complete',
+        ];
+    }
+
+    if (!$dueDate) {
+        return [
+            'label' => 'No due date',
+            'class' => 'status-open',
+        ];
+    }
+
+    try {
+        $due = new DateTimeImmutable($dueDate);
+    } catch (Exception $e) {
+        return [
+            'label' => 'Invalid due date',
+            'class' => 'status-open',
+        ];
+    }
+
+    if ($due < $today) {
+        return [
+            'label' => 'Overdue',
+            'class' => 'status-overdue',
+        ];
+    }
+
+    $diff = $today->diff($due)->days;
+
+    if ($diff <= 3) {
+        return [
+            'label' => 'Due soon',
+            'class' => 'status-warning',
+        ];
+    }
+
+    return [
+        'label' => 'On track',
+        'class' => 'status-open',
+    ];
+}
+
+function format_date(?string $date): string
+{
+    if (!$date) {
+        return '-';
+    }
+
+    try {
+        return (new DateTimeImmutable($date))->format('Y-m-d');
+    } catch (Exception $e) {
+        return $date;
+    }
+}

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,9 +1,21 @@
 <?php
 require_once __DIR__ . '/../includes/functions.php';
+
 $pageTitle = $pageTitle ?? 'Task Management Hub';
 $pageDescription = $pageDescription ?? 'Coordinate departmental workstreams in one place.';
 $workspaceUpdatedAt = date('M j, Y');
-$currentPage = basename($_SERVER['PHP_SELF']);
+$requireAuth = $requireAuth ?? true;
+
+ensure_session();
+$currentUser = current_user();
+
+if ($requireAuth && !$currentUser) {
+    header('Location: login.php');
+    exit;
+}
+
+$userName = $currentUser['name'] ?? 'Guest';
+$userRole = isset($currentUser['role']) ? user_role_label($currentUser['role']) : '';
 ?>
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
@@ -13,47 +25,59 @@ $currentPage = basename($_SERVER['PHP_SELF']);
     <title><?= sanitize($pageTitle); ?></title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/style.css">
 </head>
-<body>
+<body class="app-body">
     <div class="app-shell">
         <aside class="sidebar" aria-label="Primary">
             <div class="sidebar-brand">
-                <span class="brand-icon" aria-hidden="true">TF</span>
+                <span class="brand-icon" aria-hidden="true">TM</span>
                 <div class="brand-copy">
-                    <span class="brand-title">TaskFlow</span>
-                    <span class="brand-subtitle">Department Manager</span>
+                    <span class="brand-title">TaskMaster</span>
+                    <span class="brand-subtitle">City Coordination</span>
                 </div>
             </div>
             <nav class="sidebar-nav" role="navigation">
                 <a href="index.php" class="nav-link <?= $currentPage === 'index.php' ? 'active' : ''; ?>">Dashboard</a>
                 <a href="tasks.php" class="nav-link <?= $currentPage === 'tasks.php' ? 'active' : ''; ?>">Tasks</a>
-                <a href="task_create.php" class="nav-link <?= $currentPage === 'task_create.php' ? 'active' : ''; ?>">New Task</a>
+                <a href="task_create.php" class="nav-link <?= $currentPage === 'task_create.php' ? 'active' : ''; ?>">Create Task</a>
                 <a href="departments.php" class="nav-link <?= $currentPage === 'departments.php' ? 'active' : ''; ?>">Departments</a>
                 <a href="calendar.php" class="nav-link <?= $currentPage === 'calendar.php' ? 'active' : ''; ?>">Calendar</a>
+                <a href="reminders.php" class="nav-link <?= $currentPage === 'reminders.php' ? 'active' : ''; ?>">Reminders</a>
             </nav>
             <div class="sidebar-footer">
-                <strong>Workspace tips</strong><br>
-                Assign priorities, set due dates, and notify departments directly from each task card.
+                <strong>Workspace tips</strong>
+                <p>Assign clear due dates so the calendar and reminders stay aligned.</p>
             </div>
         </aside>
         <div class="main-area">
-            <header class="page-header">
-                <div class="page-titles">
-                    <span class="page-eyebrow">City Coordination Board</span>
+            <header class="topbar">
+                <div class="topbar-brand">
+                    <span class="topbar-eyebrow">City Task Office</span>
+                    <strong>TaskMaster Console</strong>
+                </div>
+                <div class="topbar-actions">
+                    <span class="status-pill" role="status">
+                        <span class="status-dot"></span>
+                        Synced <?= sanitize($workspaceUpdatedAt); ?>
+                    </span>
+                    <div class="user-chip">
+                        <span class="user-name"><?= sanitize($userName); ?></span>
+                        <?php if ($userRole): ?>
+                            <span class="user-role"><?= sanitize($userRole); ?></span>
+                        <?php endif; ?>
+                    </div>
+                    <a href="logout.php" class="ghost-action">Log out</a>
+                    <a href="task_create.php" class="primary-action">New task</a>
+                </div>
+            </header>
+            <div class="page-header">
+                <div class="page-header-copy">
                     <h1><?= sanitize($pageTitle); ?></h1>
                     <?php if (!empty($pageDescription)): ?>
                         <p><?= sanitize($pageDescription); ?></p>
                     <?php endif; ?>
                 </div>
-                <div class="header-actions">
-                    <button type="button" class="ghost-action" title="Invite new collaborators">Share workspace</button>
-                    <span class="status-pill" role="status">
-                        <span class="status-dot"></span>
-                        Synced <?= sanitize($workspaceUpdatedAt); ?>
-                    </span>
-                    <a href="task_create.php" class="primary-action">Create task</a>
-                </div>
-            </header>
+            </div>
             <main class="page-content">

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,58 @@
+<?php
+require_once __DIR__ . '/../includes/functions.php';
+$pageTitle = $pageTitle ?? 'Task Management Hub';
+$pageDescription = $pageDescription ?? 'Coordinate departmental workstreams in one place.';
+$workspaceUpdatedAt = date('M j, Y');
+$currentPage = basename($_SERVER['PHP_SELF']);
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= sanitize($pageTitle); ?></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+    <div class="app-shell">
+        <aside class="sidebar" aria-label="Primary">
+            <div class="sidebar-brand">
+                <span class="brand-icon" aria-hidden="true">TF</span>
+                <div class="brand-copy">
+                    <span class="brand-title">TaskFlow</span>
+                    <span class="brand-subtitle">Department Manager</span>
+                </div>
+            </div>
+            <nav class="sidebar-nav" role="navigation">
+                <a href="index.php" class="nav-link <?= $currentPage === 'index.php' ? 'active' : ''; ?>">Dashboard</a>
+                <a href="tasks.php" class="nav-link <?= $currentPage === 'tasks.php' ? 'active' : ''; ?>">Tasks</a>
+                <a href="departments.php" class="nav-link <?= $currentPage === 'departments.php' ? 'active' : ''; ?>">Departments</a>
+                <span class="nav-link muted" aria-disabled="true">Calendar</span>
+            </nav>
+            <div class="sidebar-footer">
+                <strong>Workspace tips</strong><br>
+                Assign priorities, set due dates, and notify departments directly from each task card.
+            </div>
+        </aside>
+        <div class="main-area">
+            <header class="page-header">
+                <div class="page-titles">
+                    <span class="page-eyebrow">City Coordination Board</span>
+                    <h1><?= sanitize($pageTitle); ?></h1>
+                    <?php if (!empty($pageDescription)): ?>
+                        <p><?= sanitize($pageDescription); ?></p>
+                    <?php endif; ?>
+                </div>
+                <div class="header-actions">
+                    <button type="button" class="ghost-action" title="Invite new collaborators">Share workspace</button>
+                    <span class="status-pill" role="status">
+                        <span class="status-dot"></span>
+                        Synced <?= sanitize($workspaceUpdatedAt); ?>
+                    </span>
+                    <a href="tasks.php" class="primary-action">Create task</a>
+                </div>
+            </header>
+            <main class="page-content">

--- a/includes/header.php
+++ b/includes/header.php
@@ -32,7 +32,7 @@ $userRole = isset($currentUser['role']) ? user_role_label($currentUser['role']) 
     <div class="app-shell">
         <aside class="sidebar" aria-label="Primary">
             <div class="sidebar-brand">
-                <span class="brand-icon" aria-hidden="true">HM</span>
+                <img src="assets/img/hail-region-municipality-logo.svg" alt="Hail Region Municipality" class="brand-logo">
                 <div class="brand-copy">
                     <span class="brand-title">Task Management</span>
                     <span class="brand-subtitle">Hail Region Municipality</span>

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../includes/functions.php';
 
-$pageTitle = $pageTitle ?? 'Task Management Hub';
+$pageTitle = $pageTitle ?? 'Task Management Hail Region Municipality';
 $pageDescription = $pageDescription ?? 'Coordinate departmental workstreams in one place.';
 $workspaceUpdatedAt = date('M j, Y');
 $requireAuth = $requireAuth ?? true;
@@ -32,10 +32,10 @@ $userRole = isset($currentUser['role']) ? user_role_label($currentUser['role']) 
     <div class="app-shell">
         <aside class="sidebar" aria-label="Primary">
             <div class="sidebar-brand">
-                <span class="brand-icon" aria-hidden="true">TM</span>
+                <span class="brand-icon" aria-hidden="true">HM</span>
                 <div class="brand-copy">
-                    <span class="brand-title">TaskMaster</span>
-                    <span class="brand-subtitle">City Coordination</span>
+                    <span class="brand-title">Task Management</span>
+                    <span class="brand-subtitle">Hail Region Municipality</span>
                 </div>
             </div>
             <nav class="sidebar-nav" role="navigation">
@@ -54,8 +54,8 @@ $userRole = isset($currentUser['role']) ? user_role_label($currentUser['role']) 
         <div class="main-area">
             <header class="topbar">
                 <div class="topbar-brand">
-                    <span class="topbar-eyebrow">City Task Office</span>
-                    <strong>TaskMaster Console</strong>
+                    <span class="topbar-eyebrow">Municipality Workspace</span>
+                    <strong>Task Management · Hail Region</strong>
                 </div>
                 <div class="topbar-actions">
                     <span class="status-pill" role="status">

--- a/includes/header.php
+++ b/includes/header.php
@@ -29,8 +29,9 @@ $currentPage = basename($_SERVER['PHP_SELF']);
             <nav class="sidebar-nav" role="navigation">
                 <a href="index.php" class="nav-link <?= $currentPage === 'index.php' ? 'active' : ''; ?>">Dashboard</a>
                 <a href="tasks.php" class="nav-link <?= $currentPage === 'tasks.php' ? 'active' : ''; ?>">Tasks</a>
+                <a href="task_create.php" class="nav-link <?= $currentPage === 'task_create.php' ? 'active' : ''; ?>">New Task</a>
                 <a href="departments.php" class="nav-link <?= $currentPage === 'departments.php' ? 'active' : ''; ?>">Departments</a>
-                <span class="nav-link muted" aria-disabled="true">Calendar</span>
+                <a href="calendar.php" class="nav-link <?= $currentPage === 'calendar.php' ? 'active' : ''; ?>">Calendar</a>
             </nav>
             <div class="sidebar-footer">
                 <strong>Workspace tips</strong><br>
@@ -52,7 +53,7 @@ $currentPage = basename($_SERVER['PHP_SELF']);
                         <span class="status-dot"></span>
                         Synced <?= sanitize($workspaceUpdatedAt); ?>
                     </span>
-                    <a href="tasks.php" class="primary-action">Create task</a>
+                    <a href="task_create.php" class="primary-action">Create task</a>
                 </div>
             </header>
             <main class="page-content">

--- a/index.php
+++ b/index.php
@@ -1,0 +1,145 @@
+<?php
+$pageTitle = 'Dashboard';
+$pageDescription = 'Overview of all departments and task assignments.';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$totalTasks = (int)$pdo->query('SELECT COUNT(*) FROM tasks')->fetchColumn();
+$inProgressTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status = 'In Progress'")->fetchColumn();
+$completedTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status = 'Completed'")->fetchColumn();
+$overdueTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status != 'Completed' AND due_date IS NOT NULL AND due_date < CURDATE()")
+    ->fetchColumn();
+$departmentCount = (int)$pdo->query('SELECT COUNT(*) FROM departments')->fetchColumn();
+
+$upcomingTasks = $pdo->query("SELECT t.id, t.title, t.due_date, d.name AS department_name, t.priority\n    FROM tasks t\n    JOIN departments d ON d.id = t.department_id\n    WHERE t.status != 'Completed' AND t.due_date IS NOT NULL AND t.due_date >= CURDATE()\n    ORDER BY t.due_date ASC\n    LIMIT 6")->fetchAll();
+
+$recentReminders = $pdo->query("SELECT n.message, DATE_FORMAT(n.created_at, '%b %e, %Y %H:%i') AS created_at,\n    t.title AS task_title\n    FROM notifications n\n    JOIN tasks t ON t.id = n.task_id\n    ORDER BY n.created_at DESC\n    LIMIT 5")->fetchAll();
+
+$departmentPerformance = $pdo->query("SELECT d.name,\n    COUNT(t.id) AS total_tasks,\n    SUM(CASE WHEN t.status = 'Completed' THEN 1 ELSE 0 END) AS completed_tasks,\n    SUM(CASE WHEN t.status = 'In Progress' THEN 1 ELSE 0 END) AS in_progress_tasks,\n    SUM(CASE WHEN t.due_date IS NOT NULL AND t.due_date < CURDATE() AND t.status != 'Completed' THEN 1 ELSE 0 END) AS overdue_tasks\n    FROM departments d\n    LEFT JOIN tasks t ON t.department_id = d.id\n    GROUP BY d.id\n    ORDER BY d.name ASC\n    LIMIT 6")->fetchAll();
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="metrics-grid">
+    <article class="panel metric-card">
+        <span class="metric-label">Total Tasks</span>
+        <span class="metric-value"><?= number_format($totalTasks); ?></span>
+        <span class="metric-footnote">Across all departments</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">In Progress</span>
+        <span class="metric-value"><?= number_format($inProgressTasks); ?></span>
+        <span class="metric-footnote"><?= number_format($completedTasks); ?> completed</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">Overdue</span>
+        <span class="metric-value"><?= number_format($overdueTasks); ?></span>
+        <span class="metric-footnote">Requires attention</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">Departments</span>
+        <span class="metric-value"><?= number_format($departmentCount); ?></span>
+        <span class="metric-footnote">Active divisions</span>
+    </article>
+</section>
+
+<?php if ($overdueTasks > 0): ?>
+    <section class="panel alert-card">
+        <div>
+            <h2>Overdue tasks need attention</h2>
+            <p><?= number_format($overdueTasks); ?> assignments have slipped beyond their due dates.</p>
+        </div>
+        <a href="tasks.php" class="link-button">Review tasks</a>
+    </section>
+<?php endif; ?>
+
+<section class="split-grid">
+    <article class="panel">
+        <div class="panel-header">
+            <h2>Upcoming Deadlines</h2>
+            <span class="panel-subtitle">Next <?= $upcomingTasks ? count($upcomingTasks) : 0; ?> due dates</span>
+        </div>
+        <?php if (!$upcomingTasks): ?>
+            <div class="empty-note">No upcoming due dates found.</div>
+        <?php else: ?>
+            <ul class="deadline-list">
+                <?php foreach ($upcomingTasks as $task): ?>
+                    <?php
+                    $priorityClass = strtolower($task['priority']);
+                    if (!in_array($priorityClass, ['high', 'medium', 'low'], true)) {
+                        $priorityClass = 'medium';
+                    }
+                    ?>
+                    <li class="deadline-item">
+                        <div>
+                            <strong><?= sanitize($task['title']); ?></strong>
+                            <div class="task-meta">
+                                <span><?= sanitize($task['department_name']); ?></span>
+                                <span class="priority-badge <?= $priorityClass; ?>"><?= sanitize($task['priority']); ?></span>
+                            </div>
+                        </div>
+                        <span class="badge warning">Due <?= sanitize(format_date($task['due_date'])); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </article>
+    <article class="panel">
+        <div class="panel-header">
+            <h2>Department Performance</h2>
+            <span class="panel-subtitle">Completion rate</span>
+        </div>
+        <?php if (!$departmentPerformance): ?>
+            <div class="empty-note">Add departments to track performance.</div>
+        <?php else: ?>
+            <ul class="performance-list">
+                <?php foreach ($departmentPerformance as $department): ?>
+                    <?php
+                    $total = (int)$department['total_tasks'];
+                    $completed = (int)$department['completed_tasks'];
+                    $inProgress = (int)$department['in_progress_tasks'];
+                    $overdue = (int)$department['overdue_tasks'];
+                    $rate = $total > 0 ? round(($completed / $total) * 100) : 0;
+                    ?>
+                    <li class="performance-row">
+                        <header>
+                            <strong><?= sanitize($department['name']); ?></strong>
+                            <span class="badge neutral"><?= $rate; ?>% complete</span>
+                        </header>
+                        <div class="progress-track">
+                            <span class="progress-fill" style="width: <?= $rate; ?>%"></span>
+                        </div>
+                        <div class="progress-meta">
+                            <span><?= number_format($completed); ?> completed · <?= number_format($inProgress); ?> in progress</span>
+                            <span><?= number_format($overdue); ?> overdue</span>
+                        </div>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </article>
+</section>
+
+<section class="panel">
+    <div class="panel-header">
+        <h2>Reminder Activity</h2>
+        <span class="panel-subtitle">Latest alerts to departments</span>
+    </div>
+    <?php if (!$recentReminders): ?>
+        <div class="empty-note">No reminders have been issued yet.</div>
+    <?php else: ?>
+        <ul class="activity-list">
+            <?php foreach ($recentReminders as $reminder): ?>
+                <li class="activity-item">
+                    <div>
+                        <strong><?= sanitize($reminder['task_title']); ?></strong>
+                        <div class="task-meta">
+                            <span><?= sanitize($reminder['message']); ?></span>
+                        </div>
+                    </div>
+                    <span class="badge neutral"><?= sanitize($reminder['created_at']); ?></span>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    <?php endif; ?>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/index.php
+++ b/index.php
@@ -1,8 +1,9 @@
 <?php
 $pageTitle = 'Dashboard';
-$pageDescription = 'Overview of all departments and task assignments.';
-require_once __DIR__ . '/db.php';
+$pageDescription = 'A classic control room for city task coordination.';
 require_once __DIR__ . '/includes/functions.php';
+require_login();
+require_once __DIR__ . '/db.php';
 
 $totalTasks = (int)$pdo->query('SELECT COUNT(*) FROM tasks')->fetchColumn();
 $inProgressTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status = 'In Progress'")->fetchColumn();
@@ -11,135 +12,145 @@ $overdueTasks = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status != 'Co
     ->fetchColumn();
 $departmentCount = (int)$pdo->query('SELECT COUNT(*) FROM departments')->fetchColumn();
 
-$upcomingTasks = $pdo->query("SELECT t.id, t.title, t.due_date, d.name AS department_name, t.priority\n    FROM tasks t\n    JOIN departments d ON d.id = t.department_id\n    WHERE t.status != 'Completed' AND t.due_date IS NOT NULL AND t.due_date >= CURDATE()\n    ORDER BY t.due_date ASC\n    LIMIT 6")->fetchAll();
+$upcomingTasks = $pdo->query("SELECT t.id, t.title, t.due_date, d.name AS department_name, t.priority\n    FROM tasks t\n    JOIN departments d ON d.id = t.department_id\n    WHERE t.status != 'Completed' AND t.due_date IS NOT NULL AND t.due_date >= CURDATE()\n    ORDER BY t.due_date ASC\n    LIMIT 8")->fetchAll();
 
-$recentReminders = $pdo->query("SELECT n.message, DATE_FORMAT(n.created_at, '%b %e, %Y %H:%i') AS created_at,\n    t.title AS task_title\n    FROM notifications n\n    JOIN tasks t ON t.id = n.task_id\n    ORDER BY n.created_at DESC\n    LIMIT 5")->fetchAll();
+$recentReminders = $pdo->query("SELECT n.message, DATE_FORMAT(n.created_at, '%b %e, %Y %H:%i') AS created_at,\n    t.title AS task_title\n    FROM notifications n\n    JOIN tasks t ON t.id = n.task_id\n    ORDER BY n.created_at DESC\n    LIMIT 6")->fetchAll();
 
-$departmentPerformance = $pdo->query("SELECT d.name,\n    COUNT(t.id) AS total_tasks,\n    SUM(CASE WHEN t.status = 'Completed' THEN 1 ELSE 0 END) AS completed_tasks,\n    SUM(CASE WHEN t.status = 'In Progress' THEN 1 ELSE 0 END) AS in_progress_tasks,\n    SUM(CASE WHEN t.due_date IS NOT NULL AND t.due_date < CURDATE() AND t.status != 'Completed' THEN 1 ELSE 0 END) AS overdue_tasks\n    FROM departments d\n    LEFT JOIN tasks t ON t.department_id = d.id\n    GROUP BY d.id\n    ORDER BY d.name ASC\n    LIMIT 6")->fetchAll();
+$departmentPerformance = $pdo->query("SELECT d.name,\n    COUNT(t.id) AS total_tasks,\n    SUM(CASE WHEN t.status = 'Completed' THEN 1 ELSE 0 END) AS completed_tasks,\n    SUM(CASE WHEN t.status = 'In Progress' THEN 1 ELSE 0 END) AS in_progress_tasks,\n    SUM(CASE WHEN t.due_date IS NOT NULL AND t.due_date < CURDATE() AND t.status != 'Completed' THEN 1 ELSE 0 END) AS overdue_tasks\n    FROM departments d\n    LEFT JOIN tasks t ON t.department_id = d.id\n    GROUP BY d.id\n    ORDER BY d.name ASC")->fetchAll();
 
 include __DIR__ . '/includes/header.php';
 ?>
-<section class="metrics-grid">
-    <article class="panel metric-card">
-        <span class="metric-label">Total Tasks</span>
-        <span class="metric-value"><?= number_format($totalTasks); ?></span>
-        <span class="metric-footnote">Across all departments</span>
+<section class="summary-cards">
+    <article class="summary-card">
+        <span class="summary-label">Total tasks</span>
+        <span class="summary-value"><?= number_format($totalTasks); ?></span>
+        <span class="summary-footnote">Across <?= number_format($departmentCount); ?> departments</span>
     </article>
-    <article class="panel metric-card">
-        <span class="metric-label">In Progress</span>
-        <span class="metric-value"><?= number_format($inProgressTasks); ?></span>
-        <span class="metric-footnote"><?= number_format($completedTasks); ?> completed</span>
+    <article class="summary-card">
+        <span class="summary-label">In progress</span>
+        <span class="summary-value"><?= number_format($inProgressTasks); ?></span>
+        <span class="summary-footnote"><?= number_format($completedTasks); ?> completed</span>
     </article>
-    <article class="panel metric-card">
-        <span class="metric-label">Overdue</span>
-        <span class="metric-value"><?= number_format($overdueTasks); ?></span>
-        <span class="metric-footnote">Requires attention</span>
+    <article class="summary-card">
+        <span class="summary-label">Overdue items</span>
+        <span class="summary-value"><?= number_format($overdueTasks); ?></span>
+        <span class="summary-footnote">Needing follow-up</span>
     </article>
-    <article class="panel metric-card">
-        <span class="metric-label">Departments</span>
-        <span class="metric-value"><?= number_format($departmentCount); ?></span>
-        <span class="metric-footnote">Active divisions</span>
+    <article class="summary-card">
+        <span class="summary-label">Departments tracked</span>
+        <span class="summary-value"><?= number_format($departmentCount); ?></span>
+        <span class="summary-footnote">Active city divisions</span>
     </article>
 </section>
 
-<?php if ($overdueTasks > 0): ?>
-    <section class="panel alert-card">
-        <div>
-            <h2>Overdue tasks need attention</h2>
-            <p><?= number_format($overdueTasks); ?> assignments have slipped beyond their due dates.</p>
-        </div>
-        <a href="tasks.php" class="link-button">Review tasks</a>
-    </section>
-<?php endif; ?>
-
-<section class="split-grid">
-    <article class="panel">
-        <div class="panel-header">
-            <h2>Upcoming Deadlines</h2>
-            <span class="panel-subtitle">Next <?= $upcomingTasks ? count($upcomingTasks) : 0; ?> due dates</span>
-        </div>
-        <?php if (!$upcomingTasks): ?>
-            <div class="empty-note">No upcoming due dates found.</div>
-        <?php else: ?>
-            <ul class="deadline-list">
-                <?php foreach ($upcomingTasks as $task): ?>
-                    <?php
-                    $priorityClass = strtolower($task['priority']);
-                    if (!in_array($priorityClass, ['high', 'medium', 'low'], true)) {
-                        $priorityClass = 'medium';
-                    }
-                    ?>
-                    <li class="deadline-item">
-                        <div>
-                            <strong><?= sanitize($task['title']); ?></strong>
-                            <div class="task-meta">
-                                <span><?= sanitize($task['department_name']); ?></span>
-                                <span class="priority-badge <?= $priorityClass; ?>"><?= sanitize($task['priority']); ?></span>
+<div class="content-columns">
+    <div class="column-main">
+        <section class="panel classic-panel">
+            <header class="panel-header">
+                <h2>Upcoming deadlines</h2>
+                <span><?= $upcomingTasks ? count($upcomingTasks) : 0; ?> items scheduled</span>
+            </header>
+            <?php if (!$upcomingTasks): ?>
+                <div class="empty-note">No upcoming due dates on the books.</div>
+            <?php else: ?>
+                <ul class="stacked-list">
+                    <?php foreach ($upcomingTasks as $task): ?>
+                        <?php
+                        $priorityClass = strtolower($task['priority']);
+                        if (!in_array($priorityClass, ['high', 'medium', 'low'], true)) {
+                            $priorityClass = 'medium';
+                        }
+                        ?>
+                        <li class="stacked-item">
+                            <div class="item-main">
+                                <strong><?= sanitize($task['title']); ?></strong>
+                                <span class="item-sub"><?= sanitize($task['department_name']); ?></span>
                             </div>
-                        </div>
-                        <span class="badge warning">Due <?= sanitize(format_date($task['due_date'])); ?></span>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-        <?php endif; ?>
-    </article>
-    <article class="panel">
-        <div class="panel-header">
-            <h2>Department Performance</h2>
-            <span class="panel-subtitle">Completion rate</span>
-        </div>
-        <?php if (!$departmentPerformance): ?>
-            <div class="empty-note">Add departments to track performance.</div>
-        <?php else: ?>
-            <ul class="performance-list">
-                <?php foreach ($departmentPerformance as $department): ?>
-                    <?php
-                    $total = (int)$department['total_tasks'];
-                    $completed = (int)$department['completed_tasks'];
-                    $inProgress = (int)$department['in_progress_tasks'];
-                    $overdue = (int)$department['overdue_tasks'];
-                    $rate = $total > 0 ? round(($completed / $total) * 100) : 0;
-                    ?>
-                    <li class="performance-row">
-                        <header>
-                            <strong><?= sanitize($department['name']); ?></strong>
-                            <span class="badge neutral"><?= $rate; ?>% complete</span>
-                        </header>
-                        <div class="progress-track">
-                            <span class="progress-fill" style="width: <?= $rate; ?>%"></span>
-                        </div>
-                        <div class="progress-meta">
-                            <span><?= number_format($completed); ?> completed · <?= number_format($inProgress); ?> in progress</span>
-                            <span><?= number_format($overdue); ?> overdue</span>
-                        </div>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-        <?php endif; ?>
-    </article>
-</section>
+                            <div class="item-meta">
+                                <span class="priority-chip <?= $priorityClass; ?>"><?= sanitize($task['priority']); ?></span>
+                                <span class="due-chip">Due <?= sanitize(format_date($task['due_date'])); ?></span>
+                            </div>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+        </section>
 
-<section class="panel">
-    <div class="panel-header">
-        <h2>Reminder Activity</h2>
-        <span class="panel-subtitle">Latest alerts to departments</span>
+        <section class="panel classic-panel">
+            <header class="panel-header">
+                <h2>Department performance</h2>
+                <span>Completion by division</span>
+            </header>
+            <?php if (!$departmentPerformance): ?>
+                <div class="empty-note">Add departments to begin tracking throughput.</div>
+            <?php else: ?>
+                <div class="table-scroll">
+                    <table class="data-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">Department</th>
+                                <th scope="col">Completed</th>
+                                <th scope="col">In progress</th>
+                                <th scope="col">Overdue</th>
+                                <th scope="col">Completion rate</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($departmentPerformance as $department): ?>
+                                <?php
+                                $total = (int)$department['total_tasks'];
+                                $completed = (int)$department['completed_tasks'];
+                                $inProgress = (int)$department['in_progress_tasks'];
+                                $overdue = (int)$department['overdue_tasks'];
+                                $rate = $total > 0 ? round(($completed / max($total, 1)) * 100) : 0;
+                                ?>
+                                <tr>
+                                    <td><?= sanitize($department['name']); ?></td>
+                                    <td><?= number_format($completed); ?></td>
+                                    <td><?= number_format($inProgress); ?></td>
+                                    <td><?= number_format($overdue); ?></td>
+                                    <td>
+                                        <div class="progress-inline">
+                                            <span class="progress-bar" style="width: <?= $rate; ?>%"></span>
+                                        </div>
+                                        <span class="progress-label"><?= $rate; ?>%</span>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            <?php endif; ?>
+        </section>
     </div>
-    <?php if (!$recentReminders): ?>
-        <div class="empty-note">No reminders have been issued yet.</div>
-    <?php else: ?>
-        <ul class="activity-list">
-            <?php foreach ($recentReminders as $reminder): ?>
-                <li class="activity-item">
-                    <div>
-                        <strong><?= sanitize($reminder['task_title']); ?></strong>
-                        <div class="task-meta">
+    <aside class="column-side">
+        <?php if ($overdueTasks > 0): ?>
+            <section class="panel attention-panel">
+                <h2>Overdue follow-up</h2>
+                <p><?= number_format($overdueTasks); ?> assignments need intervention. Review the task list to re-align owners and deadlines.</p>
+                <a href="tasks.php" class="ghost-action">Go to tasks</a>
+            </section>
+        <?php endif; ?>
+
+        <section class="panel classic-panel">
+            <header class="panel-header">
+                <h2>Reminder activity</h2>
+                <span>Recent notices</span>
+            </header>
+            <?php if (!$recentReminders): ?>
+                <div class="empty-note">No reminders have been issued yet.</div>
+            <?php else: ?>
+                <ul class="activity-list">
+                    <?php foreach ($recentReminders as $reminder): ?>
+                        <li class="activity-item">
+                            <strong><?= sanitize($reminder['task_title']); ?></strong>
                             <span><?= sanitize($reminder['message']); ?></span>
-                        </div>
-                    </div>
-                    <span class="badge neutral"><?= sanitize($reminder['created_at']); ?></span>
-                </li>
-            <?php endforeach; ?>
-        </ul>
-    <?php endif; ?>
-</section>
+                            <time><?= sanitize($reminder['created_at']); ?></time>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+        </section>
+    </aside>
+</div>
 <?php include __DIR__ . '/includes/footer.php'; ?>

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 $pageTitle = 'Dashboard';
-$pageDescription = 'A classic control room for city task coordination.';
+$pageDescription = 'Monitor cross-department tasks, upcoming deadlines, and reminder activity.';
 require_once __DIR__ . '/includes/functions.php';
 require_login();
 require_once __DIR__ . '/db.php';
@@ -20,26 +20,55 @@ $departmentPerformance = $pdo->query("SELECT d.name,\n    COUNT(t.id) AS total_t
 
 include __DIR__ . '/includes/header.php';
 ?>
+<?php if ($upcomingTasks): ?>
+    <section class="page-alert deadline-alert" role="alert">
+        <div class="alert-icon" aria-hidden="true">⚠️</div>
+        <div class="alert-body">
+            <h2>You have <?= count($upcomingTasks); ?> task<?= count($upcomingTasks) === 1 ? '' : 's'; ?> with upcoming deadlines</h2>
+            <ul class="alert-list">
+                <?php foreach ($upcomingTasks as $task): ?>
+                    <li>
+                        <span class="alert-task-title"><?= sanitize($task['title']); ?></span>
+                        <span class="alert-meta"><?= sanitize($task['department_name']); ?> · Due <?= sanitize(format_date($task['due_date'])); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    </section>
+<?php endif; ?>
+
 <section class="summary-cards">
     <article class="summary-card">
-        <span class="summary-label">Total tasks</span>
-        <span class="summary-value"><?= number_format($totalTasks); ?></span>
-        <span class="summary-footnote">Across <?= number_format($departmentCount); ?> departments</span>
+        <span class="summary-icon" aria-hidden="true">🏢</span>
+        <div>
+            <span class="summary-label">Departments</span>
+            <span class="summary-value"><?= number_format($departmentCount); ?></span>
+        </div>
+        <span class="summary-footnote">Actively coordinated</span>
     </article>
     <article class="summary-card">
-        <span class="summary-label">In progress</span>
-        <span class="summary-value"><?= number_format($inProgressTasks); ?></span>
+        <span class="summary-icon" aria-hidden="true">🗂️</span>
+        <div>
+            <span class="summary-label">Total tasks</span>
+            <span class="summary-value"><?= number_format($totalTasks); ?></span>
+        </div>
         <span class="summary-footnote"><?= number_format($completedTasks); ?> completed</span>
     </article>
     <article class="summary-card">
-        <span class="summary-label">Overdue items</span>
-        <span class="summary-value"><?= number_format($overdueTasks); ?></span>
-        <span class="summary-footnote">Needing follow-up</span>
+        <span class="summary-icon" aria-hidden="true">🚀</span>
+        <div>
+            <span class="summary-label">In progress</span>
+            <span class="summary-value"><?= number_format($inProgressTasks); ?></span>
+        </div>
+        <span class="summary-footnote">Tracked this week</span>
     </article>
     <article class="summary-card">
-        <span class="summary-label">Departments tracked</span>
-        <span class="summary-value"><?= number_format($departmentCount); ?></span>
-        <span class="summary-footnote">Active city divisions</span>
+        <span class="summary-icon" aria-hidden="true">⏰</span>
+        <div>
+            <span class="summary-label">Overdue</span>
+            <span class="summary-value"><?= number_format($overdueTasks); ?></span>
+        </div>
+        <span class="summary-footnote">Needs attention</span>
     </article>
 </section>
 
@@ -48,7 +77,7 @@ include __DIR__ . '/includes/header.php';
         <section class="panel classic-panel">
             <header class="panel-header">
                 <h2>Upcoming deadlines</h2>
-                <span><?= $upcomingTasks ? count($upcomingTasks) : 0; ?> items scheduled</span>
+                <span><?= $upcomingTasks ? count($upcomingTasks) : 0; ?> scheduled</span>
             </header>
             <?php if (!$upcomingTasks): ?>
                 <div class="empty-note">No upcoming due dates on the books.</div>
@@ -124,18 +153,10 @@ include __DIR__ . '/includes/header.php';
         </section>
     </div>
     <aside class="column-side">
-        <?php if ($overdueTasks > 0): ?>
-            <section class="panel attention-panel">
-                <h2>Overdue follow-up</h2>
-                <p><?= number_format($overdueTasks); ?> assignments need intervention. Review the task list to re-align owners and deadlines.</p>
-                <a href="tasks.php" class="ghost-action">Go to tasks</a>
-            </section>
-        <?php endif; ?>
-
         <section class="panel classic-panel">
             <header class="panel-header">
                 <h2>Reminder activity</h2>
-                <span>Recent notices</span>
+                <span>Latest notices</span>
             </header>
             <?php if (!$recentReminders): ?>
                 <div class="empty-note">No reminders have been issued yet.</div>
@@ -151,6 +172,14 @@ include __DIR__ . '/includes/header.php';
                 </ul>
             <?php endif; ?>
         </section>
+
+        <?php if ($overdueTasks > 0): ?>
+            <section class="panel attention-panel">
+                <h2>Overdue follow-up</h2>
+                <p><?= number_format($overdueTasks); ?> assignments need intervention. Review the task list to re-align owners and deadlines.</p>
+                <a href="tasks.php" class="ghost-action">Review tasks</a>
+            </section>
+        <?php endif; ?>
     </aside>
 </div>
 <?php include __DIR__ . '/includes/footer.php'; ?>

--- a/index.php
+++ b/index.php
@@ -153,7 +153,7 @@ include __DIR__ . '/includes/header.php';
         </section>
     </div>
     <aside class="column-side">
-        <section class="panel classic-panel">
+        <section class="panel classic-panel reminder-panel">
             <header class="panel-header">
                 <h2>Reminder activity</h2>
                 <span>Latest notices</span>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,87 @@
+<?php
+require_once __DIR__ . '/includes/functions.php';
+ensure_session();
+
+if (current_user()) {
+    header('Location: index.php');
+    exit;
+}
+
+require_once __DIR__ . '/db.php';
+
+$errors = [];
+$email = trim($_POST['email'] ?? '');
+$password = $_POST['password'] ?? '';
+$registeredMessage = get_flash('registered');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Enter a valid email address.';
+    }
+
+    if ($password === '') {
+        $errors[] = 'Enter your password.';
+    }
+
+    if (!$errors) {
+        $stmt = $pdo->prepare('SELECT id, name, email, password_hash, role FROM users WHERE email = :email LIMIT 1');
+        $stmt->execute(['email' => $email]);
+        $user = $stmt->fetch();
+
+        if (!$user || !password_verify($password, $user['password_hash'])) {
+            $errors[] = 'Invalid email or password.';
+        } else {
+            $_SESSION['user'] = [
+                'id' => (int)$user['id'],
+                'name' => $user['name'],
+                'email' => $user['email'],
+                'role' => $user['role'],
+            ];
+
+            header('Location: index.php');
+            exit;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sign in · TaskMaster</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body class="auth-page">
+    <div class="auth-card">
+        <h1>Sign in</h1>
+        <p>Access the TaskMaster console.</p>
+        <?php if ($registeredMessage): ?>
+            <div class="alert success"><?= sanitize($registeredMessage); ?></div>
+        <?php endif; ?>
+        <?php if ($errors): ?>
+            <div class="alert error"><?= implode('<br>', array_map('sanitize', $errors)); ?></div>
+        <?php endif; ?>
+        <form method="post" class="classic-form" novalidate>
+            <div class="form-group">
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" value="<?= sanitize($email); ?>" required>
+            </div>
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" required>
+            </div>
+            <div class="form-actions">
+                <button type="submit" class="primary-action">Sign in</button>
+            </div>
+        </form>
+        <div class="auth-actions">
+            <span class="auth-note">Need an account?</span>
+            <a href="register.php" class="ghost-action">Create one</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -49,16 +49,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sign in · TaskMaster</title>
+    <title>Sign in · Task Management Hail Region Municipality</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body class="auth-page">
-    <div class="auth-card">
-        <h1>Sign in</h1>
-        <p>Access the TaskMaster console.</p>
+    <div class="auth-wrapper">
+        <section class="auth-intro">
+            <span class="auth-badge">Task Management · Hail Region Municipality</span>
+            <h1>Streamline your department tasks</h1>
+            <p>Assign work, track deadlines, and collaborate smoothly across the Hail Region teams.</p>
+            <ul>
+                <li>Real-time deadline notifications</li>
+                <li>Cross-department collaboration</li>
+                <li>Structured approval workflows</li>
+            </ul>
+        </section>
+        <div class="auth-card">
+            <h2>Welcome back</h2>
+            <p>Sign in to continue coordinating tasks.</p>
         <?php if ($registeredMessage): ?>
             <div class="alert success"><?= sanitize($registeredMessage); ?></div>
         <?php endif; ?>
@@ -81,6 +92,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <div class="auth-actions">
             <span class="auth-note">Need an account?</span>
             <a href="register.php" class="ghost-action">Create one</a>
+        </div>
         </div>
     </div>
 </body>

--- a/login.php
+++ b/login.php
@@ -68,6 +68,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             </ul>
         </section>
         <div class="auth-card">
+            <div class="auth-logo">
+                <img src="assets/img/hail-region-municipality-logo.svg" alt="Hail Region Municipality logo">
+            </div>
             <h2>Welcome back</h2>
             <p>Sign in to continue coordinating tasks.</p>
         <?php if ($registeredMessage): ?>

--- a/login.php
+++ b/login.php
@@ -56,46 +56,49 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body class="auth-page">
-    <div class="auth-wrapper">
-        <section class="auth-intro">
-            <span class="auth-badge">Task Management · Hail Region Municipality</span>
-            <h1>Streamline your department tasks</h1>
-            <p>Assign work, track deadlines, and collaborate smoothly across the Hail Region teams.</p>
-            <ul>
-                <li>Real-time deadline notifications</li>
-                <li>Cross-department collaboration</li>
-                <li>Structured approval workflows</li>
-            </ul>
+    <div class="auth-shell">
+        <section class="auth-illustration">
+            <div class="auth-illustration-inner">
+                <img class="auth-masthead-logo" src="assets/img/hail-region-municipality-logo.svg" alt="Task Management Hail Region Municipality">
+                <h1>Task Management · Hail Region Municipality</h1>
+                <p>Coordinate president, manager, and employee workflows in one classic command center.</p>
+            </div>
         </section>
-        <div class="auth-card">
-            <div class="auth-logo">
-                <img src="assets/img/hail-region-municipality-logo.svg" alt="Hail Region Municipality logo">
+        <div class="auth-panel">
+            <header class="auth-panel-header">
+                <div class="auth-logo">
+                    <img src="assets/img/hail-region-municipality-logo.svg" alt="Hail Region Municipality logo">
+                </div>
+                <div>
+                    <h2>Sign in to continue</h2>
+                    <p>Access the Task Management Hail Region Municipality workspace.</p>
+                </div>
+            </header>
+            <div class="auth-panel-body">
+                <?php if ($registeredMessage): ?>
+                    <div class="alert success"><?= sanitize($registeredMessage); ?></div>
+                <?php endif; ?>
+                <?php if ($errors): ?>
+                    <div class="alert error"><?= implode('<br>', array_map('sanitize', $errors)); ?></div>
+                <?php endif; ?>
+                <form method="post" class="classic-form" novalidate>
+                    <div class="form-group">
+                        <label for="email">Email</label>
+                        <input type="email" id="email" name="email" value="<?= sanitize($email); ?>" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="password">Password</label>
+                        <input type="password" id="password" name="password" required>
+                    </div>
+                    <div class="form-actions">
+                        <button type="submit" class="primary-action">Sign in</button>
+                    </div>
+                </form>
             </div>
-            <h2>Welcome back</h2>
-            <p>Sign in to continue coordinating tasks.</p>
-        <?php if ($registeredMessage): ?>
-            <div class="alert success"><?= sanitize($registeredMessage); ?></div>
-        <?php endif; ?>
-        <?php if ($errors): ?>
-            <div class="alert error"><?= implode('<br>', array_map('sanitize', $errors)); ?></div>
-        <?php endif; ?>
-        <form method="post" class="classic-form" novalidate>
-            <div class="form-group">
-                <label for="email">Email</label>
-                <input type="email" id="email" name="email" value="<?= sanitize($email); ?>" required>
+            <div class="auth-actions">
+                <span class="auth-note">Need an account?</span>
+                <a href="register.php" class="ghost-action">Create one</a>
             </div>
-            <div class="form-group">
-                <label for="password">Password</label>
-                <input type="password" id="password" name="password" required>
-            </div>
-            <div class="form-actions">
-                <button type="submit" class="primary-action">Sign in</button>
-            </div>
-        </form>
-        <div class="auth-actions">
-            <span class="auth-note">Need an account?</span>
-            <a href="register.php" class="ghost-action">Create one</a>
-        </div>
         </div>
     </div>
 </body>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,9 @@
+<?php
+require_once __DIR__ . '/includes/functions.php';
+ensure_session();
+
+unset($_SESSION['user']);
+session_regenerate_id(true);
+
+header('Location: login.php');
+exit;

--- a/register.php
+++ b/register.php
@@ -73,53 +73,65 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Create account · TaskMaster</title>
+    <title>Create account · Task Management Hail Region Municipality</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body class="auth-page">
-    <div class="auth-card">
-        <h1>Create account</h1>
-        <p>Join the TaskMaster coordination hub.</p>
-        <?php if ($errors): ?>
-            <div class="alert error"><?= implode('<br>', array_map('sanitize', $errors)); ?></div>
-        <?php endif; ?>
-        <form method="post" class="classic-form" novalidate>
-            <div class="form-group">
-                <label for="name">Full name</label>
-                <input type="text" id="name" name="name" value="<?= sanitize($formData['name']); ?>" required>
-            </div>
-            <div class="form-group">
-                <label for="email">Email</label>
-                <input type="email" id="email" name="email" value="<?= sanitize($formData['email']); ?>" required>
-            </div>
-            <div class="form-row">
+    <div class="auth-wrapper">
+        <section class="auth-intro">
+            <span class="auth-badge">Task Management · Hail Region Municipality</span>
+            <h1>Create a collaborative workspace</h1>
+            <p>Give every department visibility from planning through delivery with shared milestones.</p>
+            <ul>
+                <li>Role-based access for presidents, managers, and employees</li>
+                <li>Deadline-driven calendar and reminder center</li>
+                <li>Unified progress and completion reporting</li>
+            </ul>
+        </section>
+        <div class="auth-card">
+            <h2>Register</h2>
+            <p>Invite your team to manage tasks together.</p>
+            <?php if ($errors): ?>
+                <div class="alert error"><?= implode('<br>', array_map('sanitize', $errors)); ?></div>
+            <?php endif; ?>
+            <form method="post" class="classic-form" novalidate>
                 <div class="form-group">
-                    <label for="password">Password</label>
-                    <input type="password" id="password" name="password" required>
+                    <label for="name">Full name</label>
+                    <input type="text" id="name" name="name" value="<?= sanitize($formData['name']); ?>" required>
                 </div>
                 <div class="form-group">
-                    <label for="confirm_password">Confirm password</label>
-                    <input type="password" id="confirm_password" name="confirm_password" required>
+                    <label for="email">Email</label>
+                    <input type="email" id="email" name="email" value="<?= sanitize($formData['email']); ?>" required>
                 </div>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="password">Password</label>
+                        <input type="password" id="password" name="password" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="confirm_password">Confirm password</label>
+                        <input type="password" id="confirm_password" name="confirm_password" required>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="role">Select your role</label>
+                    <select id="role" name="role">
+                        <?php foreach ($roleOptions as $value => $label): ?>
+                            <option value="<?= $value; ?>" <?= $formData['role'] === $value ? 'selected' : ''; ?>><?= $label; ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="form-actions">
+                    <button type="submit" class="primary-action">Create account</button>
+                </div>
+            </form>
+            <div class="auth-actions">
+                <span class="auth-note">Already registered?</span>
+                <a href="login.php" class="ghost-action">Sign in</a>
             </div>
-            <div class="form-group">
-                <label for="role">Role</label>
-                <select id="role" name="role">
-                    <?php foreach ($roleOptions as $value => $label): ?>
-                        <option value="<?= $value; ?>" <?= $formData['role'] === $value ? 'selected' : ''; ?>><?= $label; ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            <div class="form-actions">
-                <button type="submit" class="primary-action">Create account</button>
-            </div>
-        </form>
-        <div class="auth-actions">
-            <span class="auth-note">Already registered?</span>
-            <a href="login.php" class="ghost-action">Sign in</a>
         </div>
     </div>
 </body>

--- a/register.php
+++ b/register.php
@@ -80,57 +80,60 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body class="auth-page">
-    <div class="auth-wrapper">
-        <section class="auth-intro">
-            <span class="auth-badge">Task Management · Hail Region Municipality</span>
-            <h1>Create a collaborative workspace</h1>
-            <p>Give every department visibility from planning through delivery with shared milestones.</p>
-            <ul>
-                <li>Role-based access for presidents, managers, and employees</li>
-                <li>Deadline-driven calendar and reminder center</li>
-                <li>Unified progress and completion reporting</li>
-            </ul>
-        </section>
-        <div class="auth-card">
-            <div class="auth-logo">
-                <img src="assets/img/hail-region-municipality-logo.svg" alt="Hail Region Municipality logo">
+    <div class="auth-shell">
+        <section class="auth-illustration">
+            <div class="auth-illustration-inner">
+                <img class="auth-masthead-logo" src="assets/img/hail-region-municipality-logo.svg" alt="Task Management Hail Region Municipality">
+                <h1>Join Task Management Hail Region Municipality</h1>
+                <p>Empower municipal teams with a classic workspace that reflects the official identity.</p>
             </div>
-            <h2>Register</h2>
-            <p>Invite your team to manage tasks together.</p>
-            <?php if ($errors): ?>
-                <div class="alert error"><?= implode('<br>', array_map('sanitize', $errors)); ?></div>
-            <?php endif; ?>
-            <form method="post" class="classic-form" novalidate>
-                <div class="form-group">
-                    <label for="name">Full name</label>
-                    <input type="text" id="name" name="name" value="<?= sanitize($formData['name']); ?>" required>
+        </section>
+        <div class="auth-panel">
+            <header class="auth-panel-header">
+                <div class="auth-logo">
+                    <img src="assets/img/hail-region-municipality-logo.svg" alt="Hail Region Municipality logo">
                 </div>
-                <div class="form-group">
-                    <label for="email">Email</label>
-                    <input type="email" id="email" name="email" value="<?= sanitize($formData['email']); ?>" required>
+                <div>
+                    <h2>Create your account</h2>
+                    <p>Select your role to tailor the dashboard experience.</p>
                 </div>
-                <div class="form-row">
+            </header>
+            <div class="auth-panel-body">
+                <?php if ($errors): ?>
+                    <div class="alert error"><?= implode('<br>', array_map('sanitize', $errors)); ?></div>
+                <?php endif; ?>
+                <form method="post" class="classic-form" novalidate>
                     <div class="form-group">
-                        <label for="password">Password</label>
-                        <input type="password" id="password" name="password" required>
+                        <label for="name">Full name</label>
+                        <input type="text" id="name" name="name" value="<?= sanitize($formData['name']); ?>" required>
                     </div>
                     <div class="form-group">
-                        <label for="confirm_password">Confirm password</label>
-                        <input type="password" id="confirm_password" name="confirm_password" required>
+                        <label for="email">Email</label>
+                        <input type="email" id="email" name="email" value="<?= sanitize($formData['email']); ?>" required>
                     </div>
-                </div>
-                <div class="form-group">
-                    <label for="role">Select your role</label>
-                    <select id="role" name="role">
-                        <?php foreach ($roleOptions as $value => $label): ?>
-                            <option value="<?= $value; ?>" <?= $formData['role'] === $value ? 'selected' : ''; ?>><?= $label; ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </div>
-                <div class="form-actions">
-                    <button type="submit" class="primary-action">Create account</button>
-                </div>
-            </form>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="password">Password</label>
+                            <input type="password" id="password" name="password" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="confirm_password">Confirm password</label>
+                            <input type="password" id="confirm_password" name="confirm_password" required>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="role">Select your role</label>
+                        <select id="role" name="role">
+                            <?php foreach ($roleOptions as $value => $label): ?>
+                                <option value="<?= $value; ?>" <?= $formData['role'] === $value ? 'selected' : ''; ?>><?= $label; ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="form-actions">
+                        <button type="submit" class="primary-action">Create account</button>
+                    </div>
+                </form>
+            </div>
             <div class="auth-actions">
                 <span class="auth-note">Already registered?</span>
                 <a href="login.php" class="ghost-action">Sign in</a>

--- a/register.php
+++ b/register.php
@@ -92,6 +92,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             </ul>
         </section>
         <div class="auth-card">
+            <div class="auth-logo">
+                <img src="assets/img/hail-region-municipality-logo.svg" alt="Hail Region Municipality logo">
+            </div>
             <h2>Register</h2>
             <p>Invite your team to manage tasks together.</p>
             <?php if ($errors): ?>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,126 @@
+<?php
+require_once __DIR__ . '/includes/functions.php';
+ensure_session();
+
+if (current_user()) {
+    header('Location: index.php');
+    exit;
+}
+
+require_once __DIR__ . '/db.php';
+
+$errors = [];
+$formData = [
+    'name' => trim($_POST['name'] ?? ''),
+    'email' => trim($_POST['email'] ?? ''),
+    'password' => $_POST['password'] ?? '',
+    'confirm_password' => $_POST['confirm_password'] ?? '',
+    'role' => $_POST['role'] ?? 'employee',
+];
+
+$roleOptions = [
+    'president' => 'President',
+    'manager' => 'Manager',
+    'employee' => 'Employee',
+];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if ($formData['name'] === '') {
+        $errors[] = 'Enter your full name.';
+    }
+
+    if ($formData['email'] === '' || !filter_var($formData['email'], FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Enter a valid email address.';
+    }
+
+    if ($formData['password'] === '') {
+        $errors[] = 'Create a password.';
+    }
+
+    if ($formData['password'] !== $formData['confirm_password']) {
+        $errors[] = 'Passwords do not match.';
+    }
+
+    if (!array_key_exists($formData['role'], $roleOptions)) {
+        $formData['role'] = 'employee';
+    }
+
+    if (!$errors) {
+        $existing = $pdo->prepare('SELECT id FROM users WHERE email = :email LIMIT 1');
+        $existing->execute(['email' => $formData['email']]);
+        if ($existing->fetch()) {
+            $errors[] = 'An account with this email already exists.';
+        }
+    }
+
+    if (!$errors) {
+        $stmt = $pdo->prepare('INSERT INTO users (name, email, password_hash, role, created_at) VALUES (:name, :email, :password_hash, :role, NOW())');
+        $stmt->execute([
+            'name' => $formData['name'],
+            'email' => $formData['email'],
+            'password_hash' => password_hash($formData['password'], PASSWORD_DEFAULT),
+            'role' => $formData['role'],
+        ]);
+
+        set_flash('registered', 'Account created. Sign in to continue.');
+        header('Location: login.php');
+        exit;
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Create account · TaskMaster</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body class="auth-page">
+    <div class="auth-card">
+        <h1>Create account</h1>
+        <p>Join the TaskMaster coordination hub.</p>
+        <?php if ($errors): ?>
+            <div class="alert error"><?= implode('<br>', array_map('sanitize', $errors)); ?></div>
+        <?php endif; ?>
+        <form method="post" class="classic-form" novalidate>
+            <div class="form-group">
+                <label for="name">Full name</label>
+                <input type="text" id="name" name="name" value="<?= sanitize($formData['name']); ?>" required>
+            </div>
+            <div class="form-group">
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" value="<?= sanitize($formData['email']); ?>" required>
+            </div>
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="password">Password</label>
+                    <input type="password" id="password" name="password" required>
+                </div>
+                <div class="form-group">
+                    <label for="confirm_password">Confirm password</label>
+                    <input type="password" id="confirm_password" name="confirm_password" required>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="role">Role</label>
+                <select id="role" name="role">
+                    <?php foreach ($roleOptions as $value => $label): ?>
+                        <option value="<?= $value; ?>" <?= $formData['role'] === $value ? 'selected' : ''; ?>><?= $label; ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="form-actions">
+                <button type="submit" class="primary-action">Create account</button>
+            </div>
+        </form>
+        <div class="auth-actions">
+            <span class="auth-note">Already registered?</span>
+            <a href="login.php" class="ghost-action">Sign in</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/reminders.php
+++ b/reminders.php
@@ -1,6 +1,6 @@
 <?php
 $pageTitle = 'Reminders';
-$pageDescription = 'Issue and review reminders for departmental tasks.';
+$pageDescription = 'Send timely nudges and track reminder history by department.';
 require_once __DIR__ . '/includes/functions.php';
 require_login();
 require_once __DIR__ . '/db.php';
@@ -50,11 +50,11 @@ include __DIR__ . '/includes/header.php';
         <?= implode('<br>', array_map('sanitize', $errors)); ?>
     </div>
 <?php endif; ?>
-<div class="content-columns">
-    <section class="panel classic-panel">
-        <header class="panel-header">
+<section class="reminders-layout">
+    <aside class="panel reminder-compose">
+        <header>
             <h2>Create reminder</h2>
-            <span>Send a prompt to the owning department</span>
+            <p>Send a quick prompt to keep tasks on schedule.</p>
         </header>
         <form method="post" class="classic-form">
             <div class="form-group">
@@ -70,17 +70,19 @@ include __DIR__ . '/includes/header.php';
             </div>
             <div class="form-group">
                 <label for="message">Reminder message</label>
-                <textarea id="message" name="message" rows="4" placeholder="Share the next steps or highlight the approaching deadline." required><?= isset($_POST['message']) ? sanitize($_POST['message']) : ''; ?></textarea>
+                <textarea id="message" name="message" rows="5" placeholder="Highlight the actions needed or the approaching deadline." required><?= isset($_POST['message']) ? sanitize($_POST['message']) : ''; ?></textarea>
             </div>
             <div class="form-actions">
                 <button type="submit" class="primary-action">Send reminder</button>
             </div>
         </form>
-    </section>
-    <section class="panel classic-panel">
+    </aside>
+    <div class="panel reminder-log">
         <header class="panel-header">
-            <h2>Reminder log</h2>
-            <span>Latest notifications</span>
+            <div>
+                <h2>Reminder log</h2>
+                <span>Latest notifications</span>
+            </div>
         </header>
         <?php if (!$reminders): ?>
             <div class="empty-note">No reminders have been logged yet.</div>
@@ -108,6 +110,6 @@ include __DIR__ . '/includes/header.php';
                 </table>
             </div>
         <?php endif; ?>
-    </section>
-</div>
+    </div>
+</section>
 <?php include __DIR__ . '/includes/footer.php'; ?>

--- a/reminders.php
+++ b/reminders.php
@@ -1,0 +1,113 @@
+<?php
+$pageTitle = 'Reminders';
+$pageDescription = 'Issue and review reminders for departmental tasks.';
+require_once __DIR__ . '/includes/functions.php';
+require_login();
+require_once __DIR__ . '/db.php';
+
+$errors = [];
+$success = '';
+
+$tasks = $pdo->query('SELECT id, title FROM tasks ORDER BY title ASC')->fetchAll();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $taskId = (int)($_POST['task_id'] ?? 0);
+    $message = trim($_POST['message'] ?? '');
+
+    if ($taskId <= 0) {
+        $errors[] = 'Choose a task to notify.';
+    }
+
+    if ($message === '') {
+        $errors[] = 'Provide a reminder message.';
+    }
+
+    if (!$errors) {
+        $stmt = $pdo->prepare('INSERT INTO notifications (task_id, message, created_at) VALUES (:task_id, :message, NOW())');
+        $stmt->execute([
+            'task_id' => $taskId,
+            'message' => $message,
+        ]);
+        $success = 'Reminder recorded and sent.';
+    }
+}
+
+$reminders = $pdo->query('SELECT n.id, n.message, DATE_FORMAT(n.created_at, "%b %e, %Y %H:%i") AS created_at,
+    t.title AS task_title, d.name AS department_name
+    FROM notifications n
+    JOIN tasks t ON t.id = n.task_id
+    JOIN departments d ON d.id = t.department_id
+    ORDER BY n.created_at DESC
+    LIMIT 25')->fetchAll();
+
+include __DIR__ . '/includes/header.php';
+?>
+<?php if ($success): ?>
+    <div class="alert success global-alert"><?= sanitize($success); ?></div>
+<?php endif; ?>
+<?php if ($errors): ?>
+    <div class="alert error global-alert">
+        <?= implode('<br>', array_map('sanitize', $errors)); ?>
+    </div>
+<?php endif; ?>
+<div class="content-columns">
+    <section class="panel classic-panel">
+        <header class="panel-header">
+            <h2>Create reminder</h2>
+            <span>Send a prompt to the owning department</span>
+        </header>
+        <form method="post" class="classic-form">
+            <div class="form-group">
+                <label for="task_id">Task</label>
+                <select id="task_id" name="task_id" required>
+                    <option value="">Select task</option>
+                    <?php foreach ($tasks as $task): ?>
+                        <option value="<?= (int)$task['id']; ?>" <?= isset($_POST['task_id']) && (int)$_POST['task_id'] === (int)$task['id'] ? 'selected' : ''; ?>>
+                            <?= sanitize($task['title']); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="message">Reminder message</label>
+                <textarea id="message" name="message" rows="4" placeholder="Share the next steps or highlight the approaching deadline." required><?= isset($_POST['message']) ? sanitize($_POST['message']) : ''; ?></textarea>
+            </div>
+            <div class="form-actions">
+                <button type="submit" class="primary-action">Send reminder</button>
+            </div>
+        </form>
+    </section>
+    <section class="panel classic-panel">
+        <header class="panel-header">
+            <h2>Reminder log</h2>
+            <span>Latest notifications</span>
+        </header>
+        <?php if (!$reminders): ?>
+            <div class="empty-note">No reminders have been logged yet.</div>
+        <?php else: ?>
+            <div class="table-scroll">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Task</th>
+                            <th scope="col">Department</th>
+                            <th scope="col">Message</th>
+                            <th scope="col">Sent at</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($reminders as $reminder): ?>
+                            <tr>
+                                <td><?= sanitize($reminder['task_title']); ?></td>
+                                <td><?= sanitize($reminder['department_name']); ?></td>
+                                <td><?= sanitize($reminder['message']); ?></td>
+                                <td><?= sanitize($reminder['created_at']); ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        <?php endif; ?>
+    </section>
+</div>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/send_reminder.php
+++ b/send_reminder.php
@@ -1,6 +1,15 @@
 <?php
 header('Content-Type: application/json; charset=utf-8');
 
+require_once __DIR__ . '/includes/functions.php';
+ensure_session();
+
+if (!current_user()) {
+    http_response_code(403);
+    echo json_encode(['message' => 'Authentication required']);
+    exit;
+}
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(405);
     echo json_encode(['message' => 'Request method not allowed']);
@@ -28,7 +37,8 @@ if (!$task) {
     exit;
 }
 
-$message = sprintf('Reminder for task "%s". Due date: %s', $task['title'], $task['due_date'] ?: 'No due date');
+$formattedDueDate = $task['due_date'] ?: 'No due date';
+$message = sprintf('Reminder for task "%s". Due date: %s', $task['title'], $formattedDueDate);
 
 $insert = $pdo->prepare('INSERT INTO notifications (task_id, message, created_at) VALUES (:task_id, :message, NOW())');
 $insert->execute([

--- a/send_reminder.php
+++ b/send_reminder.php
@@ -1,0 +1,46 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['message' => 'Request method not allowed']);
+    exit;
+}
+
+$payload = json_decode(file_get_contents('php://input'), true) ?? [];
+$taskId = isset($payload['taskId']) ? (int) $payload['taskId'] : 0;
+
+if (!$taskId) {
+    http_response_code(400);
+    echo json_encode(['message' => 'Unknown task']);
+    exit;
+}
+
+require_once __DIR__ . '/db.php';
+
+$taskStmt = $pdo->prepare('SELECT id, title, due_date FROM tasks WHERE id = :id');
+$taskStmt->execute(['id' => $taskId]);
+$task = $taskStmt->fetch();
+
+if (!$task) {
+    http_response_code(404);
+    echo json_encode(['message' => 'Task not found']);
+    exit;
+}
+
+$message = sprintf('Reminder for task "%s". Due date: %s', $task['title'], $task['due_date'] ?: 'No due date');
+
+$insert = $pdo->prepare('INSERT INTO notifications (task_id, message, created_at) VALUES (:task_id, :message, NOW())');
+$insert->execute([
+    'task_id' => $taskId,
+    'message' => $message,
+]);
+
+$lastReminder = $pdo->prepare('SELECT DATE_FORMAT(created_at, "%Y-%m-%d %H:%i") as created_at FROM notifications WHERE task_id = :task_id ORDER BY created_at DESC LIMIT 1');
+$lastReminder->execute(['task_id' => $taskId]);
+$stamp = $lastReminder->fetchColumn();
+
+echo json_encode([
+    'message' => 'Reminder sent successfully',
+    'lastReminder' => $stamp,
+]);

--- a/task_create.php
+++ b/task_create.php
@@ -1,0 +1,130 @@
+<?php
+$pageTitle = 'Create Task';
+$pageDescription = 'Add a new assignment and notify the responsible department.';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$errors = [];
+$formData = [
+    'title' => '',
+    'department_id' => '',
+    'priority' => 'Medium',
+    'due_date' => '',
+    'description' => '',
+];
+
+$departments = $pdo->query('SELECT id, name FROM departments ORDER BY name ASC')->fetchAll();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $formData['title'] = trim($_POST['title'] ?? '');
+    $formData['department_id'] = (int)($_POST['department_id'] ?? 0);
+    $formData['priority'] = $_POST['priority'] ?? 'Medium';
+    $formData['due_date'] = $_POST['due_date'] ?? '';
+    $formData['description'] = trim($_POST['description'] ?? '');
+
+    if ($formData['title'] === '') {
+        $errors[] = 'Task title is required.';
+    }
+
+    if ($formData['department_id'] <= 0) {
+        $errors[] = 'Choose a department to own this task.';
+    }
+
+    if (!in_array($formData['priority'], ['High', 'Medium', 'Low'], true)) {
+        $formData['priority'] = 'Medium';
+    }
+
+    if ($formData['due_date'] !== '') {
+        $d = DateTime::createFromFormat('Y-m-d', $formData['due_date']);
+        if (!$d || $d->format('Y-m-d') !== $formData['due_date']) {
+            $errors[] = 'Provide a valid due date (YYYY-MM-DD).';
+        }
+    }
+
+    if (!$errors) {
+        $stmt = $pdo->prepare('INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+            VALUES (:title, :description, :department_id, :priority, :status, :due_date, NOW(), NOW())');
+        $stmt->execute([
+            'title' => $formData['title'],
+            'description' => $formData['description'],
+            'department_id' => $formData['department_id'],
+            'priority' => $formData['priority'],
+            'status' => 'Pending',
+            'due_date' => $formData['due_date'] ?: null,
+        ]);
+
+        header('Location: tasks.php?created=1');
+        exit;
+    }
+}
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="form-page">
+    <article class="panel form-primary">
+        <header class="form-header">
+            <h2>Task details</h2>
+            <p>Provide enough context so departments can execute without delays.</p>
+        </header>
+        <?php if ($errors): ?>
+            <div class="alert error">
+                <?= implode('<br>', array_map('sanitize', $errors)); ?>
+            </div>
+        <?php endif; ?>
+        <form method="post" class="task-form" novalidate>
+            <div class="form-group">
+                <label for="title">Task title</label>
+                <input type="text" id="title" name="title" value="<?= sanitize($formData['title']); ?>" required placeholder="e.g. Update emergency drill playbook">
+            </div>
+            <div class="form-grid">
+                <div class="form-group">
+                    <label for="department_id">Department</label>
+                    <select id="department_id" name="department_id" required>
+                        <option value="">Select department</option>
+                        <?php foreach ($departments as $department): ?>
+                            <option value="<?= (int)$department['id']; ?>" <?= (int)$department['id'] === (int)$formData['department_id'] ? 'selected' : ''; ?>>
+                                <?= sanitize($department['name']); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="priority">Priority</label>
+                    <div class="priority-pills">
+                        <?php foreach (['High', 'Medium', 'Low'] as $priority): ?>
+                            <label class="pill-option">
+                                <input type="radio" name="priority" value="<?= $priority; ?>" <?= $formData['priority'] === $priority ? 'checked' : ''; ?>>
+                                <span><?= $priority; ?></span>
+                            </label>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="due_date">Due date</label>
+                    <input type="date" id="due_date" name="due_date" value="<?= sanitize($formData['due_date']); ?>">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="description">Brief</label>
+                <textarea id="description" name="description" rows="5" placeholder="Outline deliverables, attachments, and expected outcomes."><?= sanitize($formData['description']); ?></textarea>
+            </div>
+            <div class="form-actions">
+                <a href="tasks.php" class="ghost-action">Cancel</a>
+                <button type="submit" class="primary-action">Save task</button>
+            </div>
+        </form>
+    </article>
+    <aside class="panel form-sidebar">
+        <h2>Planning checklist</h2>
+        <ul class="form-tips">
+            <li><strong>Set clear ownership:</strong> choose the department that will lead execution.</li>
+            <li><strong>Clarify urgency:</strong> use High for critical escalations, Medium for standard work, and Low for flexible items.</li>
+            <li><strong>Add due dates:</strong> deadlines power the new calendar view and trigger reminder insights.</li>
+        </ul>
+        <div class="calendar-preview">
+            <span class="calendar-preview-month"><?= date('F Y'); ?></span>
+            <p>New tasks with due dates are automatically surfaced on the calendar.</p>
+        </div>
+    </aside>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/task_create.php
+++ b/task_create.php
@@ -1,8 +1,9 @@
 <?php
 $pageTitle = 'Create Task';
 $pageDescription = 'Add a new assignment and notify the responsible department.';
-require_once __DIR__ . '/db.php';
 require_once __DIR__ . '/includes/functions.php';
+require_login();
+require_once __DIR__ . '/db.php';
 
 $errors = [];
 $formData = [
@@ -60,23 +61,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 include __DIR__ . '/includes/header.php';
 ?>
-<section class="form-page">
-    <article class="panel form-primary">
-        <header class="form-header">
+<div class="content-columns form-layout">
+    <section class="panel classic-panel">
+        <header class="panel-header">
             <h2>Task details</h2>
-            <p>Provide enough context so departments can execute without delays.</p>
+            <span>Provide the essentials for a clear assignment</span>
         </header>
         <?php if ($errors): ?>
-            <div class="alert error">
-                <?= implode('<br>', array_map('sanitize', $errors)); ?>
-            </div>
+            <div class="alert error"><?= implode('<br>', array_map('sanitize', $errors)); ?></div>
         <?php endif; ?>
-        <form method="post" class="task-form" novalidate>
+        <form method="post" class="classic-form" novalidate>
             <div class="form-group">
                 <label for="title">Task title</label>
                 <input type="text" id="title" name="title" value="<?= sanitize($formData['title']); ?>" required placeholder="e.g. Update emergency drill playbook">
             </div>
-            <div class="form-grid">
+            <div class="form-row">
                 <div class="form-group">
                     <label for="department_id">Department</label>
                     <select id="department_id" name="department_id" required>
@@ -90,14 +89,11 @@ include __DIR__ . '/includes/header.php';
                 </div>
                 <div class="form-group">
                     <label for="priority">Priority</label>
-                    <div class="priority-pills">
+                    <select id="priority" name="priority">
                         <?php foreach (['High', 'Medium', 'Low'] as $priority): ?>
-                            <label class="pill-option">
-                                <input type="radio" name="priority" value="<?= $priority; ?>" <?= $formData['priority'] === $priority ? 'checked' : ''; ?>>
-                                <span><?= $priority; ?></span>
-                            </label>
+                            <option value="<?= $priority; ?>" <?= $formData['priority'] === $priority ? 'selected' : ''; ?>><?= $priority; ?></option>
                         <?php endforeach; ?>
-                    </div>
+                    </select>
                 </div>
                 <div class="form-group">
                     <label for="due_date">Due date</label>
@@ -106,25 +102,28 @@ include __DIR__ . '/includes/header.php';
             </div>
             <div class="form-group">
                 <label for="description">Brief</label>
-                <textarea id="description" name="description" rows="5" placeholder="Outline deliverables, attachments, and expected outcomes."><?= sanitize($formData['description']); ?></textarea>
+                <textarea id="description" name="description" rows="6" placeholder="Outline deliverables, attachments, and expected outcomes."><?= sanitize($formData['description']); ?></textarea>
             </div>
             <div class="form-actions">
                 <a href="tasks.php" class="ghost-action">Cancel</a>
                 <button type="submit" class="primary-action">Save task</button>
             </div>
         </form>
-    </article>
-    <aside class="panel form-sidebar">
-        <h2>Planning checklist</h2>
-        <ul class="form-tips">
+    </section>
+    <aside class="panel classic-panel">
+        <header class="panel-header">
+            <h2>Planning tips</h2>
+            <span>Keep departments aligned</span>
+        </header>
+        <ul class="insight-list">
             <li><strong>Set clear ownership:</strong> choose the department that will lead execution.</li>
-            <li><strong>Clarify urgency:</strong> use High for critical escalations, Medium for standard work, and Low for flexible items.</li>
-            <li><strong>Add due dates:</strong> deadlines power the new calendar view and trigger reminder insights.</li>
+            <li><strong>Clarify urgency:</strong> High for escalations, Medium for routine, Low for flexible work.</li>
+            <li><strong>Add due dates:</strong> deadlines power the calendar and reminder insights automatically.</li>
         </ul>
         <div class="calendar-preview">
             <span class="calendar-preview-month"><?= date('F Y'); ?></span>
-            <p>New tasks with due dates are automatically surfaced on the calendar.</p>
+            <p>New tasks with due dates appear on the shared calendar automatically.</p>
         </div>
     </aside>
-</section>
+</div>
 <?php include __DIR__ . '/includes/footer.php'; ?>

--- a/tasks.php
+++ b/tasks.php
@@ -1,0 +1,259 @@
+<?php
+$pageTitle = 'Tasks';
+$pageDescription = 'Manage and track work across every department.';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/includes/functions.php';
+
+$errors = [];
+$success = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'create') {
+        $title = trim($_POST['title'] ?? '');
+        $departmentId = (int)($_POST['department_id'] ?? 0);
+        $priority = $_POST['priority'] ?? 'Medium';
+        $dueDate = $_POST['due_date'] ?? null;
+        $description = trim($_POST['description'] ?? '');
+
+        if ($title === '') {
+            $errors[] = 'Task title is required.';
+        }
+
+        if ($departmentId <= 0) {
+            $errors[] = 'Select a responsible department.';
+        }
+
+        if (empty($errors)) {
+            $stmt = $pdo->prepare('INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
+                VALUES (:title, :description, :department_id, :priority, :status, :due_date, NOW(), NOW())');
+            $stmt->execute([
+                'title' => $title,
+                'description' => $description,
+                'department_id' => $departmentId,
+                'priority' => $priority,
+                'status' => 'Pending',
+                'due_date' => $dueDate ?: null,
+            ]);
+
+            $success = 'Task created successfully.';
+        }
+    } elseif ($action === 'update_status') {
+        $taskId = (int)($_POST['task_id'] ?? 0);
+        $status = $_POST['status'] ?? 'Pending';
+
+        if ($taskId > 0) {
+            $update = $pdo->prepare('UPDATE tasks SET status = :status, updated_at = NOW() WHERE id = :id');
+            $update->execute([
+                'status' => $status,
+                'id' => $taskId,
+            ]);
+            $success = 'Task status updated.';
+        }
+    } elseif ($action === 'delete') {
+        $taskId = (int)($_POST['task_id'] ?? 0);
+        if ($taskId > 0) {
+            $pdo->prepare('DELETE FROM notifications WHERE task_id = :id')->execute(['id' => $taskId]);
+            $pdo->prepare('DELETE FROM tasks WHERE id = :id')->execute(['id' => $taskId]);
+            $success = 'Task deleted.';
+        }
+    }
+}
+
+$departments = $pdo->query('SELECT id, name FROM departments ORDER BY name ASC')->fetchAll();
+
+$tasksStmt = $pdo->query('SELECT t.*, d.name AS department_name,
+    (SELECT DATE_FORMAT(n.created_at, "%b %e, %Y %H:%i") FROM notifications n WHERE n.task_id = t.id ORDER BY n.created_at DESC LIMIT 1) AS last_reminder
+    FROM tasks t
+    JOIN departments d ON t.department_id = d.id
+    ORDER BY t.due_date IS NULL, t.due_date ASC, t.created_at DESC');
+$tasks = $tasksStmt->fetchAll();
+
+$statusCounts = [
+    'Pending' => 0,
+    'In Progress' => 0,
+    'Completed' => 0,
+];
+
+$statusSummaryStmt = $pdo->query("SELECT status, COUNT(*) AS total FROM tasks GROUP BY status");
+foreach ($statusSummaryStmt as $row) {
+    $status = $row['status'] ?? '';
+    if (isset($statusCounts[$status])) {
+        $statusCounts[$status] = (int)$row['total'];
+    }
+}
+
+$overdueCount = (int)$pdo->query("SELECT COUNT(*) FROM tasks WHERE status != 'Completed' AND due_date IS NOT NULL AND due_date < CURDATE()")
+    ->fetchColumn();
+
+$nextDueTask = $pdo->query("SELECT t.title, t.due_date, d.name AS department_name
+    FROM tasks t
+    JOIN departments d ON d.id = t.department_id
+    WHERE t.status != 'Completed' AND t.due_date IS NOT NULL AND t.due_date >= CURDATE()
+    ORDER BY t.due_date ASC
+    LIMIT 1")
+    ->fetch();
+
+$statusGroups = [
+    'Pending' => [],
+    'In Progress' => [],
+    'Completed' => [],
+    'Overdue' => [],
+];
+
+foreach ($tasks as $task) {
+    $isOverdue = !empty($task['due_date']) && $task['status'] !== 'Completed' && strtotime($task['due_date']) < strtotime(date('Y-m-d'));
+    if ($isOverdue) {
+        $statusGroups['Overdue'][] = $task;
+    } elseif (isset($statusGroups[$task['status']])) {
+        $statusGroups[$task['status']][] = $task;
+    } else {
+        $statusGroups['Pending'][] = $task;
+    }
+}
+
+include __DIR__ . '/includes/header.php';
+?>
+<section class="metrics-grid">
+    <article class="panel metric-card">
+        <span class="metric-label">Pending</span>
+        <span class="metric-value"><?= number_format($statusCounts['Pending']); ?></span>
+        <span class="metric-footnote">Awaiting kickoff</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">In Progress</span>
+        <span class="metric-value"><?= number_format($statusCounts['In Progress']); ?></span>
+        <span class="metric-footnote"><?= $nextDueTask ? sanitize(format_date($nextDueTask['due_date'])) : 'No due dates'; ?></span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">Completed</span>
+        <span class="metric-value"><?= number_format($statusCounts['Completed']); ?></span>
+        <span class="metric-footnote">Recently closed work</span>
+    </article>
+    <article class="panel metric-card">
+        <span class="metric-label">Overdue</span>
+        <span class="metric-value"><?= number_format($overdueCount); ?></span>
+        <span class="metric-footnote">Requires follow-up</span>
+    </article>
+</section>
+
+<section class="panel">
+    <div class="panel-header">
+        <h2>Board view</h2>
+        <span class="panel-subtitle">Status lanes for quick scanning</span>
+    </div>
+    <div class="task-board">
+        <?php
+        $laneOrder = ['Pending', 'In Progress', 'Completed', 'Overdue'];
+        foreach ($laneOrder as $lane):
+            $tasksInLane = $statusGroups[$lane];
+        ?>
+            <div class="board-column">
+                <header>
+                    <h2><?= sanitize($lane); ?></h2>
+                    <span class="badge neutral"><?= count($tasksInLane); ?></span>
+                </header>
+                <div class="column-body">
+                    <?php if (!$tasksInLane): ?>
+                        <div class="empty-note">No tasks in this lane.</div>
+                    <?php else: ?>
+                        <?php foreach ($tasksInLane as $task): ?>
+                            <?php
+                            $priorityClass = strtolower($task['priority']);
+                            if (!in_array($priorityClass, ['high', 'medium', 'low'], true)) {
+                                $priorityClass = 'medium';
+                            }
+                            ?>
+                            <article class="task-card">
+                                <div>
+                                    <h3><?= sanitize($task['title']); ?></h3>
+                                    <div class="task-meta">
+                                        <span><?= sanitize($task['department_name']); ?></span>
+                                        <?php if (!empty($task['due_date'])): ?>
+                                            <span>Due <?= sanitize(format_date($task['due_date'])); ?></span>
+                                        <?php endif; ?>
+                                        <span class="priority-badge <?= $priorityClass; ?>"><?= sanitize($task['priority']); ?></span>
+                                    </div>
+                                </div>
+                                <?php if (!empty($task['description'])): ?>
+                                    <p class="task-description"><?= sanitize($task['description']); ?></p>
+                                <?php endif; ?>
+                                <div class="card-actions">
+                                    <form method="post" class="inline-form">
+                                        <input type="hidden" name="action" value="update_status">
+                                        <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
+                                        <select name="status">
+                                            <option value="Pending" <?= $task['status'] === 'Pending' ? 'selected' : ''; ?>>Pending</option>
+                                            <option value="In Progress" <?= $task['status'] === 'In Progress' ? 'selected' : ''; ?>>In Progress</option>
+                                            <option value="Completed" <?= $task['status'] === 'Completed' ? 'selected' : ''; ?>>Completed</option>
+                                        </select>
+                                        <button type="submit" class="secondary">Update</button>
+                                    </form>
+                                    <div class="action-row">
+                                        <button type="button" class="secondary reminder-button" data-task-id="<?= (int)$task['id']; ?>">Send reminder</button>
+                                        <form method="post" onsubmit="return confirm('Delete this task?');">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
+                                            <button type="submit" class="secondary">Delete</button>
+                                        </form>
+                                    </div>
+                                    <span class="reminder-stamp">Last reminder: <?= $task['last_reminder'] ? sanitize($task['last_reminder']) : 'Not sent yet'; ?></span>
+                                </div>
+                            </article>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+</section>
+
+<section class="panel form-panel">
+    <h2>Create Task</h2>
+    <p class="panel-subtitle">Assign work to departments and set due dates</p>
+    <?php if ($errors): ?>
+        <div class="alert error">
+            <?= implode('<br>', array_map('sanitize', $errors)); ?>
+        </div>
+    <?php endif; ?>
+    <?php if ($success && !$errors): ?>
+        <div class="alert success"><?= sanitize($success); ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <input type="hidden" name="action" value="create">
+        <div>
+            <label for="title">Task title</label>
+            <input type="text" id="title" name="title" required>
+        </div>
+        <div class="task-overview">
+            <div>
+                <label for="department_id">Department</label>
+                <select id="department_id" name="department_id" required>
+                    <option value="">Select department</option>
+                    <?php foreach ($departments as $department): ?>
+                        <option value="<?= (int)$department['id']; ?>"><?= sanitize($department['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div>
+                <label for="priority">Priority</label>
+                <select id="priority" name="priority">
+                    <option value="High">High</option>
+                    <option value="Medium" selected>Medium</option>
+                    <option value="Low">Low</option>
+                </select>
+            </div>
+            <div>
+                <label for="due_date">Due date</label>
+                <input type="date" id="due_date" name="due_date">
+            </div>
+        </div>
+        <div>
+            <label for="description">Task description</label>
+            <textarea id="description" name="description" placeholder="Add details and instructions"></textarea>
+        </div>
+        <button type="submit">Save task</button>
+    </form>
+</section>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/tasks.php
+++ b/tasks.php
@@ -1,8 +1,9 @@
 <?php
 $pageTitle = 'Tasks';
-$pageDescription = 'Manage and track work across every department.';
-require_once __DIR__ . '/db.php';
+$pageDescription = 'Track assignments with a tidy roster and classic controls.';
 require_once __DIR__ . '/includes/functions.php';
+require_login();
+require_once __DIR__ . '/db.php';
 
 $errors = [];
 $success = '';
@@ -14,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $taskId = (int)($_POST['task_id'] ?? 0);
         $status = $_POST['status'] ?? 'Pending';
 
-        if ($taskId > 0) {
+        if ($taskId > 0 && in_array($status, ['Pending', 'In Progress', 'Completed'], true)) {
             $update = $pdo->prepare('UPDATE tasks SET status = :status, updated_at = NOW() WHERE id = :id');
             $update->execute([
                 'status' => $status,
@@ -35,8 +36,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 if (!$success && isset($_GET['created']) && $_GET['created'] === '1') {
     $success = 'Task created successfully.';
 }
-
-$departments = $pdo->query('SELECT id, name FROM departments ORDER BY name ASC')->fetchAll();
 
 $tasksStmt = $pdo->query('SELECT t.*, d.name AS department_name,
     (SELECT DATE_FORMAT(n.created_at, "%b %e, %Y %H:%i") FROM notifications n WHERE n.task_id = t.id ORDER BY n.created_at DESC LIMIT 1) AS last_reminder
@@ -70,121 +69,106 @@ $nextDueTask = $pdo->query("SELECT t.title, t.due_date, d.name AS department_nam
     LIMIT 1")
     ->fetch();
 
-$statusGroups = [
-    'Pending' => [],
-    'In Progress' => [],
-    'Completed' => [],
-    'Overdue' => [],
-];
-
-foreach ($tasks as $task) {
-    $isOverdue = !empty($task['due_date']) && $task['status'] !== 'Completed' && strtotime($task['due_date']) < strtotime(date('Y-m-d'));
-    if ($isOverdue) {
-        $statusGroups['Overdue'][] = $task;
-    } elseif (isset($statusGroups[$task['status']])) {
-        $statusGroups[$task['status']][] = $task;
-    } else {
-        $statusGroups['Pending'][] = $task;
-    }
-}
-
 include __DIR__ . '/includes/header.php';
 ?>
 <?php if ($success): ?>
     <div class="alert success global-alert"><?= sanitize($success); ?></div>
 <?php endif; ?>
-<section class="metrics-grid">
-    <article class="panel metric-card">
-        <span class="metric-label">Pending</span>
-        <span class="metric-value"><?= number_format($statusCounts['Pending']); ?></span>
-        <span class="metric-footnote">Awaiting kickoff</span>
+<section class="summary-cards">
+    <article class="summary-card">
+        <span class="summary-label">Pending</span>
+        <span class="summary-value"><?= number_format($statusCounts['Pending']); ?></span>
+        <span class="summary-footnote">Awaiting kickoff</span>
     </article>
-    <article class="panel metric-card">
-        <span class="metric-label">In Progress</span>
-        <span class="metric-value"><?= number_format($statusCounts['In Progress']); ?></span>
-        <span class="metric-footnote"><?= $nextDueTask ? sanitize(format_date($nextDueTask['due_date'])) : 'No due dates'; ?></span>
+    <article class="summary-card">
+        <span class="summary-label">In progress</span>
+        <span class="summary-value"><?= number_format($statusCounts['In Progress']); ?></span>
+        <span class="summary-footnote"><?= $nextDueTask ? sanitize(format_date($nextDueTask['due_date'])) : 'No due dates'; ?></span>
     </article>
-    <article class="panel metric-card">
-        <span class="metric-label">Completed</span>
-        <span class="metric-value"><?= number_format($statusCounts['Completed']); ?></span>
-        <span class="metric-footnote">Recently closed work</span>
+    <article class="summary-card">
+        <span class="summary-label">Completed</span>
+        <span class="summary-value"><?= number_format($statusCounts['Completed']); ?></span>
+        <span class="summary-footnote">Recently closed work</span>
     </article>
-    <article class="panel metric-card">
-        <span class="metric-label">Overdue</span>
-        <span class="metric-value"><?= number_format($overdueCount); ?></span>
-        <span class="metric-footnote">Requires follow-up</span>
+    <article class="summary-card">
+        <span class="summary-label">Overdue</span>
+        <span class="summary-value"><?= number_format($overdueCount); ?></span>
+        <span class="summary-footnote">Requires follow-up</span>
     </article>
 </section>
 
-<section class="panel">
-    <div class="panel-header">
-        <h2>Board view</h2>
-        <span class="panel-subtitle">Status lanes for quick scanning</span>
-    </div>
-    <div class="task-board">
-        <?php
-        $laneOrder = ['Pending', 'In Progress', 'Completed', 'Overdue'];
-        foreach ($laneOrder as $lane):
-            $tasksInLane = $statusGroups[$lane];
-        ?>
-            <div class="board-column">
-                <header>
-                    <h2><?= sanitize($lane); ?></h2>
-                    <span class="badge neutral"><?= count($tasksInLane); ?></span>
-                </header>
-                <div class="column-body">
-                    <?php if (!$tasksInLane): ?>
-                        <div class="empty-note">No tasks in this lane.</div>
-                    <?php else: ?>
-                        <?php foreach ($tasksInLane as $task): ?>
-                            <?php
-                            $priorityClass = strtolower($task['priority']);
-                            if (!in_array($priorityClass, ['high', 'medium', 'low'], true)) {
-                                $priorityClass = 'medium';
-                            }
-                            ?>
-                            <article class="task-card">
-                                <div>
-                                    <h3><?= sanitize($task['title']); ?></h3>
-                                    <div class="task-meta">
-                                        <span><?= sanitize($task['department_name']); ?></span>
-                                        <?php if (!empty($task['due_date'])): ?>
-                                            <span>Due <?= sanitize(format_date($task['due_date'])); ?></span>
-                                        <?php endif; ?>
-                                        <span class="priority-badge <?= $priorityClass; ?>"><?= sanitize($task['priority']); ?></span>
-                                    </div>
-                                </div>
+<section class="panel classic-panel">
+    <header class="panel-header">
+        <h2>Task roster</h2>
+        <span><?= count($tasks); ?> tasks listed</span>
+    </header>
+    <?php if (!$tasks): ?>
+        <div class="empty-note">No tasks have been added yet. Use the Create Task page to get started.</div>
+    <?php else: ?>
+        <div class="table-scroll">
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th scope="col">Task</th>
+                        <th scope="col">Department</th>
+                        <th scope="col">Priority</th>
+                        <th scope="col">Due date</th>
+                        <th scope="col">Status</th>
+                        <th scope="col">Last reminder</th>
+                        <th scope="col" class="actions-col">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($tasks as $task): ?>
+                        <?php
+                        $priorityClass = strtolower($task['priority'] ?? 'medium');
+                        if (!in_array($priorityClass, ['high', 'medium', 'low'], true)) {
+                            $priorityClass = 'medium';
+                        }
+                        $dueStatus = analyze_due_status($task['due_date'], $task['status']);
+                        $stampId = 'reminder-stamp-' . (int)$task['id'];
+                        ?>
+                        <tr>
+                            <td>
+                                <strong><?= sanitize($task['title']); ?></strong>
                                 <?php if (!empty($task['description'])): ?>
-                                    <p class="task-description"><?= sanitize($task['description']); ?></p>
+                                    <p class="table-note"><?= sanitize($task['description']); ?></p>
                                 <?php endif; ?>
-                                <div class="card-actions">
-                                    <form method="post" class="inline-form">
-                                        <input type="hidden" name="action" value="update_status">
+                            </td>
+                            <td><?= sanitize($task['department_name']); ?></td>
+                            <td><span class="priority-chip <?= $priorityClass; ?>"><?= sanitize($task['priority']); ?></span></td>
+                            <td>
+                                <span class="due-chip <?= sanitize($dueStatus['class']); ?>"><?= sanitize(format_date($task['due_date'])); ?></span>
+                            </td>
+                            <td>
+                                <form method="post" class="inline-form">
+                                    <input type="hidden" name="action" value="update_status">
+                                    <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
+                                    <select name="status" onchange="this.form.submit()">
+                                        <?php foreach (['Pending', 'In Progress', 'Completed'] as $status): ?>
+                                            <option value="<?= $status; ?>" <?= $task['status'] === $status ? 'selected' : ''; ?>><?= $status; ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </form>
+                            </td>
+                            <td>
+                                <span id="<?= $stampId; ?>" class="reminder-stamp"><?= $task['last_reminder'] ? sanitize($task['last_reminder']) : '—'; ?></span>
+                            </td>
+                            <td class="actions-col">
+                                <div class="action-stack">
+                                    <button type="button" class="ghost-action reminder-button" data-task-id="<?= (int)$task['id']; ?>" data-target="#<?= $stampId; ?>">Send reminder</button>
+                                    <form method="post" class="inline-form" onsubmit="return confirm('Delete this task?');">
+                                        <input type="hidden" name="action" value="delete">
                                         <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
-                                        <select name="status">
-                                            <option value="Pending" <?= $task['status'] === 'Pending' ? 'selected' : ''; ?>>Pending</option>
-                                            <option value="In Progress" <?= $task['status'] === 'In Progress' ? 'selected' : ''; ?>>In Progress</option>
-                                            <option value="Completed" <?= $task['status'] === 'Completed' ? 'selected' : ''; ?>>Completed</option>
-                                        </select>
-                                        <button type="submit" class="secondary">Update</button>
+                                        <button type="submit" class="ghost-action danger">Delete</button>
                                     </form>
-                                    <div class="action-row">
-                                        <button type="button" class="secondary reminder-button" data-task-id="<?= (int)$task['id']; ?>">Send reminder</button>
-                                        <form method="post" onsubmit="return confirm('Delete this task?');">
-                                            <input type="hidden" name="action" value="delete">
-                                            <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
-                                            <button type="submit" class="secondary">Delete</button>
-                                        </form>
-                                    </div>
-                                    <span class="reminder-stamp">Last reminder: <?= $task['last_reminder'] ? sanitize($task['last_reminder']) : 'Not sent yet'; ?></span>
                                 </div>
-                            </article>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
-                </div>
-            </div>
-        <?php endforeach; ?>
-    </div>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php endif; ?>
 </section>
-
 <?php include __DIR__ . '/includes/footer.php'; ?>

--- a/tasks.php
+++ b/tasks.php
@@ -10,36 +10,7 @@ $success = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? '';
 
-    if ($action === 'create') {
-        $title = trim($_POST['title'] ?? '');
-        $departmentId = (int)($_POST['department_id'] ?? 0);
-        $priority = $_POST['priority'] ?? 'Medium';
-        $dueDate = $_POST['due_date'] ?? null;
-        $description = trim($_POST['description'] ?? '');
-
-        if ($title === '') {
-            $errors[] = 'Task title is required.';
-        }
-
-        if ($departmentId <= 0) {
-            $errors[] = 'Select a responsible department.';
-        }
-
-        if (empty($errors)) {
-            $stmt = $pdo->prepare('INSERT INTO tasks (title, description, department_id, priority, status, due_date, created_at, updated_at)
-                VALUES (:title, :description, :department_id, :priority, :status, :due_date, NOW(), NOW())');
-            $stmt->execute([
-                'title' => $title,
-                'description' => $description,
-                'department_id' => $departmentId,
-                'priority' => $priority,
-                'status' => 'Pending',
-                'due_date' => $dueDate ?: null,
-            ]);
-
-            $success = 'Task created successfully.';
-        }
-    } elseif ($action === 'update_status') {
+    if ($action === 'update_status') {
         $taskId = (int)($_POST['task_id'] ?? 0);
         $status = $_POST['status'] ?? 'Pending';
 
@@ -59,6 +30,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $success = 'Task deleted.';
         }
     }
+}
+
+if (!$success && isset($_GET['created']) && $_GET['created'] === '1') {
+    $success = 'Task created successfully.';
 }
 
 $departments = $pdo->query('SELECT id, name FROM departments ORDER BY name ASC')->fetchAll();
@@ -115,6 +90,9 @@ foreach ($tasks as $task) {
 
 include __DIR__ . '/includes/header.php';
 ?>
+<?php if ($success): ?>
+    <div class="alert success global-alert"><?= sanitize($success); ?></div>
+<?php endif; ?>
 <section class="metrics-grid">
     <article class="panel metric-card">
         <span class="metric-label">Pending</span>
@@ -209,51 +187,4 @@ include __DIR__ . '/includes/header.php';
     </div>
 </section>
 
-<section class="panel form-panel">
-    <h2>Create Task</h2>
-    <p class="panel-subtitle">Assign work to departments and set due dates</p>
-    <?php if ($errors): ?>
-        <div class="alert error">
-            <?= implode('<br>', array_map('sanitize', $errors)); ?>
-        </div>
-    <?php endif; ?>
-    <?php if ($success && !$errors): ?>
-        <div class="alert success"><?= sanitize($success); ?></div>
-    <?php endif; ?>
-    <form method="post">
-        <input type="hidden" name="action" value="create">
-        <div>
-            <label for="title">Task title</label>
-            <input type="text" id="title" name="title" required>
-        </div>
-        <div class="task-overview">
-            <div>
-                <label for="department_id">Department</label>
-                <select id="department_id" name="department_id" required>
-                    <option value="">Select department</option>
-                    <?php foreach ($departments as $department): ?>
-                        <option value="<?= (int)$department['id']; ?>"><?= sanitize($department['name']); ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            <div>
-                <label for="priority">Priority</label>
-                <select id="priority" name="priority">
-                    <option value="High">High</option>
-                    <option value="Medium" selected>Medium</option>
-                    <option value="Low">Low</option>
-                </select>
-            </div>
-            <div>
-                <label for="due_date">Due date</label>
-                <input type="date" id="due_date" name="due_date">
-            </div>
-        </div>
-        <div>
-            <label for="description">Task description</label>
-            <textarea id="description" name="description" placeholder="Add details and instructions"></textarea>
-        </div>
-        <button type="submit">Save task</button>
-    </form>
-</section>
 <?php include __DIR__ . '/includes/footer.php'; ?>

--- a/tasks.php
+++ b/tasks.php
@@ -1,12 +1,13 @@
 <?php
 $pageTitle = 'Tasks';
-$pageDescription = 'Track assignments with a tidy roster and classic controls.';
+$pageDescription = 'Track assignments with a refined board and quick actions.';
 require_once __DIR__ . '/includes/functions.php';
 require_login();
 require_once __DIR__ . '/db.php';
 
 $errors = [];
 $success = '';
+$searchTerm = trim($_GET['q'] ?? '');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? '';
@@ -37,11 +38,20 @@ if (!$success && isset($_GET['created']) && $_GET['created'] === '1') {
     $success = 'Task created successfully.';
 }
 
-$tasksStmt = $pdo->query('SELECT t.*, d.name AS department_name,
+$taskQuery = 'SELECT t.*, d.name AS department_name,
     (SELECT DATE_FORMAT(n.created_at, "%b %e, %Y %H:%i") FROM notifications n WHERE n.task_id = t.id ORDER BY n.created_at DESC LIMIT 1) AS last_reminder
     FROM tasks t
-    JOIN departments d ON t.department_id = d.id
-    ORDER BY t.due_date IS NULL, t.due_date ASC, t.created_at DESC');
+    JOIN departments d ON t.department_id = d.id';
+
+$queryParams = [];
+if ($searchTerm !== '') {
+    $taskQuery .= ' WHERE t.title LIKE :search OR d.name LIKE :search';
+    $queryParams['search'] = '%' . $searchTerm . '%';
+}
+
+$taskQuery .= ' ORDER BY t.due_date IS NULL, t.due_date ASC, t.created_at DESC';
+$tasksStmt = $pdo->prepare($taskQuery);
+$tasksStmt->execute($queryParams);
 $tasks = $tasksStmt->fetchAll();
 
 $statusCounts = [
@@ -74,100 +84,126 @@ include __DIR__ . '/includes/header.php';
 <?php if ($success): ?>
     <div class="alert success global-alert"><?= sanitize($success); ?></div>
 <?php endif; ?>
+
+<?php if ($nextDueTask): ?>
+    <section class="page-alert deadline-alert" role="alert">
+        <div class="alert-icon" aria-hidden="true">⏰</div>
+        <div class="alert-body">
+            <h2>Next due: <?= sanitize($nextDueTask['title']); ?></h2>
+            <p><?= sanitize($nextDueTask['department_name']); ?> · Due <?= sanitize(format_date($nextDueTask['due_date'])); ?></p>
+        </div>
+    </section>
+<?php endif; ?>
+
 <section class="summary-cards">
     <article class="summary-card">
-        <span class="summary-label">Pending</span>
-        <span class="summary-value"><?= number_format($statusCounts['Pending']); ?></span>
+        <span class="summary-icon" aria-hidden="true">🕒</span>
+        <div>
+            <span class="summary-label">Pending</span>
+            <span class="summary-value"><?= number_format($statusCounts['Pending']); ?></span>
+        </div>
         <span class="summary-footnote">Awaiting kickoff</span>
     </article>
     <article class="summary-card">
-        <span class="summary-label">In progress</span>
-        <span class="summary-value"><?= number_format($statusCounts['In Progress']); ?></span>
+        <span class="summary-icon" aria-hidden="true">🔄</span>
+        <div>
+            <span class="summary-label">In progress</span>
+            <span class="summary-value"><?= number_format($statusCounts['In Progress']); ?></span>
+        </div>
         <span class="summary-footnote"><?= $nextDueTask ? sanitize(format_date($nextDueTask['due_date'])) : 'No due dates'; ?></span>
     </article>
     <article class="summary-card">
-        <span class="summary-label">Completed</span>
-        <span class="summary-value"><?= number_format($statusCounts['Completed']); ?></span>
+        <span class="summary-icon" aria-hidden="true">✅</span>
+        <div>
+            <span class="summary-label">Completed</span>
+            <span class="summary-value"><?= number_format($statusCounts['Completed']); ?></span>
+        </div>
         <span class="summary-footnote">Recently closed work</span>
     </article>
     <article class="summary-card">
-        <span class="summary-label">Overdue</span>
-        <span class="summary-value"><?= number_format($overdueCount); ?></span>
+        <span class="summary-icon" aria-hidden="true">⚠️</span>
+        <div>
+            <span class="summary-label">Overdue</span>
+            <span class="summary-value"><?= number_format($overdueCount); ?></span>
+        </div>
         <span class="summary-footnote">Requires follow-up</span>
     </article>
 </section>
 
 <section class="panel classic-panel">
-    <header class="panel-header">
-        <h2>Task roster</h2>
-        <span><?= count($tasks); ?> tasks listed</span>
+    <header class="panel-header tasks-header">
+        <div>
+            <h2>Task list</h2>
+            <span><?= count($tasks); ?> tasks listed</span>
+        </div>
+        <form method="get" class="tasks-filter" role="search">
+            <label for="task-search" class="sr-only">Search tasks</label>
+            <input type="search" id="task-search" name="q" placeholder="Search tasks or departments" value="<?= sanitize($searchTerm); ?>">
+            <?php if ($searchTerm !== ''): ?>
+                <a href="tasks.php" class="ghost-action">Clear</a>
+            <?php endif; ?>
+        </form>
     </header>
     <?php if (!$tasks): ?>
-        <div class="empty-note">No tasks have been added yet. Use the Create Task page to get started.</div>
+        <div class="empty-note">No tasks found. Create a new task or adjust your search.</div>
     <?php else: ?>
-        <div class="table-scroll">
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th scope="col">Task</th>
-                        <th scope="col">Department</th>
-                        <th scope="col">Priority</th>
-                        <th scope="col">Due date</th>
-                        <th scope="col">Status</th>
-                        <th scope="col">Last reminder</th>
-                        <th scope="col" class="actions-col">Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($tasks as $task): ?>
-                        <?php
-                        $priorityClass = strtolower($task['priority'] ?? 'medium');
-                        if (!in_array($priorityClass, ['high', 'medium', 'low'], true)) {
-                            $priorityClass = 'medium';
-                        }
-                        $dueStatus = analyze_due_status($task['due_date'], $task['status']);
-                        $stampId = 'reminder-stamp-' . (int)$task['id'];
-                        ?>
-                        <tr>
-                            <td>
-                                <strong><?= sanitize($task['title']); ?></strong>
-                                <?php if (!empty($task['description'])): ?>
-                                    <p class="table-note"><?= sanitize($task['description']); ?></p>
-                                <?php endif; ?>
-                            </td>
-                            <td><?= sanitize($task['department_name']); ?></td>
-                            <td><span class="priority-chip <?= $priorityClass; ?>"><?= sanitize($task['priority']); ?></span></td>
-                            <td>
-                                <span class="due-chip <?= sanitize($dueStatus['class']); ?>"><?= sanitize(format_date($task['due_date'])); ?></span>
-                            </td>
-                            <td>
-                                <form method="post" class="inline-form">
-                                    <input type="hidden" name="action" value="update_status">
-                                    <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
-                                    <select name="status" onchange="this.form.submit()">
-                                        <?php foreach (['Pending', 'In Progress', 'Completed'] as $status): ?>
-                                            <option value="<?= $status; ?>" <?= $task['status'] === $status ? 'selected' : ''; ?>><?= $status; ?></option>
-                                        <?php endforeach; ?>
-                                    </select>
-                                </form>
-                            </td>
-                            <td>
-                                <span id="<?= $stampId; ?>" class="reminder-stamp"><?= $task['last_reminder'] ? sanitize($task['last_reminder']) : '—'; ?></span>
-                            </td>
-                            <td class="actions-col">
-                                <div class="action-stack">
-                                    <button type="button" class="ghost-action reminder-button" data-task-id="<?= (int)$task['id']; ?>" data-target="#<?= $stampId; ?>">Send reminder</button>
-                                    <form method="post" class="inline-form" onsubmit="return confirm('Delete this task?');">
-                                        <input type="hidden" name="action" value="delete">
-                                        <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
-                                        <button type="submit" class="ghost-action danger">Delete</button>
-                                    </form>
-                                </div>
-                            </td>
-                        </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
+        <div class="task-collection">
+            <?php foreach ($tasks as $task): ?>
+                <?php
+                $priorityClass = strtolower($task['priority'] ?? 'medium');
+                if (!in_array($priorityClass, ['high', 'medium', 'low'], true)) {
+                    $priorityClass = 'medium';
+                }
+                $dueStatus = analyze_due_status($task['due_date'], $task['status']);
+                $stampId = 'reminder-stamp-' . (int)$task['id'];
+                $statusClass = 'status-' . strtolower(str_replace(' ', '-', $task['status']));
+                ?>
+                <article class="task-card <?= $statusClass; ?>">
+                    <header class="task-card-header">
+                        <div>
+                            <h3><?= sanitize($task['title']); ?></h3>
+                            <?php if (!empty($task['description'])): ?>
+                                <p><?= sanitize($task['description']); ?></p>
+                            <?php endif; ?>
+                        </div>
+                        <span class="priority-chip <?= $priorityClass; ?>"><?= sanitize($task['priority']); ?></span>
+                    </header>
+                    <div class="task-card-body">
+                        <dl class="task-meta">
+                            <div>
+                                <dt>Department</dt>
+                                <dd><?= sanitize($task['department_name']); ?></dd>
+                            </div>
+                            <div>
+                                <dt>Due date</dt>
+                                <dd><span class="due-chip <?= sanitize($dueStatus['class']); ?>"><?= sanitize(format_date($task['due_date'])); ?></span></dd>
+                            </div>
+                            <div>
+                                <dt>Last reminder</dt>
+                                <dd><span id="<?= $stampId; ?>" class="reminder-stamp"><?= $task['last_reminder'] ? sanitize($task['last_reminder']) : '—'; ?></span></dd>
+                            </div>
+                        </dl>
+                        <div class="task-card-actions">
+                            <form method="post" class="inline-form">
+                                <input type="hidden" name="action" value="update_status">
+                                <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
+                                <label class="sr-only" for="status-<?= (int)$task['id']; ?>">Status</label>
+                                <select id="status-<?= (int)$task['id']; ?>" name="status" onchange="this.form.submit()">
+                                    <?php foreach (['Pending', 'In Progress', 'Completed'] as $status): ?>
+                                        <option value="<?= $status; ?>" <?= $task['status'] === $status ? 'selected' : ''; ?>><?= $status; ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </form>
+                            <button type="button" class="ghost-action reminder-button" data-task-id="<?= (int)$task['id']; ?>" data-target="#<?= $stampId; ?>">Send reminder</button>
+                            <form method="post" class="inline-form" onsubmit="return confirm('Delete this task?');">
+                                <input type="hidden" name="action" value="delete">
+                                <input type="hidden" name="task_id" value="<?= (int)$task['id']; ?>">
+                                <button type="submit" class="ghost-action danger">Delete</button>
+                            </form>
+                        </div>
+                    </div>
+                </article>
+            <?php endforeach; ?>
         </div>
     <?php endif; ?>
 </section>


### PR DESCRIPTION
## Summary
- rework the TaskFlow chrome with glassmorphism styling, updated header actions, and a contextual sidebar footer
- refresh dashboard, board, and department components with gradient panels, clearer typography, and vivid badges so numbers and controls stand out
- add a styled database connection fallback screen and wire db.php to surface setup instructions when MySQL is offline

## Testing
- php -l index.php
- php -l tasks.php
- php -l departments.php
- php -l send_reminder.php
- php -l includes/header.php
- php -l includes/footer.php
- php -l includes/db_error.php

------
https://chatgpt.com/codex/tasks/task_e_68ed33eeec68832cba2eeea9e2c18e2b